### PR TITLE
feat: add collapsible navigation component

### DIFF
--- a/backend/tests/facilities_test.go
+++ b/backend/tests/facilities_test.go
@@ -76,7 +76,7 @@ func TestCreateFacility(t *testing.T) {
 		}
 		created := facilities.Data[0]
 		if strings.Compare(created.Name, "TestingFacility") != 0 {
-			t.Error("incorrect output, expected: TestingFacility, got: " + created.Name)
+			t.Errorf("incorrect output, expected: TestingFacility, got %v", created.Name)
 		}
 	})
 }

--- a/frontend/src/Components/Navbar.tsx
+++ b/frontend/src/Components/Navbar.tsx
@@ -6,19 +6,52 @@ import {
     BuildingStorefrontIcon,
     HomeIcon,
     RectangleStackIcon,
+    ChevronDoubleLeftIcon,
+    ChevronDoubleRightIcon,
     TrophyIcon,
     UsersIcon
 } from '@heroicons/react/24/solid';
 import { useAuth } from '@/AuthContext';
 
-export default function Navbar() {
+export default function Navbar({
+    isPinned,
+    onTogglePin
+}: {
+    isPinned: boolean;
+    onTogglePin: () => void;
+}) {
     const user = useAuth();
     return (
-        <div className="w-60 min-w-[240px] h-screen flex flex-col justify-between bg-background">
+        <div className="w-60 min-w-[240px] h-screen flex flex-col justify-start bg-background group">
+            <div className="hidden lg:flex self-end py-6 mr-4">
+                {isPinned ? (
+                    <div
+                        className="tooltip tooltip-left"
+                        data-tip="Close sidebar"
+                    >
+                        <ChevronDoubleLeftIcon
+                            className="w-4 opacity-0 group-hover:opacity-100 transition-opacity duration=300 cursor-pointer"
+                            onClick={onTogglePin}
+                        ></ChevronDoubleLeftIcon>
+                    </div>
+                ) : (
+                    <div
+                        className="tooltip tooltip-left"
+                        data-tip="Lock sidebar open"
+                    >
+                        <ChevronDoubleRightIcon
+                            className="w-4 opacity-0 group-hover:opacity-100 transition-opacity duration=300 cursor-pointer"
+                            onClick={onTogglePin}
+                        ></ChevronDoubleRightIcon>
+                    </div>
+                )}
+            </div>
+
+            <a href="/" className="mt-16">
+                <Brand />
+            </a>
+
             <ul className="menu">
-                <a href="/" className="mt-24">
-                    <Brand />
-                </a>
                 {user.user.role == UserRole.Admin ? (
                     <>
                         {/* admin view */}

--- a/frontend/src/Components/PageNav.tsx
+++ b/frontend/src/Components/PageNav.tsx
@@ -1,22 +1,27 @@
 import { User, UserRole } from '../common';
 import { useEffect, useRef } from 'react';
+import { useAuth } from '../AuthContext';
 import {
     ArrowRightEndOnRectangleIcon,
     HomeIcon,
     UsersIcon,
     RectangleStackIcon,
+    Bars3Icon,
     ArchiveBoxIcon
 } from '@heroicons/react/24/solid';
 import ThemeToggle from './ThemeToggle';
 import { handleLogout } from '../AuthContext';
 
 export default function PageNav({
-    user,
-    path
+    path,
+    showOpenMenu,
+    onShowNav
 }: {
-    user: User;
     path: Array<string>;
+    showOpenMenu: boolean;
+    onShowNav?: () => void;
 }) {
+    const { user } = useAuth();
     const detailsRef = useRef<HTMLDetailsElement>(null);
     useEffect(() => {
         const closeDropdown = ({ target }: MouseEvent) => {
@@ -37,11 +42,25 @@ export default function PageNav({
 
     return (
         <div className="navbar px-8">
-            <div className="navbar-start breadcrumbs pl-0">
+            <div className="navbar-start breadcrumbs !py-0 pl-0">
                 <ul>
-                    <li>
-                        <HomeIcon className="h-5" />
-                    </li>
+                    {showOpenMenu ? (
+                        <li>
+                            <Bars3Icon
+                                onClick={onShowNav}
+                                className="w-4 cursor-pointer"
+                            />
+                        </li>
+                    ) : (
+                        <li>
+                            <Bars3Icon
+                                onClick={onShowNav}
+                                className="w-4 lg:hidden cursor-pointer"
+                            />
+                            <HomeIcon className="w-4 hidden lg:block" />
+                        </li>
+                    )}
+
                     {path.map((p) => (
                         <li key={p}>{p}</li>
                     ))}

--- a/frontend/src/Layouts/AuthenticatedLayout.tsx
+++ b/frontend/src/Layouts/AuthenticatedLayout.tsx
@@ -1,19 +1,67 @@
-import { PropsWithChildren } from 'react';
+import { PropsWithChildren, useState } from 'react';
 import Navbar from '@/Components/Navbar';
+import PageNav from '@/Components/PageNav';
 
 export default function AuthenticatedLayout({
     title,
+    path,
     children
-}: PropsWithChildren<{ title: string }>) {
+}: PropsWithChildren<{ title: string; path?: Array<string> }>) {
+    // We have three states we need to factor for.
+    // 1. If the nav is open & pinned (Large screens only & uses lg:drawer-open)
+    // 2. If the nav is open & not pinned (Large screens only)
+    // 3. If the nav is not open. (Small screens only)
+
+    const getInitialPinnedState = () => {
+        const storedNavPinned = localStorage.getItem('navPinned');
+        return storedNavPinned ? JSON.parse(storedNavPinned) : true;
+    };
+
+    const [isNavOpen, setIsNavOpen] = useState(false);
+    const [isNavPinned, setIsNavPinned] = useState(getInitialPinnedState);
+
+    const showNav = () => {
+        setIsNavPinned(false);
+        setIsNavOpen(true);
+    };
+
+    const togglePin = () => {
+        const newPinnedState = !isNavPinned;
+        setIsNavPinned(newPinnedState);
+        setIsNavOpen(newPinnedState);
+        localStorage.setItem('navPinned', JSON.stringify(newPinnedState));
+    };
+
     return (
         <div className="font-lato">
             <div title={title} />
-            <div className="flex">
-                <Navbar />
-                <div className="min-w-px bg-grey-1"></div>
-                <main className="w-full min-h-screen bg-background">
-                    {children}
-                </main>
+            <div
+                className={`drawer drawer-mobile  ${isNavPinned ? 'lg:drawer-open' : ''} `}
+            >
+                <div className="drawer-content flex flex-col border-l border-grey-1">
+                    <main className="w-full min-h-screen bg-background">
+                        <PageNav
+                            path={path}
+                            showOpenMenu={!isNavPinned}
+                            onShowNav={showNav}
+                        />
+                        {children}
+                    </main>
+                </div>
+                <input
+                    id="nav-drawer"
+                    type="checkbox"
+                    className="drawer-toggle"
+                    checked={isNavOpen && !isNavPinned}
+                    onChange={() => setIsNavOpen(!isNavOpen)}
+                />
+                <div className="drawer-side">
+                    <label
+                        htmlFor="nav-drawer"
+                        className="drawer-overlay"
+                    ></label>
+                    <Navbar onTogglePin={togglePin} isPinned={isNavPinned} />
+                </div>
             </div>
         </div>
     );

--- a/frontend/src/Pages/CourseCatalog.tsx
+++ b/frontend/src/Pages/CourseCatalog.tsx
@@ -1,5 +1,4 @@
 import { useAuth } from '@/AuthContext';
-import PageNav from '@/Components/PageNav';
 import ToggleView, { ViewType } from '@/Components/ToggleView';
 import AuthenticatedLayout from '@/Layouts/AuthenticatedLayout';
 import { useState } from 'react';
@@ -26,8 +25,7 @@ export default function CourseCatalog() {
     }
 
     return (
-        <AuthenticatedLayout title="Course Catalog">
-            <PageNav user={user} path={['Course Catalog']} />
+        <AuthenticatedLayout title="Course Catalog" path={['Course Catalog']}>
             <div className="px-8 py-4">
                 <div className="flex flex-row justify-between">
                     <h1>Course Catalog</h1>

--- a/frontend/src/Pages/Dashboard.tsx
+++ b/frontend/src/Pages/Dashboard.tsx
@@ -1,4 +1,3 @@
-import PageNav from '@/Components/PageNav';
 import AuthenticatedLayout from '@/Layouts/AuthenticatedLayout';
 import { useAuth } from '@/AuthContext';
 import { UserRole } from '@/common';
@@ -9,8 +8,7 @@ export default function Dashboard() {
     const { user } = useAuth();
 
     return (
-        <AuthenticatedLayout title="Dashboard">
-            <PageNav user={user} path={['Dashboard']} />
+        <AuthenticatedLayout title="Dashboard" path={['Dashboard']}>
             {user.role == UserRole.Student ? (
                 <StudentDashboard />
             ) : (

--- a/frontend/src/Pages/MyCourses.tsx
+++ b/frontend/src/Pages/MyCourses.tsx
@@ -1,5 +1,4 @@
 import { useAuth } from '@/AuthContext';
-import PageNav from '@/Components/PageNav';
 import AuthenticatedLayout from '@/Layouts/AuthenticatedLayout';
 import EnrolledCourseCard from '@/Components/EnrolledCourseCard';
 import { useEffect, useState } from 'react';
@@ -60,8 +59,7 @@ export default function MyCourses() {
     }
 
     return (
-        <AuthenticatedLayout title="My Courses">
-            <PageNav user={user} path={['My Courses']} />
+        <AuthenticatedLayout title="My Courses" path={['My Courses']}>
             <div className="px-8 py-4">
                 <h1>My Courses</h1>
                 <div className="flex flex-row gap-16 w-100 border-b-2 border-grey-2 py-3">

--- a/frontend/src/Pages/MyProgress.tsx
+++ b/frontend/src/Pages/MyProgress.tsx
@@ -1,6 +1,5 @@
 import { useAuth } from '@/AuthContext';
 import { useState } from 'react';
-import PageNav from '@/Components/PageNav';
 import StatsCard from '@/Components/StatsCard';
 import UserActivityMap from '@/Components/UserActivityMap';
 import AuthenticatedLayout from '@/Layouts/AuthenticatedLayout';
@@ -48,8 +47,7 @@ export default function MyProgress() {
     console.log(data);
 
     return (
-        <AuthenticatedLayout title="My Progress">
-            <PageNav user={user} path={['My Progress']} />
+        <AuthenticatedLayout title="My Progress" path={['My Progress']}>
             <div className="px-8 py-4">
                 <h1>My Progress</h1>
                 {data && (

--- a/frontend/src/Pages/ProviderPlatformManagement.tsx
+++ b/frontend/src/Pages/ProviderPlatformManagement.tsx
@@ -1,4 +1,3 @@
-import PageNav from '@/Components/PageNav';
 import ProviderCard from '@/Components/ProviderCard';
 import AddProviderForm from '@/Components/forms/AddProviderForm';
 import EditProviderForm from '@/Components/forms/EditProviderForm';
@@ -9,7 +8,6 @@ import { PlusCircleIcon } from '@heroicons/react/24/outline';
 import { useRef, useState } from 'react';
 import useSWR from 'swr';
 import Toast, { ToastState } from '@/Components/Toast';
-import { useAuth } from '../AuthContext';
 import RegisterOidcClientForm from '@/Components/forms/RegisterOidcClientForm';
 import NewOidcClientNotification from '@/Components/NewOidcClientNotification';
 import axios from 'axios';
@@ -20,7 +18,6 @@ interface ToastProps {
 }
 
 export default function ProviderPlatformManagement() {
-    const { user } = useAuth();
     const addProviderModal = useRef<null | HTMLDialogElement>(null);
     const editProviderModal = useRef<null | HTMLDialogElement>(null);
     const [editProvider, setEditProvider] = useState<ProviderPlatform | null>(
@@ -137,11 +134,10 @@ export default function ProviderPlatformManagement() {
     };
 
     return (
-        <AuthenticatedLayout title="Provider Platform Management">
-            <PageNav
-                user={user}
-                path={['Settings', 'Provider Platform Management']}
-            />
+        <AuthenticatedLayout
+            title="Provider Platform Management"
+            path={['Provider Platform Management']}
+        >
             <div className="px-8 py-4">
                 <h1>Provider Platforms</h1>
                 <div className="flex flex-row justify-between">

--- a/frontend/src/Pages/ProviderUserManagement.tsx
+++ b/frontend/src/Pages/ProviderUserManagement.tsx
@@ -9,7 +9,6 @@ import {
     ProviderUser,
     UserImports
 } from '../common';
-import PageNav from '../Components/PageNav';
 import Toast, { ToastState } from '../Components/Toast';
 import Modal, { ModalType } from '../Components/Modal';
 import { useAuth } from '../AuthContext';
@@ -209,14 +208,13 @@ export default function ProviderUserManagement() {
     }, [providerId]);
 
     return (
-        <AuthenticatedLayout title="Users">
-            <PageNav
-                user={auth.user!}
-                path={[
-                    'Provider Platforms',
-                    `Provider User Management${provider ? ' (' + provider[0]?.name + ')' : ''}`
-                ]}
-            />
+        <AuthenticatedLayout
+            title="Users"
+            path={[
+                'Provider Platforms',
+                `Provider User Management${provider ? ' (' + provider[0]?.name + ')' : ''}`
+            ]}
+        >
             <div className="flex flex-col space-y-6 overflow-x-auto rounded-lg p-4">
                 <div className="flex justify-between">
                     <input

--- a/frontend/src/Pages/ResourcesManagement.tsx
+++ b/frontend/src/Pages/ResourcesManagement.tsx
@@ -1,6 +1,5 @@
 import CategoryItem from '../Components/CategoryItem';
 import Modal, { ModalType } from '../Components/Modal';
-import PageNav from '../Components/PageNav';
 import Toast, { ToastState } from '../Components/Toast';
 import AddCategoryForm from '../Components/forms/AddCategoryForm';
 import AuthenticatedLayout from '../Layouts/AuthenticatedLayout';
@@ -12,7 +11,6 @@ import { useEffect, useMemo, useRef, useState } from 'react';
 import useSWR from 'swr';
 import DeleteForm from '../Components/forms/DeleteForm';
 import { useDebounceValue } from 'usehooks-ts';
-import { useAuth } from '../AuthContext';
 
 interface ToastProps {
     state: ToastState;
@@ -20,7 +18,6 @@ interface ToastProps {
 }
 
 export default function ResourcesManagement() {
-    const auth = useAuth();
     const { data, error, mutate, isLoading } = useSWR('/api/left-menu');
 
     const [categoryList, setCategoryList] = useState(Array<Category>);
@@ -284,11 +281,7 @@ export default function ResourcesManagement() {
     }
 
     return (
-        <AuthenticatedLayout title="Categories">
-            <PageNav
-                user={auth.user}
-                path={['Settings', 'Resource Management']}
-            />
+        <AuthenticatedLayout title="Categories" path={['Resource Management']}>
             <div className="p-4">
                 <div className="flex justify-between">
                     <button

--- a/frontend/src/Pages/UserActivity.tsx
+++ b/frontend/src/Pages/UserActivity.tsx
@@ -1,4 +1,3 @@
-import PageNav from '../Components/PageNav';
 import Pagination from '../Components/Pagination';
 import AuthenticatedLayout from '../Layouts/AuthenticatedLayout';
 import DropdownControl from '@/Components/inputs/DropdownControl';
@@ -8,12 +7,9 @@ import { useState } from 'react';
 import useSWR from 'swr';
 // import { useDebounceValue } from "usehooks-ts";
 
-import { useAuth } from '../AuthContext';
-
 export default function UserActivity() {
     const [searchTerm, setSearchTerm] = useState('');
     // const searchQuery = useDebounceValue(searchTerm, 300);
-    const { user } = useAuth();
     // TO DO: come back and figure out pagequery
     const [pageQuery, setPageQuery] = useState(1);
     pageQuery;
@@ -32,8 +28,10 @@ export default function UserActivity() {
     };
 
     return (
-        <AuthenticatedLayout title="User Activity">
-            <PageNav user={user!} path={['Settings', 'User Activity']} />
+        <AuthenticatedLayout
+            title="User Activity"
+            path={['Settings', 'User Activity']}
+        >
             <div className="flex flex-col space-y-6 overflow-x-auto rounded-lg p-4">
                 <div className="flex justify-between">
                     <div className="flex space-x-4">

--- a/frontend/src/Pages/Users.tsx
+++ b/frontend/src/Pages/Users.tsx
@@ -10,7 +10,6 @@ import {
     UserPlusIcon
 } from '@heroicons/react/20/solid';
 import { DEFAULT_ADMIN_ID, PaginatedResponse, User } from '../common';
-import PageNav from '../Components/PageNav';
 import AddUserForm from '../Components/forms/AddUserForm';
 import EditUserForm from '../Components/forms/EditUserForm';
 import Toast, { ToastState } from '../Components/Toast';
@@ -20,12 +19,10 @@ import ResetPasswordForm from '../Components/forms/ResetPasswordForm';
 import ShowTempPasswordForm from '../Components/forms/ShowTempPasswordForm';
 import DropdownControl from '@/Components/inputs/DropdownControl';
 import SearchBar from '../Components/inputs/SearchBar';
-import { useAuth } from '../AuthContext';
 import { useDebounceValue } from 'usehooks-ts';
 import Pagination from '@/Components/Pagination';
 
 export default function Users() {
-    const auth = useAuth();
     const addUserModal = useRef<null | HTMLDialogElement>(null);
     const editUserModal = useRef<null | HTMLDialogElement>(null);
     const resetUserPasswordModal = useRef<null | HTMLDialogElement>(null);
@@ -150,8 +147,7 @@ export default function Users() {
     };
 
     return (
-        <AuthenticatedLayout title="Users">
-            <PageNav user={auth.user!} path={['Settings', 'Users']} />
+        <AuthenticatedLayout title="Users" path={['Users']}>
             <div className="flex flex-col space-y-6 overflow-x-auto rounded-lg p-4">
                 <div className="flex justify-between">
                     <div className="flex flex-row gap-x-2">


### PR DESCRIPTION
Duplicate of #353 because that was accidentally closed 🤷‍♂️ 

This PR introduces a pinnable navigation bar.
- On large screens users can "unpin" the navbar by clicking << and "pin" the navbar by clicking >>. 
- They can open a hidden navbar by clicking the hamburger menu.
- On smaller screens the navbar is automatically hidden and cannot be pinned.
- Navbar "pin" settings are saved in localstorage. 

https://github.com/user-attachments/assets/446113e8-dda7-438e-a7d4-90d5163d6037

Other changes that were included in this PR:
- Refactored the PageNav to be part of AuthenticatedLayout.
- Fixed a logging message on `facilities_test` (The linter kept failing on the pre-commit hook.)

Closes #340 