### PR TITLE
fix: fixes invalid use of hooks in edit user form

### DIFF
--- a/resources/js/Components/forms/EditUserForm.tsx
+++ b/resources/js/Components/forms/EditUserForm.tsx
@@ -20,12 +20,8 @@ export default function EditUserForm({
     user,
 }: {
     onSuccess: () => void;
-    user: null | User;
+    user: User;
 }) {
-    if (user === null) {
-        return <div>No user defined!</div>;
-    }
-
     const [errorMessage, setErrorMessage] = useState("");
 
     const {

--- a/resources/js/Pages/Users.tsx
+++ b/resources/js/Pages/Users.tsx
@@ -263,10 +263,14 @@ export default function Users({ auth }: PageProps) {
                 type={ModalType.Edit}
                 item="User"
                 form={
-                    <EditUserForm
-                        onSuccess={hanldleEditUser}
-                        user={targetUser}
-                    />
+                    targetUser ? (
+                        <EditUserForm
+                            onSuccess={hanldleEditUser}
+                            user={targetUser}
+                        />
+                    ) : (
+                        <div>No user defined!</div>
+                    )
                 }
             />
             <Modal


### PR DESCRIPTION
Hooks must always be at the top level of react components. My bad on letting this slip during code review.