### PR TITLE
fix #224: implement `getProviderServices` to get Canvas service

### DIFF
--- a/app/Http/Controllers/v1/Actions/StoreCanvasCoursesController.php
+++ b/app/Http/Controllers/v1/Actions/StoreCanvasCoursesController.php
@@ -8,19 +8,16 @@ use App\Http\Controllers\Controller;
 use App\Http\Requests\AdminRequest;
 use App\Http\Resources\CourseResource;
 use App\Models\Course;
-use App\Services\CanvasServices;
+use App\Models\ProviderPlatform;
 
 class StoreCanvasCoursesController extends Controller
 {
     public function __invoke(AdminRequest $request)
     {
-        try {
-            $canvasService = CanvasServices::byProviderId($request['provider_platform_id']);
-        } catch (\Exception) {
-            return response()->json(['message' => 'Provider not found'], 404);
-        }
+        $provider = ProviderPlatform::findOrFail($request['provider_platform_id']);
+        $canvas = $provider->getProviderServices();
         // list all the courses in the account
-        $canvasCourses = $canvasService->listCourses();
+        $canvasCourses = $canvas->listCourses();
         $courseCollection = collect();
         foreach ($canvasCourses as $course) {
             if (isset($course['public_description'])) {


### PR DESCRIPTION
In order to avoid `TypeError` due to the  `provider_platform_id` in request being a `string` instead of `int`, updated code to use the newer method of generating a provider service.