### PR TITLE
fix: make login button visible in light-mode

### DIFF
--- a/resources/js/Pages/Welcome.tsx
+++ b/resources/js/Pages/Welcome.tsx
@@ -12,7 +12,7 @@ export default function Welcome({ auth }: PageProps) {
                         <Brand />
                     </div>
                     <div className="flex-none">
-                        <ul className="menu menu-horizontal px-1 text-white">
+                        <ul className="menu menu-horizontal px-1 text-teal-500">
                             {!auth.user ? (
                                 <>
                                     <li>


### PR DESCRIPTION
Issue Image:
![issueProof](https://github.com/UnlockedLabs/UnlockEdv2/assets/123181203/01a31b14-b347-433c-9321-a2c28ac3c933)

After building this project and going to the sign-in page I could not see the login button, so I changed the log-in button color to teal (same as the UnlockEdv2 logo).

Here is what it looks like in light-mode:
![issueFixLightMode](https://github.com/UnlockedLabs/UnlockEdv2/assets/123181203/2119d67b-8207-49e8-a272-1c7773ffebaa)

And what it looks like in dark-mode:
![issueFixDarkMode](https://github.com/UnlockedLabs/UnlockEdv2/assets/123181203/bec94d34-17d8-4e40-9b6f-3aee850dfd13)


