### PR TITLE
fix: make login button visible

### DIFF
--- a/resources/js/Pages/Welcome.tsx
+++ b/resources/js/Pages/Welcome.tsx
@@ -12,7 +12,7 @@ export default function Welcome({ auth }: PageProps) {
                         <Brand />
                     </div>
                     <div className="flex-none">
-                        <ul className="menu menu-horizontal px-1 text-white">
+                        <ul className="menu menu-horizontal px-1 text-primary">
                             {!auth.user ? (
                                 <>
                                     <li>


### PR DESCRIPTION
Issue proof:
![issueProof](https://github.com/UnlockedLabs/UnlockEdv2/assets/123181203/ca03b2c2-ebfd-418c-b4d5-0e048686aa63)

After I built and ran, I noticed that the login button was not visible in light mode, so I changed the text color of the login button to primary.

Here is what it looks like in light mode:
![issueFixLightMode](https://github.com/UnlockedLabs/UnlockEdv2/assets/123181203/14048e2d-df7d-4c72-a7e7-46cf0913e42b)

And how it looks in dark mode:
![issueFixDarkMode](https://github.com/UnlockedLabs/UnlockEdv2/assets/123181203/76dc5e6c-712a-4ea7-956e-6973a90958d5)