### PR TITLE
fix: fixes toast alert colors

### DIFF
--- a/frontend/src/Components/Toast.tsx
+++ b/frontend/src/Components/Toast.tsx
@@ -34,8 +34,10 @@ export default function Toast({ state, message, reset }: ToastProps) {
                 isVisible ? 'opacity-100' : 'opacity-0'
             }`}
         >
-            <div className={`alert alert-${state}`}>
-                {state == 'success' ? (
+            <div
+                className={`alert text-white ${state == ToastState.success ? 'bg-success' : 'bg-error'}`}
+            >
+                {state == ToastState.success ? (
                     <CheckCircleIcon className="h-6" />
                 ) : (
                     <ExclamationCircleIcon className="h-6" />

--- a/frontend/src/Components/Toast.tsx
+++ b/frontend/src/Components/Toast.tsx
@@ -37,7 +37,7 @@ export default function Toast({ state, message, reset }: ToastProps) {
             <div
                 className={`alert text-white ${state == ToastState.success ? 'bg-success' : 'bg-error'}`}
             >
-                {state == ToastState.success ? (
+                {state === ToastState.success ? (
                     <CheckCircleIcon className="h-6" />
                 ) : (
                     <ExclamationCircleIcon className="h-6" />


### PR DESCRIPTION
## Description of the change
Updates toast color so that color changes for success and error. Previously these were grey.

## Screenshot(s)
Light mode:
<img width="1512" alt="Screenshot 2024-10-08 at 12 14 28 PM" src="https://github.com/user-attachments/assets/5175dcf5-95d6-4cfa-8ebc-42e141b474a0">
<img width="1512" alt="Screenshot 2024-10-08 at 12 15 03 PM" src="https://github.com/user-attachments/assets/db31caea-bc93-4468-bb57-2a0a4678ff1b">

Dark mode:
<img width="1512" alt="Screenshot 2024-10-08 at 12 16 01 PM" src="https://github.com/user-attachments/assets/395051d8-d148-44ed-b505-e351835ff3cf">
<img width="1512" alt="Screenshot 2024-10-08 at 12 16 59 PM" src="https://github.com/user-attachments/assets/5dfed200-6abc-4e49-83b2-28509d247215">
