### PR TITLE
fix: fixes import users modal on dark mode

### DIFF
--- a/frontend/src/Components/forms/ShowImportedUsers.tsx
+++ b/frontend/src/Components/forms/ShowImportedUsers.tsx
@@ -26,7 +26,7 @@ const PaginatedUserTable = ({ users, onExit }: ImportedUserProps) => {
       <div className="overflow-x-auto">
         <table className="table table-xs table-auto w-full">
           <thead>
-            <tr className="bg-gray-200">
+            <tr className="bg-grey-1 text-body-text">
               <th className="px-4 py-2">Username</th>
               <th className="px-4 py-2">Temp Password</th>
               <th className="px-4 py-2">Error</th>


### PR DESCRIPTION
Changes the background on import users modal so text is seen in dark mode. Closes #326 

<img width="1512" alt="Screenshot 2024-08-02 at 10 35 58 AM" src="https://github.com/user-attachments/assets/39087547-b056-49b1-a06c-477d0f84f45f">
<img width="1512" alt="Screenshot 2024-08-02 at 10 36 06 AM" src="https://github.com/user-attachments/assets/082452af-b4c5-4184-afbd-1fee29866db8">
