### PR TITLE
fix: change course description and image array key names to match Canvas

### DIFF
--- a/app/Http/Controllers/v1/Actions/StoreCanvasCoursesController.php
+++ b/app/Http/Controllers/v1/Actions/StoreCanvasCoursesController.php
@@ -22,10 +22,14 @@ class StoreCanvasCoursesController extends Controller
         $courseCollection = collect();
         foreach ($canvasCourses as $course) {
             if (isset($course['public_description'])) {
-                $request->merge(['public_description' => $course['public_description'] ?? '']);
+                $request->merge(['description' => $course['public_description']]);
+            } else {
+                $request->merge(['description' => '']);
             }
-            if (isset($course['course_image'])) {
-                $request->merge(['course_image' => $course['course_image'] ?? '']);
+            if (isset($course['image_download_url'])) {
+                $request->merge(['img_url' => $course['image_download_url']]);
+            } else {
+                $request->merge(['img_url' => '']);
             }
             $request->merge([
                 'external_resource_id' => $course['id'], 'external_course_name' => $course['name'], 'provider_platform_id' => $request['provider_platform_id'],

--- a/app/Http/Controllers/v1/Actions/StoreUserCourseController.php
+++ b/app/Http/Controllers/v1/Actions/StoreUserCourseController.php
@@ -28,10 +28,14 @@ class StoreUserCourseController extends Controller
         $courseCollection = collect();
         foreach ($canvasCourses as $course) {
             if (isset($course['public_description'])) {
-                $request->merge(['public_description' => $course['public_description'] ?? '']);
+                $request->merge(['description' => $course['public_description']]);
+            } else {
+                $request->merge(['description' => '']);
             }
-            if (isset($course['course_image'])) {
-                $request->merge(['img_url' => $course['course_image'] ?? '']);
+            if (isset($course['image_download_url'])) {
+                $request->merge(['img_url' => $course['image_download_url']]);
+            } else {
+                $request->merge(['img_url' => '']);
             }
             $request->merge([
                 'external_resource_id' => $course['id'], 'external_course_name' => $course['name'], 'provider_platform_id' => $request['provider_platform_id'],


### PR DESCRIPTION
Corrected the key names for course `description` and course img_url to match those in Canvas and v2 database. Replaced the nullish coalescing operators with else statements to stop description and img_url values from being repeated from previous course during course iteration process.