### PR TITLE
Feature: add git hook to check for unstaged files that prettier may have written to during commit hook

### DIFF
--- a/.husky/check_unstaged.py
+++ b/.husky/check_unstaged.py
@@ -1,0 +1,31 @@
+#!/usr/bin/env python
+
+import subprocess
+
+
+def print_red(text):
+    return f"\033[91m{text}\033[0m"
+
+
+def print_green(text):
+    # ANSI escape code for green text
+    return f"\033[92m{text}\033[0m"
+
+
+def check_unstaged_files():
+    try:
+        status_output = subprocess.check_output(["git", "diff"]).decode("utf-8").strip()
+        if status_output:
+            print(print_red("*** Alert ***"))
+            print(
+                print_green(
+                    "There are unstaged changes in the working directory, the formatter was run on your last commit and may have changed some files. Please re stage those files and"
+                )
+            )
+            print(print_red("git commit --amend"))
+    except subprocess.CalledProcessError as e:
+        print(f"Error: Unable to execute 'git hook'. {e}")
+
+
+if __name__ == "__main__":
+    check_unstaged_files()

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -4,3 +4,4 @@
 npx lint-staged
 npx prettier -w .
 ./vendor/bin/pint
+./.husky/check_unstaged.py

--- a/README.md
+++ b/README.md
@@ -18,8 +18,11 @@ The commands below assume you have a shell alias setup in your .bashrc or .zshrc
 -   Run `sail artisan migrate`
 -   Run `sail npm install`
 -   Run `sail npm run dev`
+-   Run `sail artisan db:seed`
 -   Open http://localhost
 -   Register a user or login
+
+#### NOTE: `php artisan db:seed --class=DefaultAdmin` will create a default SuperUser account with the following credentials: Username: SuperAdmin, Password: Ch@ngeMe! (Will redirect immediately on login to change)
 
 ## Style/Linting
 

--- a/database/seeders/DefaultAdmin.php
+++ b/database/seeders/DefaultAdmin.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Database\Seeders;
+
+use Illuminate\Database\Seeder;
+use Illuminate\Support\Facades\DB;
+
+class DefaultAdmin extends Seeder
+{
+    /**
+     * Run the database seeds.
+     */
+    public function run(): void
+    {
+        DB::table('users')->insert([
+            'name_first' => 'Super',
+            'name_last' => 'Admin',
+            'email' => 'admin@unlocked.v2',
+            'username' => 'SuperAdmin',
+            'password' => bcrypt('ChangeMe!'),
+            'password_reset' => true,
+        ]);
+    }
+}


### PR DESCRIPTION
Adds ANSI-colored string warning if there are unstaged files in the CWD that prettier may have formatted, and will not be committed in your git commit.

The alternative would be to have `git add .` run in this hook, but we cannot arbitrarily do that because someone may have selectively committed 
![image](https://github.com/UnlockedLabs/UnlockEdv2/assets/121899304/479943b5-5ea7-4f7a-ae4a-96e0c9f36ed9)
