### PR TITLE
feat: change status of PR to "In Review" when added to project

### DIFF
--- a/.github/workflows/project-status-update.yml
+++ b/.github/workflows/project-status-update.yml
@@ -1,0 +1,46 @@
+# File: .github/workflows/project-status-update.yml
+name: Update Project Status to "In Review" on PR
+
+on:
+  pull_request:
+    types: [opened, reopened, edited]
+
+permissions:
+  contents: read
+  pull-requests: read
+jobs:
+  update-project-status:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout the repository
+        uses: actions/checkout@v4
+
+      - name: Set project item to "In Review"
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          PR_NUMBER=${{ github.event.pull_request.number }}
+          REPO_NAME=${{ github.repository }}
+          
+          echo "Fetching the project items associated with PR #${PR_NUMBER} in repository ${REPO_NAME}."
+
+          # Retrieve associated project item using GitHub API
+          ITEM_ID=$(curl -s -H "Authorization: token $GITHUB_TOKEN" \
+            -H "Accept: application/vnd.github+json" \
+            "https://api.github.com/repos/$REPO_NAME/issues/$PR_NUMBER/timeline" \
+            | jq -r '.[] | select(.project_card != null) | .project_card.project_url' | head -n 1)
+
+          if [ -z "$ITEM_ID" ]; then
+            echo "No associated project found for this PR."
+            exit 0
+          fi
+
+          echo "Found associated project item: $ITEM_ID"
+
+          # Update the status of the item to "In Review"
+          curl -s -X PATCH -H "Authorization: token $GITHUB_TOKEN" \
+            -H "Accept: application/vnd.github+json" \
+            -d '{"status":"In Review"}' \
+            "$ITEM_ID"
+
+          echo "The status has been updated to 'In Review'."


### PR DESCRIPTION
## Description of the change

This pull request introduces a GitHub Actions workflow that automatically updates the status of associated GitHub Project items to "In Review" when a pull request is created, reopened, or edited. The workflow uses the GitHub API to locate the relevant project item linked to the pull request and modifies its status accordingly.

- **Related issues**: This PR addresses the need for automatic status updates in project management workflows to streamline the review process for new pull requests. No specific issue numbers to close.

## Screenshot(s)

No UI changes are included in this pull request, as this change is purely workflow-based.

## Additional context

The workflow is defined in `.github/workflows/project-status-update.yml` and is triggered on the `pull_request` event. It interacts with the GitHub Projects API to locate the associated project item for the pull request and updates its status to "In Review" using the default GitHub token (`secrets.GITHUB_TOKEN`). 

This change will help automate project tracking and ensure that pull requests entering the review stage are accurately reflected in the project's status.