### PR TITLE
fix: fixes mapping modal, updates pagination, updates seeder

### DIFF
--- a/backend/src/database/provider_user_mappings.go
+++ b/backend/src/database/provider_user_mappings.go
@@ -106,14 +106,6 @@ func (db *DB) getUnmappedProviderUsersWithSearch(providerID string, userSearch [
 	if err := tx.Find(&users).Error; err != nil {
 		return nil, err
 	}
-	if len(users) == 0 {
-		fmt.Println("couldn't find any good searches, returning all")
-		return users, db.Conn.Table("users u").Select("u.*").
-			Where("u.role = ?", "student").
-			Where("u.id NOT IN (SELECT user_id FROM provider_user_mappings WHERE provider_platform_id = ?)", providerID).
-			Where("facility_id = ?", fmt.Sprintf("%d", facilityId)).
-			Find(&users).Error
-	}
 
 	fmt.Printf("found %d matches", len(users))
 	return users, nil

--- a/backend/tests/test_data/users.json
+++ b/backend/tests/test_data/users.json
@@ -19,7 +19,7 @@
     "updated_at": "2024-04-09T22:17:17.000000Z",
     "username": "MeaganDouglas13",
     "password_reset": false,
-    "facility_id": 1
+    "facility_id": 3
   },
   {
     "name_first": "Mr. Garett Willms",
@@ -30,7 +30,7 @@
     "updated_at": "2024-04-09T21:57:50.000000Z",
     "username": "ClaraFrami10",
     "password_reset": false,
-    "facility_id": 1
+    "facility_id": 4
   },
   {
     "name_first": "Rebeka Gleichner",
@@ -63,7 +63,7 @@
     "updated_at": "2024-04-09T18:55:27.000000Z",
     "username": "LavadaLittel12",
     "password_reset": true,
-    "facility_id": 1
+    "facility_id": 4
   },
   {
     "name_first": "Eliseo Reichert",
@@ -74,7 +74,7 @@
     "updated_at": "2024-04-09T18:55:42.000000Z",
     "username": "JulietFriesen13",
     "password_reset": false,
-    "facility_id": 1
+    "facility_id": 5
   },
   {
     "name_first": "Santino Kautzer",
@@ -85,7 +85,7 @@
     "updated_at": "2024-04-09T18:55:28.000000Z",
     "username": "HeidiVonRueden14",
     "password_reset": true,
-    "facility_id": 1
+    "facility_id": 3
   },
   {
     "name_first": "Raina Upton",
@@ -96,6 +96,6 @@
     "updated_at": "2024-04-09T18:55:40.000000Z",
     "username": "AshleeGaylord13",
     "password_reset": false,
-    "facility_id": 1
+    "facility_id": 2
   }
 ]

--- a/backend/tests/test_data/users.json
+++ b/backend/tests/test_data/users.json
@@ -19,7 +19,7 @@
     "updated_at": "2024-04-09T22:17:17.000000Z",
     "username": "MeaganDouglas13",
     "password_reset": false,
-    "facility_id": 3
+    "facility_id": 1
   },
   {
     "name_first": "Mr. Garett Willms",
@@ -30,7 +30,7 @@
     "updated_at": "2024-04-09T21:57:50.000000Z",
     "username": "ClaraFrami10",
     "password_reset": false,
-    "facility_id": 4
+    "facility_id": 1
   },
   {
     "name_first": "Rebeka Gleichner",
@@ -63,7 +63,7 @@
     "updated_at": "2024-04-09T18:55:27.000000Z",
     "username": "LavadaLittel12",
     "password_reset": true,
-    "facility_id": 4
+    "facility_id": 1
   },
   {
     "name_first": "Eliseo Reichert",
@@ -74,7 +74,7 @@
     "updated_at": "2024-04-09T18:55:42.000000Z",
     "username": "JulietFriesen13",
     "password_reset": false,
-    "facility_id": 5
+    "facility_id": 1
   },
   {
     "name_first": "Santino Kautzer",
@@ -85,7 +85,7 @@
     "updated_at": "2024-04-09T18:55:28.000000Z",
     "username": "HeidiVonRueden14",
     "password_reset": true,
-    "facility_id": 3
+    "facility_id": 1
   },
   {
     "name_first": "Raina Upton",
@@ -96,6 +96,6 @@
     "updated_at": "2024-04-09T18:55:40.000000Z",
     "username": "AshleeGaylord13",
     "password_reset": false,
-    "facility_id": 2
+    "facility_id": 1
   }
 ]

--- a/frontend/src/Components/NewOidcClientNotification.tsx
+++ b/frontend/src/Components/NewOidcClientNotification.tsx
@@ -18,8 +18,7 @@ export default function NewOidcClientNotification({
             </div>
             <div className="modal-body">
                 <div className="text-warning font-semibold">
-                    Please make sure to save the following information. It will
-                    not be displayed again.
+                    Please make sure to save the following information.
                 </div>
                 <br />
                 <div className="label-text-alt text-md font-semibold">

--- a/frontend/src/Pages/ProviderUserManagement.tsx
+++ b/frontend/src/Pages/ProviderUserManagement.tsx
@@ -208,8 +208,6 @@ export default function ProviderUserManagement() {
         getData();
     }, [providerId]);
 
-    console.log(provider);
-
     return (
         <AuthenticatedLayout title="Users">
             <PageNav


### PR DESCRIPTION
Fixes the user management mapping modal. This updates the UI for more clarity and uses backend pagination rather than doing it in the frontend. It renders different views for when a user is fuzzy matched vs not, clears up naming conventions, and provides the user with more information on what each page means. Functionality should be the same as it was before. Screenshots below for reference:

### Previous Modal
<img width="1512" alt="Screenshot 2024-08-15 at 11 36 50 AM" src="https://github.com/user-attachments/assets/2cc3ac19-75f7-4296-b087-377b2271cb72">
<img width="1512" alt="Screenshot 2024-08-15 at 11 37 01 AM" src="https://github.com/user-attachments/assets/3d231e31-a50b-4f5b-9210-776b64d4460a">


 ### Updated Modal
If the user has no fuzzy matches, will show all users.
<img width="1512" alt="Screenshot 2024-08-15 at 11 17 56 AM" src="https://github.com/user-attachments/assets/7d0c6584-0ca5-4d5f-9163-949a688ca905">

If the user has a fuzzy match, it will show that match.
<img width="1512" alt="Screenshot 2024-08-15 at 11 17 39 AM" src="https://github.com/user-attachments/assets/9327a387-dd45-4647-bb2e-b849e58edfbe">

On selection of a user the map student button is enabled.
<img width="1512" alt="Screenshot 2024-08-15 at 11 17 43 AM" src="https://github.com/user-attachments/assets/8f99a70d-6ff7-4b29-832e-4a56c075c0d9">

If they click see all users, it will show all users along with a link to display the fuzzy users again.
<img width="1512" alt="Screenshot 2024-08-15 at 11 17 49 AM" src="https://github.com/user-attachments/assets/17539d2b-34c3-4384-9a91-7342806f7112">

Closes #331.