### PR TITLE
feat: add controller test generation command rough draft

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,12 @@ _This could be any one of the following, or a combination_
 -   Run `sail artisan test`
 -   (Or alternatively ./vendor/bin/pest)
 
+-   To generate a template for a Controller crud test, run:
+    #### `'sail artisan app:make-controller-test {name_of_controller}'`
+    and follow the prompts to generate the test for your handler.
+
+NOTE: This is only a template and will need to be modified to fit your specific needs
+
 # Debugging
 
 Two tools you can use to aid in debugging:

--- a/app/Console/Commands/MakeControllerTest.php
+++ b/app/Console/Commands/MakeControllerTest.php
@@ -1,0 +1,322 @@
+<?php
+
+namespace App\Console\Commands;
+
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\App;
+use Illuminate\Support\Facades\File;
+use Illuminate\Support\Facades\Schema;
+
+class MakeControllerTest extends Command
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'app:make-controller-test {name}';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Command description';
+
+    /**
+     * Execute the console command.
+     */
+    public function handle()
+    {
+        $controllerName = $this->argument('name');
+        $this->alert("Please make sure you have a factory setup properly with the typical naming convention,
+            and setup properly in the TestSeeder.php class. If the route has user access, the factory must have a forUser()
+             method that creates a model with the user_id field of a specific user'");
+
+        $modelName = $this->ask('What is the name of the model?');
+        $route = $this->ask('What is the route for the controller?');
+        $protected = $this->choice('Is this a Admin only resource?', ['admin access only', 'user can access']);
+        if ($protected === 'admin access only') {
+            $this->info('Tests will assert failed status for non-admin users');
+            $testContent = $this->generateTestContentAdmin($controllerName, $modelName, $route);
+        } else {
+            $this->info('Tests will assert users can access their own data at the resource, but cannot create or delete');
+            $testContent = $this->generateTestContent($controllerName, $modelName, $route);
+        }
+
+        $filePath = base_path("tests/Feature/{$controllerName}GeneratedTest.php");
+
+        File::put($filePath, $testContent);
+
+        $this->info("Generated feature test for controller: {$controllerName}");
+    }
+
+    private function generateTestContent($controllerName, $modelName, $route)
+    {
+        $class = "\App\Models\\{$modelName}";
+        $resource = App::make($class);
+        $modelTable = $resource->getTable();
+        $columns = Schema::getColumnListing($modelTable);
+        $className = "{$controllerName}Test";
+        $model = ucfirst($modelName);
+        $seederField = "public \$seeder = \Database\Seeders\TestSeeder::class;";
+        $routeField = 'public string $url = '."'$route';";
+        $jsonScheme = [];
+        foreach ($columns as $column) {
+            $jsonScheme[] = "'$column'";
+        }
+        $fieldsList = implode(",\n", $jsonScheme);
+        $singleJsonStructure = <<<TAG
+        public  \$single_json_structure = [
+            'data' => [
+                 $fieldsList
+            ]
+        ];
+        TAG;
+        $arrayJsonStructure = <<<TAG
+            public  \$array_json_structure = [
+                'data' => [
+                '*' => [
+                $fieldsList
+                ],
+                ],
+            ];
+         TAG;
+        $fileHeader = <<<TEXT
+            <?php
+            namespace Tests\Feature;
+            use App\Models\\{$model};
+            use Database\Seeders\TestSeeder;
+            use Illuminate\Foundation\Testing\RefreshDatabase;
+            use Tests\TestCase;
+
+        class {$className} extends TestCase
+        {
+            use RefreshDatabase;
+            $routeField
+            $seederField
+            $singleJsonStructure
+            $arrayJsonStructure
+
+            public function testAdminCanAccess{$modelName}()
+            {
+                \$this->seed(\$this->seeder);
+                \$admin = \App\Models\User::factory()->admin()->createOne();
+                \$response = \$this->actingAs(\$admin)->get(\$this->url);
+                \$response->assertStatus(200);
+                \$response->assertJsonStructure(\$this->array_json_structure);
+            }
+
+            public function testUserCanAccess{$modelName}()
+            {
+                // seed to assert there is more than 3 records in the database
+                \$this->seed(\$this->seeder);
+                {$model}::factory(3)->forUser()->create();
+                \$user = \App\Models\User::factory()->createOne();
+                \$response = \$this->actingAs(\$user)->get(\$this->url);
+                \$response->assertStatus(200);
+                \$response->assertJsonCount(3, 'data');
+            }
+
+            public function testAdminCanCreate{$modelName}()
+            {
+                \$this->seed(\$this->seeder);
+                \$admin = \App\Models\User::factory()->admin()->createOne();
+                \$model = {$model}::factory()->makeOne();
+                \$response = \$this->actingAs(\$admin)->post(\$this->url, \$model->toArray());
+                \$response->assertStatus(201);
+                \$response->assertJsonStructure(\$this->single_json_structure);
+            }
+
+            public function testProtectedCreate{$modelName}()
+            {
+                \$this->seed(\$this->seeder);
+                \$user = \App\Models\User::factory()->createOne();
+                \$model = {$model}::factory()->makeOne();
+                \$response = \$this->actingAs(\$user)->post(\$this->url, \$model->toArray());
+                \$response->assertStatus(403);
+            }
+
+            public function testAdminCanUpdate{$modelName}()
+            {
+                \$this->seed(\$this->seeder);
+                \$admin = \App\Models\User::factory()->admin()->createOne();
+                \$model = {$model}::factory()->createOne();
+                \$response = \$this->actingAs(\$admin)->put(\$this->url . '/' . \$model->id, \$model->toArray());
+                \$response->assertStatus(200);
+                \$response->assertJsonStructure(\$this->single_json_structure);
+            }
+
+            public function testProtectedUpdate{$modelName}()
+            {
+                \$this->seed(\$this->seeder);
+                \$user = \App\Models\User::factory()->createOne();
+                \$model = {$model}::factory()->createOne();
+                \$response = \$this->actingAs(\$user)->patch(\$this->url . '/' . \$model->id, \$model->toArray());
+                \$response->assertStatus(403);
+            }
+
+            public function testAdminCanDelete{$modelName}()
+            {
+                \$this->seed(\$this->seeder);
+                \$admin = \App\Models\User::factory()->admin()->createOne();
+                \$model = {$model}::factory()->createOne();
+                \$response = \$this->actingAs(\$admin)->delete(\$this->url . '/' . \$model->id);
+                \$response->assertStatus(204);
+            }
+
+            public function testProtectedDelete{$modelName}()
+            {
+                \$this->seed(\$this->seeder);
+                \$user = \App\Models\User::factory()->createOne();
+                \$model = {$model}::factory()->createOne();
+                \$response = \$this->actingAs(\$user)->delete(\$this->url . '/' . \$model->id);
+                \$response->assertStatus(403);
+            }
+
+            public function testUserAccessView{$modelName}()
+            {
+                \$this->seed(\$this->seeder);
+                \$admin = \App\Models\User::factory()->createOne();
+                \$model = {$model}::factory()->forUser()->createOne();
+                \$response = \$this->actingAs(\$admin)->get(\$this->url . '/' . \$model->id);
+                \$response->assertStatus(200);
+                \$response->assertJsonStructure(\$this->single_json_structure);
+            }
+        }
+        TEXT;
+
+        return $fileHeader;
+    }
+
+    private function generateTestContentAdmin($controllerName, $modelName, $route)
+    {
+        $class = "\App\Models\\{$modelName}";
+        $resource = App::make($class);
+        $modelTable = $resource->getTable();
+        $columns = Schema::getColumnListing($modelTable);
+        $className = "{$controllerName}Test";
+        $model = ucfirst($modelName);
+        $seederField = "public \$seeder = \Database\Seeders\TestSeeder::class;";
+        $routeField = 'public string $url = '."'$route';";
+        $jsonScheme = [];
+        foreach ($columns as $column) {
+            $jsonScheme[] = "'$column'";
+        }
+        $fieldsList = implode(",\n", $jsonScheme);
+        $singleJsonStructure = <<<TAG
+        public  \$single_json_structure = [
+            'data' => [
+                 $fieldsList
+            ]
+        ];
+        TAG;
+        $arrayJsonStructure = <<<TAG
+            public  \$array_json_structure = [
+                'data' => [
+                '*' => [
+                $fieldsList
+                ],
+                ],
+            ];
+         TAG;
+        $fileHeader = <<<TEXT
+            <?php
+            namespace Tests\Feature;
+            use App\Models\\{$model};
+            user \Database\Seeders\TestSeeder;
+            use Illuminate\Foundation\Testing\RefreshDatabase;
+            use Tests\TestCase;
+
+        class {$className} extends TestCase
+        {
+
+            use RefreshDatabase;
+            $routeField
+            $seederField
+            $singleJsonStructure
+            $arrayJsonStructure
+
+
+            /* You may need to edit these tests to match the actual behavior of the controller
+            * this is just a template and a good starting point, be sure to test for any edge cases
+            * and any other behavior that is not covered here
+            */
+            public function testAdminCanAccess{$modelName}()
+            {
+                \$this->seed(\$this->seeder);
+                \$admin = \App\Models\User::factory()->admin()->createOne();
+                \$response = \$this->actingAs(\$admin)->get(\$this->url);
+                \$response->assertStatus(200);
+                \$response->assertJsonStructure(\$this->array_json_structure);
+            }
+
+            public function testProtected{$modelName}()
+            {
+                \$this->seed(\$this->seeder);
+                \$user = \App\Models\User::factory()->createOne();
+                \$response = \$this->actingAs(\$user)->get(\$this->url);
+                \$response->assertStatus(403);
+            }
+
+            public function testAdminCanCreate{$modelName}()
+            {
+                \$this->seed(\$this->seeder);
+                \$admin = \App\Models\User::factory()->admin()->createOne();
+                \$model = {$model}::factory()->makeOne();
+                \$response = \$this->actingAs(\$admin)->post(\$this->url, \$model->toArray());
+                \$response->assertStatus(201);
+                \$response->assertJsonStructure(\$this->single_json_structure);
+            }
+
+            public function testProtectedCreate{$modelName}()
+            {
+                \$this->seed(\$this->seeder);
+                \$user = \App\Models\User::factory()->createOne();
+                \$model = {$model}::factory()->makeOne();
+                \$response = \$this->actingAs(\$user)->post(\$this->url, \$model->toArray());
+                \$response->assertStatus(403);
+            }
+
+            public function testAdminCanUpdate{$modelName}()
+            {
+                \$this->seed(\$this->seeder);
+                \$admin = \App\Models\User::factory()->admin()->createOne();
+                \$model = {$model}::factory()->createOne();
+                \$response = \$this->actingAs(\$admin)->patch(\$this->url . '/' . \$model->id, \$model->toArray());
+                \$response->assertStatus(200);
+                \$response->assertJsonStructure(\$this->single_json_structure);
+            }
+
+            public function testProtectedUpdate{$modelName}()
+            {
+                \$this->seed(\$this->seeder);
+                \$user = \App\Models\User::factory()->createOne();
+                \$model = {$model}::factory()->createOne();
+                \$response = \$this->actingAs(\$user)->put(\$this->url . '/' . \$model->id, \$model->toArray());
+                \$response->assertStatus(403);
+            }
+
+            public function testAdminCanDelete{$modelName}()
+            {
+                \$this->seed(\$this->seeder);
+                \$admin = \App\Models\User::factory()->admin()->createOne();
+                \$model = {$model}::factory()->createOne();
+                \$response = \$this->actingAs(\$admin)->delete(\$this->url . '/' . \$model->id);
+                \$response->assertStatus(204);
+            }
+
+            public function testProtectedDelete{$modelName}()
+            {
+                \$this->seed(\$this->seeder);
+                \$user = \App\Models\User::factory()->createOne();
+                \$model = {$model}::factory()->createOne();
+                \$response = \$this->actingAs(\$user)->delete(\$this->url . '/' . \$model->id);
+                \$response->assertStatus(403);
+            }
+        }
+        TEXT;
+
+        return $fileHeader;
+    }
+}

--- a/app/Http/Controllers/v1/EnrollmentController.php
+++ b/app/Http/Controllers/v1/EnrollmentController.php
@@ -29,16 +29,19 @@ class EnrollmentController extends Controller
                     ->orWhere('links', 'like', '%'.$search.'%');
             });
         }
-        // If user is not admin, only show their enrollments
-        if (! $request->user()->isAdmin()) {
+        if ($request->user()->isAdmin()) {
+            $query->orderBy($sortBy, $sortOrder);
+            $categories = $query->paginate($perPage);
+
+            return EnrollmentResource::collection($categories);
+        } else {
+
             $query->where(['user_id' => $request->user()->id]);
+            $query->orderBy($sortBy, $sortOrder);
+            $categories = $query->paginate($perPage);
+
+            return EnrollmentResource::collection($categories);
         }
-
-        $query->orderBy($sortBy, $sortOrder);
-
-        $categories = $query->paginate($perPage);
-
-        return EnrollmentResource::collection($categories);
     }
 
     public function show(Request $request, string $id)

--- a/app/Http/Requests/StoreEnrollmentRequest.php
+++ b/app/Http/Requests/StoreEnrollmentRequest.php
@@ -30,6 +30,8 @@ class StoreEnrollmentRequest extends FormRequest
             'provider_user_id' => 'required|max:255',
             'provider_course_id' => 'required|max:255',
             'provider_enrollment_id' => 'required|max:255',
+            'provider_start_at' => 'required|date',
+            'provider_end_at' => 'nullable|date|after_or_equal:provider_start_at',
         ];
     }
 }

--- a/app/Http/Requests/UpdateEnrollmentRequest.php
+++ b/app/Http/Requests/UpdateEnrollmentRequest.php
@@ -22,7 +22,7 @@ class UpdateEnrollmentRequest extends FormRequest
     public function rules(): array
     {
         return [
-            'provider_id' => 'nullable|string',
+            'provider_platform_id' => 'nullable|string',
             'enrollment_state' => 'nullable|in:active,inactive,completed,deleted',
             'links' => 'nullable|json',
             'provider_start_at' => 'nullable|date',
@@ -30,6 +30,7 @@ class UpdateEnrollmentRequest extends FormRequest
             'provider_platform_id' => 'nullable|exists:provider_platforms,id',
             'provider_user_id' => 'nullable|max:255',
             'provider_course_id' => 'nullable|max:255',
+            'provider_enrollment_id' => 'nullable|max:255',
         ];
     }
 }

--- a/database/factories/EnrollmentFactory.php
+++ b/database/factories/EnrollmentFactory.php
@@ -4,6 +4,7 @@
 
 namespace Database\Factories;
 
+use App\Models\Course;
 use App\Models\Enrollment;
 use App\Models\ProviderPlatform;
 use App\Models\User;
@@ -21,13 +22,13 @@ class EnrollmentFactory extends Factory
 
         return [
             'user_id' => User::factory(),
-            'course_id' => $this->faker->numberBetween(1, 1000000),
+            'course_id' => Course::factory()->createOne()->id,
             'provider_platform_id' => ProviderPlatform::factory()->create()->id,
             'provider_user_id' => $this->faker->numberBetween(1, 1000000),
             'provider_course_id' => $this->faker->numberBetween(1, 1000000),
             'provider_enrollment_id' => $this->faker->numberBetween(1, 1000000),
             'enrollment_state' => $this->faker->randomElement(['active', 'inactive', 'completed']),
-            'links' => ['link1' => $this->faker->url, 'link2' => $this->faker->url],
+            'links' => json_encode(['link1' => $this->faker->url, 'link2' => $this->faker->url]),
             'provider_start_at' => $startAt,
             'provider_end_at' => $endAt,
         ];

--- a/database/factories/EnrollmentFactory.php
+++ b/database/factories/EnrollmentFactory.php
@@ -26,7 +26,7 @@ class EnrollmentFactory extends Factory
             'provider_platform_id' => ProviderPlatform::factory()->create()->id,
             'provider_user_id' => $this->faker->numberBetween(1, 1000000),
             'provider_course_id' => $this->faker->numberBetween(1, 1000000),
-            'provider_enrollment_id' => $this->faker->numberBetween(1, 1000000),
+            'provider_enrollment_id' => $this->faker->unique()->numberBetween(1, 1000),
             'enrollment_state' => $this->faker->randomElement(['active', 'inactive', 'completed']),
             'links' => json_encode(['link1' => $this->faker->url, 'link2' => $this->faker->url]),
             'provider_start_at' => $startAt,


### PR DESCRIPTION
This provides a new command: `artisan app:make-controller-test {NameOfController}`

That will prompt the user for information about the controller, model, and visitbility and generate a class of tests that will test for all the basic CRUD operations and assert that either the route is protected (will fail if non-admin makes requests) or it will assert that the user will be returned only data that belongs to the user. 