### PR TITLE
feat(334): validation support in TextInput

### DIFF
--- a/frontend/src/Components/forms/AddUserForm.tsx
+++ b/frontend/src/Components/forms/AddUserForm.tsx
@@ -105,6 +105,13 @@ export default function AddUserForm({
                     length={50}
                     errors={errors}
                     register={register}
+                    validationRules={{
+                        pattern: {
+                            value: /^[a-zA-Z0-9]+$/,
+                            message:
+                                'Username must only contain letters and numbers'
+                        }
+                    }}
                 />
                 <DropdownInput
                     label={'Role'}

--- a/frontend/src/Components/forms/EditUserForm.tsx
+++ b/frontend/src/Components/forms/EditUserForm.tsx
@@ -90,6 +90,13 @@ export default function EditUserForm({
                     length={50}
                     errors={errors}
                     register={register}
+                    validationRules={{
+                        pattern: {
+                            value: /^[a-zA-Z0-9]+$/,
+                            message:
+                                'Username must only contain letters and numbers'
+                        }
+                    }}
                 />
                 <TextInput
                     label={'Email'}

--- a/frontend/src/Components/inputs/TextInput.tsx
+++ b/frontend/src/Components/inputs/TextInput.tsx
@@ -10,6 +10,7 @@ interface TextProps {
     password?: boolean;
     isFocused?: boolean;
     autoComplete?: string;
+    validationRules?: Record<string, any>;
 }
 
 export function TextInput({
@@ -21,9 +22,10 @@ export function TextInput({
     register,
     password = false,
     isFocused = false,
-    autoComplete = 'on'
+    autoComplete = 'on',
+    validationRules,
 }: TextProps) {
-    const options = {
+    let options = {
         required: {
             value: required,
             message: `${label} is required`
@@ -35,6 +37,9 @@ export function TextInput({
             }
         })
     };
+    if(validationRules) {
+        options = { ...options, ...validationRules };
+    }
     return (
         <label className="form-control">
             <div className="label">


### PR DESCRIPTION
Instead of using setError I used the built in validation support via register by adding an optional field to TextInput.
I wanted to get opinion on this, I thought it would be more versatile.  I would be happy to set this up with setError instead if that is your preference.
I like that it live auto-updates as you type instead of waiting for submit.