### PR TITLE
feat: add unauthorized page and protect routes

### DIFF
--- a/backend/src/handlers/actions.go
+++ b/backend/src/handlers/actions.go
@@ -13,12 +13,12 @@ import (
 
 func (srv *Server) registerActionsRoutes() {
 	// returns the users for mapping on the client
-	srv.Mux.Handle("GET /api/actions/provider-platforms/{id}/get-users", srv.applyMiddleware(srv.HandleGetUsers))
+	srv.Mux.Handle("GET /api/actions/provider-platforms/{id}/get-users", srv.ApplyAdminMiddleware(srv.HandleGetUsers))
 
-	srv.Mux.Handle("POST /api/actions/provider-platforms/{id}/import-users", srv.applyMiddleware(srv.HandleImportUsers))
-	srv.Mux.Handle("POST /api/actions/provider-platforms/{id}/import-programs", srv.applyMiddleware(srv.HandleImportPrograms))
-	srv.Mux.Handle("POST /api/actions/provider-platforms/{id}/import-milestones", srv.applyMiddleware(srv.HandleImportMilestones))
-	srv.Mux.Handle("POST /api/actions/provider-platforms/{id}/import-activity", srv.applyMiddleware(srv.HandleImportActivity))
+	srv.Mux.Handle("POST /api/actions/provider-platforms/{id}/import-users", srv.ApplyAdminMiddleware(srv.HandleImportUsers))
+	srv.Mux.Handle("POST /api/actions/provider-platforms/{id}/import-programs", srv.ApplyAdminMiddleware(srv.HandleImportPrograms))
+	srv.Mux.Handle("POST /api/actions/provider-platforms/{id}/import-milestones", srv.ApplyAdminMiddleware(srv.HandleImportMilestones))
+	srv.Mux.Handle("POST /api/actions/provider-platforms/{id}/import-activity", srv.ApplyAdminMiddleware(srv.HandleImportActivity))
 }
 
 /****************************************************************************************************

--- a/backend/src/handlers/dashboard.go
+++ b/backend/src/handlers/dashboard.go
@@ -10,7 +10,7 @@ import (
 
 func (srv *Server) registerDashboardRoutes() {
 	srv.Mux.Handle("GET /api/users/{id}/student-dashboard", srv.applyMiddleware(srv.HandleStudentDashboard))
-	srv.Mux.Handle("GET /api/users/{id}/admin-dashboard", srv.applyMiddleware(srv.HandleAdminDashboard))
+	srv.Mux.Handle("GET /api/users/{id}/admin-dashboard", srv.ApplyAdminMiddleware(srv.HandleAdminDashboard))
 	srv.Mux.Handle("GET /api/users/{id}/catalogue", srv.applyMiddleware(srv.HandleUserCatalogue))
 	srv.Mux.Handle("GET /api/users/{id}/programs", srv.applyMiddleware(srv.HandleUserPrograms))
 }

--- a/backend/src/handlers/provider_platform_handler.go
+++ b/backend/src/handlers/provider_platform_handler.go
@@ -10,11 +10,11 @@ import (
 )
 
 func (srv *Server) registerProviderPlatformRoutes() {
-	srv.Mux.Handle("GET /api/provider-platforms", srv.applyMiddleware(http.HandlerFunc(srv.HandleIndexProviders)))
-	srv.Mux.Handle("GET /api/provider-platforms/{id}", srv.applyMiddleware(http.HandlerFunc(srv.HandleShowProvider)))
-	srv.Mux.Handle("POST /api/provider-platforms", srv.applyMiddleware(http.HandlerFunc(srv.HandleCreateProvider)))
-	srv.Mux.Handle("PATCH /api/provider-platforms/{id}", srv.applyMiddleware(http.HandlerFunc(srv.HandleUpdateProvider)))
-	srv.Mux.Handle("DELETE /api/provider-platforms/{id}", srv.applyMiddleware(http.HandlerFunc(srv.HandleDeleteProvider)))
+	srv.Mux.HandleFunc("GET /api/provider-platforms", srv.ApplyAdminMiddleware(srv.HandleIndexProviders))
+	srv.Mux.HandleFunc("GET /api/provider-platforms/{id}", srv.ApplyAdminMiddleware(srv.HandleShowProvider))
+	srv.Mux.HandleFunc("POST /api/provider-platforms", srv.ApplyAdminMiddleware(srv.HandleCreateProvider))
+	srv.Mux.HandleFunc("PATCH /api/provider-platforms/{id}", srv.ApplyAdminMiddleware(srv.HandleUpdateProvider))
+	srv.Mux.HandleFunc("DELETE /api/provider-platforms/{id}", srv.ApplyAdminMiddleware(srv.HandleDeleteProvider))
 }
 
 func (srv *Server) HandleIndexProviders(w http.ResponseWriter, r *http.Request) {

--- a/backend/src/handlers/provider_user_mapping_handler.go
+++ b/backend/src/handlers/provider_user_mapping_handler.go
@@ -8,10 +8,10 @@ import (
 )
 
 func (srv *Server) registerProviderMappingRoutes() {
-	srv.Mux.Handle("GET /api/users/{id}/logins", srv.applyMiddleware(srv.handleGetMappingsForUser))
-	srv.Mux.Handle("POST /api/users/{id}/logins", srv.applyMiddleware(srv.handleCreateProviderUserMapping))
-	srv.Mux.Handle("POST /api/provider-platforms/{id}/user-accounts/{user_id}", srv.applyMiddleware(srv.handleCreateProviderUserAccount))
-	srv.Mux.Handle("DELETE /api/users/{userId}/logins/{providerId}", srv.applyMiddleware(srv.handleDeleteProviderUserMapping))
+	srv.Mux.Handle("GET /api/users/{id}/logins", srv.ApplyAdminMiddleware(srv.handleGetMappingsForUser))
+	srv.Mux.Handle("POST /api/users/{id}/logins", srv.ApplyAdminMiddleware(srv.handleCreateProviderUserMapping))
+	srv.Mux.Handle("POST /api/provider-platforms/{id}/user-accounts/{user_id}", srv.ApplyAdminMiddleware(srv.handleCreateProviderUserAccount))
+	srv.Mux.Handle("DELETE /api/users/{userId}/logins/{providerId}", srv.ApplyAdminMiddleware(srv.handleDeleteProviderUserMapping))
 }
 
 func (srv *Server) handleGetMappingsForUser(w http.ResponseWriter, r *http.Request) {

--- a/backend/tests/facilities_test.go
+++ b/backend/tests/facilities_test.go
@@ -76,7 +76,7 @@ func TestCreateFacility(t *testing.T) {
 		}
 		created := facilities.Data[0]
 		if strings.Compare(created.Name, "TestingFacility") != 0 {
-			t.Errorf("incorrect output, expected: TestingFacility, got: " + created.Name)
+			t.Error("incorrect output, expected: TestingFacility, got: " + created.Name)
 		}
 	})
 }

--- a/frontend/src/AuthContext.tsx
+++ b/frontend/src/AuthContext.tsx
@@ -10,6 +10,7 @@ import React, {
 import { User } from './types';
 import axios from 'axios';
 import { BROWSER_URL } from './common';
+import UnauthorizedNotFound from './Pages/Unauthorized';
 
 interface AuthContextType {
     user: User | null;
@@ -30,6 +31,7 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({
                 setUser(response.data);
             } catch (error) {
                 console.log('Authentication check failed', error);
+                window.location.href = BROWSER_URL;
                 setUser(null);
             } finally {
                 setLoading(false);
@@ -55,6 +57,20 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({
             {children}
         </AuthContext.Provider>
     );
+};
+
+export const AdminOnly: React.FC<{ children: React.ReactNode }> = ({
+    children
+}) => {
+    const { user } = useAuth();
+    if (!user) {
+        return null;
+    }
+    if (user.role === 'admin') {
+        return <>{children}</>;
+    } else {
+        return <UnauthorizedNotFound which="unauthorized" />;
+    }
 };
 
 export const useAuth = () => {

--- a/frontend/src/Pages/Unauthorized.tsx
+++ b/frontend/src/Pages/Unauthorized.tsx
@@ -1,0 +1,30 @@
+import AuthenticatedLayout from '@/Layouts/AuthenticatedLayout';
+
+export default function UnauthorizedNotFound({ which }: { which: string }) {
+    return (
+        <>
+            <AuthenticatedLayout title="Error">
+                <div className="flex items-center justify-center min-h-screen">
+                    <div className="card content-center shadow-md w-96">
+                        <div className="text-center card-body">
+                            <div className="mb-4 font-medium text-sm text-green-600">
+                                {which === 'unauthorized'
+                                    ? `You are not authorized to view this page, please contact your administrator if you believe
+                you have reached this page in error.`
+                                    : `The page you requested was not found`}
+                            </div>
+                            <button
+                                className="btn btn-primary btn-outline"
+                                onClick={() => {
+                                    window.location.href = '/dashboard';
+                                }}
+                            >
+                                Dashboard
+                            </button>
+                        </div>
+                    </div>
+                </div>
+            </AuthenticatedLayout>
+        </>
+    );
+}

--- a/frontend/src/app.tsx
+++ b/frontend/src/app.tsx
@@ -7,7 +7,7 @@ import Login from '@/Pages/Auth/Login';
 import Users from '@/Pages/Users';
 import ResetPassword from '@/Pages/Auth/ResetPassword';
 import ProviderPlatformManagement from './Pages/ProviderPlatformManagement';
-import { AuthProvider } from './AuthContext';
+import { AdminOnly, AuthProvider } from './AuthContext';
 import Consent from './Pages/Auth/Consent';
 import MyCourses from './Pages/MyCourses';
 import MyProgress from './Pages/MyProgress';
@@ -15,9 +15,18 @@ import CourseCatalog from './Pages/CourseCatalog';
 import ProviderUserManagement from './Pages/ProviderUserManagement';
 import Error from './Pages/Error';
 import ResourcesManagement from './Pages/ResourcesManagement';
+import UnauthorizedNotFound from './Pages/Unauthorized';
 
 function WithAuth({ children }) {
     return <AuthProvider>{children}</AuthProvider>;
+}
+
+function WithAdmin({ children }) {
+    return (
+        <WithAuth>
+            <AdminOnly>{children}</AdminOnly>
+        </WithAuth>
+    );
 }
 
 export default function App() {
@@ -39,12 +48,12 @@ export default function App() {
         },
         {
             path: '/users',
-            element: WithAuth({ children: <Users /> }),
+            element: WithAdmin({ children: <Users /> }),
             errorElement: <Error />
         },
         {
             path: '/resources-management',
-            element: WithAuth({ children: <ResourcesManagement /> }),
+            element: WithAdmin({ children: <ResourcesManagement /> }),
             errorElement: <Error />
         },
         {
@@ -61,7 +70,7 @@ export default function App() {
         },
         {
             path: '/provider-platform-management',
-            element: WithAuth({ children: <ProviderPlatformManagement /> }),
+            element: WithAdmin({ children: <ProviderPlatformManagement /> }),
             errorElement: <Error />
         },
         {
@@ -81,12 +90,18 @@ export default function App() {
         },
         {
             path: '/provider-users/:providerId',
-            element: WithAuth({ children: <ProviderUserManagement /> }),
+            element: WithAdmin({ children: <ProviderUserManagement /> }),
             errorElement: <Error />
         },
         {
             path: '/error',
             element: <Error />
+        },
+        {
+            path: '/*',
+            element: WithAuth({
+                children: <UnauthorizedNotFound which="notFound" />
+            })
         }
     ]);
 


### PR DESCRIPTION
When a user is not logged in and tries to access any page that requires authentication, they will be redirected to the login page.

When a student (non-admin) is logged in, and tries to access a page that requires administrative privileges, they will be presented with the following page:
![unauthorized](https://github.com/user-attachments/assets/6f095b78-ea37-4ffe-91e6-2ca693e923ea)


When any logged in user attempts to access a page that doesn't exist, they will be presented with: 

![not_found](https://github.com/user-attachments/assets/2930d533-1050-4e93-8dfd-573d8568e6a5)

fixes #344 