### PR TITLE
Adds open content management ui for admins and students

### DIFF
--- a/backend/src/database/libraries.go
+++ b/backend/src/database/libraries.go
@@ -7,17 +7,21 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
-func (db *DB) GetAllLibraries(page, perPage int, showHidden bool, search string, providerId int) (int64, []models.Library, error) {
+func (db *DB) GetAllLibraries(page, perPage int, visibility string, search string, providerId int) (int64, []models.Library, error) {
 	var libraries []models.Library
 	var total int64
 	offset := (page - 1) * perPage
-	tx := db.Model(&models.Library{})
-	if !showHidden {
+	tx := db.Model(&models.Library{}).Preload("OpenContentProvider").Order("created_at DESC")
+	visibility = strings.ToLower(visibility)
+	if visibility == "hidden" {
+		tx = tx.Where("visibility_status = false")
+	}
+	if visibility == "visible" {
 		tx = tx.Where("visibility_status = true")
 	}
 	if search != "" {
 		search = "%" + strings.ToLower(search) + "%"
-		tx = tx.Where("name LIKE ?", search)
+		tx = tx.Where("LOWER(name) LIKE ?", search)
 	}
 	if providerId != 0 {
 		tx = tx.Where("open_content_provider_id = ?", providerId)

--- a/backend/src/handlers/libraries_handler.go
+++ b/backend/src/handlers/libraries_handler.go
@@ -18,9 +18,12 @@ func (srv *Server) handleIndexLibraries(w http.ResponseWriter, r *http.Request, 
 	if err != nil {
 		providerId = 0
 	}
-	showHidden := false
+	showHidden := "visible"
+	if !srv.UserIsAdmin(r) && r.URL.Query().Get("visibility") == "hidden" {
+		return newUnauthorizedServiceError()
+	}
 	if srv.UserIsAdmin(r) {
-		showHidden = r.URL.Query().Get("show_hidden") == "true"
+		showHidden = r.URL.Query().Get("visibility")
 	}
 	total, libraries, err := srv.Db.GetAllLibraries(page, perPage, showHidden, search, providerId)
 	if err != nil {

--- a/backend/src/handlers/libraries_handler_test.go
+++ b/backend/src/handlers/libraries_handler_test.go
@@ -12,12 +12,14 @@ import (
 
 func TestHandleIndexLibraries(t *testing.T) {
 	httpTests := []httpTest{
-		{"TestGetLibrariesAsUser", "student", map[string]any{"page": 1, "per_page": 10, "show_hidden": false, "search": "", "provider_id": 0}, http.StatusOK, "?page=1&per_page=10"},
-		{"TestGetLibrariesAsUserShowHidden", "student", map[string]any{"page": 1, "per_page": 10, "show_hidden": false, "search": "", "provider_id": 0}, http.StatusOK, "?page=1&per_page=10&show_hidden=true"},
-		{"TestGetLibrariesAsAdmin", "admin", map[string]any{"page": 1, "per_page": 10, "show_hidden": false, "search": "", "provider_id": 0}, http.StatusOK, "?page=1&per_page=10"},
-		{"TestGetLibrariesAsAdmin", "admin", map[string]any{"page": 1, "per_page": 10, "show_hidden": true, "search": "", "provider_id": 0}, http.StatusOK, "?page=1&per_page=10&show_hidden=true&provider_id=0"},
-		{"TestGetLibrariesAsAdmin", "admin", map[string]any{"page": 1, "per_page": 10, "show_hidden": true, "search": "", "provider_id": 1}, http.StatusOK, "?page=1&per_page=10&show_hidden=true&provider_id=1"},
-		{"TestGetLibrariesAsAdminWithParams", "admin", map[string]any{"page": 1, "per_page": 10, "show_hidden": false, "search": "python", "provider_id": 0}, http.StatusOK, "?page=1&per_page=10&search=python"},
+		{"TestGetLibrariesAsUser", "student", map[string]any{"page": 1, "per_page": 10, "visibility": "visible", "search": "", "provider_id": 0}, http.StatusOK, "?page=1&per_page=10"},
+		{"TestGetLibrariesAsUserShowHidden", "student", map[string]any{"page": 1, "per_page": 10, "visibility": "hidden", "search": "", "provider_id": 0}, http.StatusUnauthorized, "?page=1&per_page=10&visibility=hidden"},
+		{"TestGetLibrariesAsAdmin", "admin", map[string]any{"page": 1, "per_page": 10, "visibility": "", "search": "", "provider_id": 0}, http.StatusOK, "?page=1&per_page=10"},
+		{"TestGetLibrariesAsAdmin", "admin", map[string]any{"page": 1, "per_page": 10, "visibility": "hidden", "search": "", "provider_id": 0}, http.StatusOK, "?page=1&per_page=10&visibility=hidden&provider_id=0"},
+		{"TestGetLibrariesAsAdmin", "admin", map[string]any{"page": 1, "per_page": 10, "visibility": "hidden", "search": "", "provider_id": 1}, http.StatusOK, "?page=1&per_page=10&visibility=hidden&provider_id=1"},
+		{"TestGetLibrariesAsAdminOnlyVisible", "admin", map[string]any{"page": 1, "per_page": 10, "visibility": "visible", "search": "", "provider_id": 0}, http.StatusOK, "?page=1&per_page=10&visibility=visible"},
+		{"TestGetLibrariesAsAdminOnlyHidden", "admin", map[string]any{"page": 1, "per_page": 10, "visibility": "hidden", "search": "", "provider_id": 0}, http.StatusOK, "?page=1&per_page=10&visibility=hidden"},
+		{"TestGetLibrariesAsAdminWithParams", "admin", map[string]any{"page": 1, "per_page": 10, "visibility": "", "search": "python", "provider_id": 0}, http.StatusOK, "?page=1&per_page=10&search=python"},
 	}
 	for _, test := range httpTests {
 		t.Run(test.testName, func(t *testing.T) {
@@ -28,7 +30,7 @@ func TestHandleIndexLibraries(t *testing.T) {
 			handler := getHandlerByRole(server.handleIndexLibraries, test.role)
 			rr := executeRequest(t, req, handler, test)
 			if test.expectedStatusCode == http.StatusOK {
-				_, expectedLibraries, err := server.Db.GetAllLibraries(test.mapKeyValues["page"].(int), test.mapKeyValues["per_page"].(int), test.mapKeyValues["show_hidden"].(bool), test.mapKeyValues["search"].(string), test.mapKeyValues["provider_id"].(int))
+				_, expectedLibraries, err := server.Db.GetAllLibraries(test.mapKeyValues["page"].(int), test.mapKeyValues["per_page"].(int), test.mapKeyValues["visibility"].(string), test.mapKeyValues["search"].(string), test.mapKeyValues["provider_id"].(int))
 				if err != nil {
 					t.Fatalf("unable to get libraries, error is %v", err)
 				}

--- a/backend/src/models/library.go
+++ b/backend/src/models/library.go
@@ -11,7 +11,7 @@ type Library struct {
 	ImageUrl              *string `json:"image_url"`
 	VisibilityStatus      bool    `gorm:"default:false;not null" json:"visibility_status"`
 
-	OpenContentProvider *OpenContentProvider `gorm:"foreignKey:OpenContentProviderID;constraint:OnUpdate:CASCADE,OnDelete:SET NULL" json:"-"`
+	OpenContentProvider *OpenContentProvider `gorm:"foreignKey:OpenContentProviderID;constraint:OnUpdate:CASCADE,OnDelete:SET NULL" json:"open_content_provider"`
 }
 
 func (Library) TableName() string { return "libraries" }

--- a/frontend/src/Components/LibraryCard.tsx
+++ b/frontend/src/Components/LibraryCard.tsx
@@ -1,0 +1,84 @@
+import { useState } from 'react';
+import VisibleHiddenToggle from './VisibleHiddenToggle';
+import {
+    Library,
+    ServerResponse,
+    ToastProps,
+    ToastState,
+    UserRole
+} from '@/common';
+import API from '@/api/api';
+import { KeyedMutator } from 'swr';
+
+// TO DO: update URLS to refelct the actual URL rather than the half generated one
+
+export default function LibraryCard({
+    library,
+    setToast,
+    mutate,
+    role
+}: {
+    library: Library;
+    setToast: React.Dispatch<React.SetStateAction<ToastProps>>;
+    mutate: KeyedMutator<ServerResponse<Library[]>>;
+    role: string;
+}) {
+    const [visible, setVisible] = useState<boolean>(library.visibility_status);
+
+    function changeVisibility(visibilityStatus: boolean) {
+        if (visibilityStatus == !visible) {
+            setVisible(visibilityStatus);
+            handleToggleVisibility();
+        }
+    }
+
+    const handleToggleVisibility = async () => {
+        const response = await API.put(`libraries/${library.id}`, {});
+        if (response.success) {
+            setToast({
+                state: ToastState.success,
+                message: response.message
+            });
+            mutate();
+        } else {
+            setToast({
+                state: ToastState.error,
+                message: response.message
+            });
+        }
+    };
+
+    return (
+        <div className="card">
+            <figure className="h-[100px]">
+                {library.image_url ? (
+                    <img
+                        className="object-cover w-full h-full"
+                        // TO DO: make sure that scraper is grabbing the entire URL so we dont have to append this
+                        src={'https://library.kiwix.org' + library.image_url}
+                        alt={`${library.name} thumbnail`}
+                    />
+                ) : (
+                    <div className="bg-teal-1 h-full w-full"></div>
+                )}
+            </figure>
+            <div className="p-4 space-y-2">
+                <p className="body-small">
+                    {library?.open_content_provider.name}
+                </p>
+                <h3 className="card-title text-sm line-clamp-1">
+                    {library.name}
+                </h3>
+                <p className="body-small h-[40px] leading-5 line-clamp-2">
+                    {library?.description}
+                </p>
+                {role == UserRole.Admin && (
+                    <VisibleHiddenToggle
+                        visible={visible}
+                        changeVisibility={changeVisibility}
+                    />
+                )}
+            </div>
+        </div>
+    );
+}

--- a/frontend/src/Components/LibraryLayout.tsx
+++ b/frontend/src/Components/LibraryLayout.tsx
@@ -1,0 +1,99 @@
+import {
+    FilterLibraries,
+    FilterLibrariesAdmin,
+    Library,
+    OpenContentProvider,
+    ServerResponse,
+    Tab,
+    ToastProps,
+    UserRole
+} from '@/common';
+import DropdownControl from '@/Components/inputs/DropdownControl';
+import SearchBar from '@/Components/inputs/SearchBar';
+import LibraryCard from '@/Components/LibraryCard';
+import TabView from '@/Components/TabView';
+import { useAuth } from '@/useAuth';
+import { useMemo, useState } from 'react';
+import useSWR from 'swr';
+
+export default function LibaryLayout({
+    setToast,
+    studentView
+}: {
+    setToast?: React.Dispatch<React.SetStateAction<ToastProps>>;
+    studentView?: boolean;
+}) {
+    const [searchTerm, setSearchTerm] = useState<string>('');
+    const allLibrariesTab: Tab = {
+        name: 'All',
+        value: 'all'
+    };
+    const [activeTab, setActiveTab] = useState<Tab>(allLibrariesTab);
+    const [filterLibraries, setFilterLibraries] = useState<FilterLibraries>(
+        FilterLibraries['All Libraries']
+    );
+    const [filterLibrariesAdmin, setFilterLibrariesAdmin] =
+        useState<FilterLibrariesAdmin>(FilterLibrariesAdmin['All Libraries']);
+    let role = useAuth().user.role;
+    if (studentView) {
+        role = UserRole.Student;
+    }
+
+    const { data: libraries, mutate: mutateLibraries } = useSWR<
+        ServerResponse<Library[]>
+    >(
+        `/api/libraries?${role == UserRole.Admin ? filterLibrariesAdmin : filterLibraries}&search=${searchTerm}`
+    );
+    const { data: openContentProviders } =
+        useSWR<ServerResponse<OpenContentProvider[]>>('/api/open-content');
+
+    const openContentTabs = useMemo(() => {
+        return [
+            allLibrariesTab,
+            ...(openContentProviders?.data?.map((provider) => ({
+                name: provider.name,
+                value: provider.id
+            })) ?? [])
+        ];
+    }, [openContentProviders]); //eslint-disable-line
+
+    return (
+        <div className="pt-6 space-y-6">
+            <TabView
+                tabs={openContentTabs}
+                activeTab={activeTab}
+                setActiveTab={setActiveTab}
+            />
+            <div className="flex flex-row gap-4">
+                <SearchBar
+                    searchTerm={searchTerm}
+                    changeCallback={setSearchTerm}
+                />
+                {role == UserRole.Admin ? (
+                    <DropdownControl
+                        label="Filter by"
+                        enumType={FilterLibrariesAdmin}
+                        callback={setFilterLibrariesAdmin}
+                    />
+                ) : (
+                    <DropdownControl
+                        label="Filter by"
+                        enumType={FilterLibraries}
+                        callback={setFilterLibraries}
+                    />
+                )}
+            </div>
+            <div className="grid grid-cols-4 gap-6">
+                {libraries?.data.map((library) => (
+                    <LibraryCard
+                        key={library.id}
+                        library={library}
+                        setToast={setToast}
+                        mutate={mutateLibraries}
+                        role={role}
+                    />
+                ))}
+            </div>
+        </div>
+    );
+}

--- a/frontend/src/Components/Navbar.tsx
+++ b/frontend/src/Components/Navbar.tsx
@@ -13,6 +13,7 @@ import {
     UsersIcon
 } from '@heroicons/react/24/solid';
 import { useAuth } from '@/useAuth';
+import ULIComponent from './ULIComponent';
 
 export default function Navbar({
     isPinned,
@@ -58,30 +59,36 @@ export default function Navbar({
                         {/* admin view */}
                         <li className="mt-16">
                             <a href="/dashboard">
-                                <HomeIcon className="w-4" /> Dashboard
+                                <ULIComponent icon={HomeIcon} /> Dashboard
                             </a>
                         </li>
                         <li>
                             <a href="/student-management">
-                                <AcademicCapIcon className="h-4" />
+                                <ULIComponent icon={AcademicCapIcon} />
                                 Students
                             </a>
                         </li>
                         <li>
                             <a href="/admin-management">
-                                <UsersIcon className="h-4" />
+                                <ULIComponent icon={UsersIcon} />
                                 Admins
                             </a>
                         </li>
                         <li>
+                            <a href="/open-content-management">
+                                <ULIComponent icon={BookOpenIcon} />
+                                Open Content
+                            </a>
+                        </li>
+                        <li>
                             <a href="/resources-management">
-                                <ArchiveBoxIcon className="h-4" />
+                                <ULIComponent icon={ArchiveBoxIcon} />
                                 Resources
                             </a>
                         </li>
                         <li>
                             <a href="/provider-platform-management">
-                                <RectangleStackIcon className="h-4" />
+                                <ULIComponent icon={RectangleStackIcon} />
                                 Platforms
                             </a>
                         </li>
@@ -91,38 +98,34 @@ export default function Navbar({
                         {/* student view */}
                         <li className="mt-16">
                             <a href="/dashboard">
-                                <HomeIcon className="w-4" /> Dashboard
+                                <ULIComponent icon={HomeIcon} /> Dashboard
                             </a>
                         </li>
                         <li className="">
                             <a href="/my-courses">
-                                <BookOpenIcon className="w-4" /> My Courses
+                                <ULIComponent icon={BookOpenIcon} /> My Courses
                             </a>
                         </li>
                         <li className="">
                             <a href="/my-progress">
-                                <TrophyIcon className="w-4" /> My Progress
+                                <ULIComponent icon={TrophyIcon} /> My Progress
+                            </a>
+                        </li>
+                        <li>
+                            <a href="/open-content">
+                                <ULIComponent icon={BookOpenIcon} />
+                                Open Content
                             </a>
                         </li>
                         <li className="">
                             <a href="/course-catalog">
-                                <BuildingStorefrontIcon className="w-4" />{' '}
+                                <ULIComponent icon={BuildingStorefrontIcon} />
                                 Course Catalog
                             </a>
                         </li>
                     </>
                 )}
             </ul>
-            {/* <div className="">
-                <ul className="menu mb-5">
-                    <li>
-                        <button onClick={() => handleLogout()}>
-                            <ArrowRightEndOnRectangleIcon className="h-4" />
-                            Logout
-                        </button>
-                    </li>
-                </ul>
-            </div> */}
         </div>
     );
 }

--- a/frontend/src/Components/TabView.tsx
+++ b/frontend/src/Components/TabView.tsx
@@ -1,0 +1,30 @@
+import { Tab } from '@/common';
+import { SetStateAction } from 'react';
+
+export default function TabView({
+    tabs,
+    activeTab,
+    setActiveTab
+}: {
+    tabs: Tab[];
+    activeTab: Tab;
+    setActiveTab: (state: SetStateAction<Tab>) => void;
+}) {
+    return (
+        <div className="flex flex-row gap-16 w-100 border-b-2 border-grey-2 py-3">
+            {tabs.map((tab: Tab, index: number) => (
+                <button
+                    className={
+                        activeTab.value == tab.value
+                            ? 'text-teal-4 font-bold drop-shadow'
+                            : ''
+                    }
+                    onClick={() => setActiveTab(tab)}
+                    key={index}
+                >
+                    {tab.name}
+                </button>
+            ))}
+        </div>
+    );
+}

--- a/frontend/src/Components/VisibleHiddenToggle.tsx
+++ b/frontend/src/Components/VisibleHiddenToggle.tsx
@@ -1,0 +1,31 @@
+import { CheckCircleIcon, XCircleIcon } from '@heroicons/react/24/outline';
+import ULIComponent from './ULIComponent';
+
+export default function VisibleHiddenToggle({
+    visible,
+    changeVisibility
+}: {
+    visible: boolean;
+    changeVisibility: (visibilityStatus: boolean) => void;
+}) {
+    const toggleClass =
+        'py-1 rounded-lg inline-flex items-center justify-center gap-2';
+    return (
+        <div className="bg-grey-1 rounded-lg border border-grey-2 w-full p-1 grid grid-cols-2 shadow-md justify-self-end">
+            <button
+                className={`${toggleClass} ${visible ? 'bg-teal-3 text-white' : 'bg-transparent'}`}
+                onClick={() => changeVisibility(true)}
+            >
+                <ULIComponent icon={CheckCircleIcon} />
+                <label className="body-small cursor-pointer">VISIBLE</label>
+            </button>
+            <button
+                className={`${toggleClass} ${visible ? 'bg-transparent' : 'bg-error text-white'}`}
+                onClick={() => changeVisibility(false)}
+            >
+                <ULIComponent icon={XCircleIcon} />
+                <label className="body-small cursor-pointer">HIDDEN</label>
+            </button>
+        </div>
+    );
+}

--- a/frontend/src/Pages/MyCourses.tsx
+++ b/frontend/src/Pages/MyCourses.tsx
@@ -5,6 +5,7 @@ import { useState } from 'react';
 import ToggleView from '@/Components/ToggleView';
 import SearchBar from '@/Components/inputs/SearchBar';
 import DropdownControl from '@/Components/inputs/DropdownControl';
+import { Tab } from '@/common';
 import {
     ServerResponse,
     UserCourses,
@@ -12,23 +13,20 @@ import {
     ViewType
 } from '@/common';
 import useSWR from 'swr';
-
-// TO DO: make sure this lives in the right place
-
-enum TabType {
-    Current = 'in_progress',
-    Completed = 'completed',
-    Favorited = 'is_favorited',
-    All = 'all'
-}
-
-// TO DO: go back and fix all "key" values that are mapped and make them intentional
+import TabView from '@/Components/TabView';
 
 export default function MyCourses() {
+    const tabs: Tab[] = [
+        { name: 'Current', value: 'in_progress' },
+        { name: 'Completed', value: 'completed' },
+        { name: 'Favorited', value: 'is_favorited' },
+        { name: 'All', value: 'all' }
+    ];
+
     const { user } = useAuth();
     const [searchTerm, setSearchTerm] = useState<string>('');
     const [sort, setSort] = useState<string>('order=asc&order_by=course_name');
-    const [activeTab, setActiveTab] = useState<TabType>(TabType.Current);
+    const [activeTab, setActiveTab] = useState<Tab>(tabs[0]);
     const [activeView, setActiveView] = useState<ViewType>(ViewType.Grid);
 
     const { data, mutate, isLoading, error } = useSWR<
@@ -36,7 +34,7 @@ export default function MyCourses() {
     >(
         `/api/users/${user.id}/courses?${
             sort +
-            (activeTab !== TabType.All ? `&tags=${activeTab}` : '') +
+            (activeTab.value !== 'all' ? `&tags=${activeTab.value}` : '') +
             (searchTerm ? `&search=${searchTerm}` : '')
         }`
     );
@@ -57,21 +55,11 @@ export default function MyCourses() {
         <AuthenticatedLayout title="My Courses" path={['My Courses']}>
             <div className="px-8 py-4">
                 <h1>My Courses</h1>
-                <div className="flex flex-row gap-16 w-100 border-b-2 border-grey-2 py-3">
-                    {Object.entries(TabType).map(([key]) => (
-                        <button
-                            className={
-                                activeTab == TabType[key]
-                                    ? 'text-teal-4 font-bold'
-                                    : ''
-                            }
-                            onClick={() => setActiveTab(TabType[key])}
-                            key={key}
-                        >
-                            {key}
-                        </button>
-                    ))}
-                </div>
+                <TabView
+                    tabs={tabs}
+                    activeTab={activeTab}
+                    setActiveTab={setActiveTab}
+                />
                 <div className="flex flex-row items-center mt-4 justify-between">
                     <div className="flex flex-row gap-x-2">
                         <SearchBar

--- a/frontend/src/Pages/OpenContent.tsx
+++ b/frontend/src/Pages/OpenContent.tsx
@@ -1,0 +1,13 @@
+import LibaryLayout from '@/Components/LibraryLayout';
+import AuthenticatedLayout from '@/Layouts/AuthenticatedLayout';
+
+export default function OpenContent() {
+    return (
+        <AuthenticatedLayout title="Open Content" path={['Open Content']}>
+            <div className="px-8 pb-4">
+                <h1>Open Content</h1>
+                <LibaryLayout studentView={true} />
+            </div>
+        </AuthenticatedLayout>
+    );
+}

--- a/frontend/src/Pages/OpenContentManagement.tsx
+++ b/frontend/src/Pages/OpenContentManagement.tsx
@@ -1,0 +1,34 @@
+import { ToastProps, ToastState } from '@/common';
+import LibaryLayout from '@/Components/LibraryLayout';
+import Toast from '@/Components/Toast';
+import AuthenticatedLayout from '@/Layouts/AuthenticatedLayout';
+import { useState } from 'react';
+
+export default function OpenContentManagement() {
+    const [toast, setToast] = useState<ToastProps>({
+        state: ToastState.null,
+        message: ''
+    });
+
+    return (
+        <AuthenticatedLayout
+            title="Open Content Management"
+            path={['Open Content Management']}
+        >
+            <div className="px-8 pb-4">
+                <h1>Open Content Management</h1>
+                <LibaryLayout setToast={setToast} />
+            </div>
+            {/* Toasts */}
+            {toast.state !== ToastState.null && (
+                <Toast
+                    state={toast.state}
+                    message={toast.message}
+                    reset={() =>
+                        setToast({ state: ToastState.null, message: '' })
+                    }
+                />
+            )}
+        </AuthenticatedLayout>
+    );
+}

--- a/frontend/src/Pages/ProviderPlatformManagement.tsx
+++ b/frontend/src/Pages/ProviderPlatformManagement.tsx
@@ -8,6 +8,7 @@ import {
     OidcClient,
     ProviderPlatform,
     ServerResponse,
+    ToastProps,
     ToastState
 } from '@/common';
 import { PlusCircleIcon } from '@heroicons/react/24/outline';
@@ -17,11 +18,6 @@ import Toast from '@/Components/Toast';
 import RegisterOidcClientForm from '@/Components/forms/RegisterOidcClientForm';
 import NewOidcClientNotification from '@/Components/NewOidcClientNotification';
 import API from '@/api/api';
-
-interface ToastProps {
-    state: ToastState;
-    message: string;
-}
 
 export default function ProviderPlatformManagement() {
     const addProviderModal = useRef<undefined | HTMLDialogElement>();

--- a/frontend/src/app.tsx
+++ b/frontend/src/app.tsx
@@ -18,6 +18,8 @@ import UnauthorizedNotFound from './Pages/Unauthorized';
 import AdminManagement from '@/Pages/AdminManagement.tsx';
 import StudentManagement from '@/Pages/StudentManagement.tsx';
 import { useAuth } from './useAuth';
+import OpenContentManagement from './Pages/OpenContentManagement';
+import OpenContent from './Pages/OpenContent';
 
 function WithAuth({ children }) {
     return <AuthProvider>{children}</AuthProvider>;
@@ -71,6 +73,11 @@ export default function App() {
             errorElement: <Error />
         },
         {
+            path: '/open-content-management',
+            element: WithAdmin({ children: <OpenContentManagement /> }),
+            errorElement: <Error />
+        },
+        {
             path: '/resources-management',
             element: WithAdmin({ children: <ResourcesManagement /> }),
             errorElement: <Error />
@@ -105,6 +112,11 @@ export default function App() {
         {
             path: '/course-catalog',
             element: WithAuth({ children: <CourseCatalog /> }),
+            errorElement: <Error />
+        },
+        {
+            path: '/open-content',
+            element: WithAuth({ children: <OpenContent /> }),
             errorElement: <Error />
         },
         {

--- a/frontend/src/common.ts
+++ b/frontend/src/common.ts
@@ -413,3 +413,45 @@ export enum ViewType {
     Grid = 'Grid',
     List = 'List'
 }
+
+export interface Tab {
+    name: string;
+    value: string | number;
+}
+
+export interface Library {
+    description: string | null;
+    external_id: string | null;
+    id: number;
+    image_url: string | null;
+    language: string | null;
+    name: string;
+    open_content_provider_id: number;
+    updated_at: string;
+    url: string;
+    visibility_status: boolean;
+    open_content_provider: OpenContentProvider;
+}
+
+export interface OpenContentProvider {
+    name: string;
+    url: string;
+    provider_platform_id: number | null;
+    thumbnail_url: string | null;
+    currently_enabled: boolean;
+    description: string | null;
+}
+
+export interface ToastProps {
+    state: ToastState;
+    message: string;
+}
+
+export enum FilterLibraries {
+    'All Libraries' = 'all'
+}
+export enum FilterLibrariesAdmin {
+    'All Libraries' = 'all',
+    'Visible' = '&visibility=visible',
+    'Hidden' = '&visibility=hidden'
+}


### PR DESCRIPTION
## Description of the change

Adds the open content management UI, and fixes a couple things in the backend for visibility. Also moves toast props to common file for access in other places.

- **Related issues**: Closes #409 

## Screenshot(s)

Admin View/Open Content Management:

<img width="1512" alt="Screenshot 2024-10-09 at 4 03 21 PM" src="https://github.com/user-attachments/assets/41ad6d00-a28f-40fb-a146-eef94b3213de">

Student View/Open Content:
<img width="1512" alt="Screenshot 2024-10-09 at 4 01 53 PM" src="https://github.com/user-attachments/assets/330f8dec-8631-4985-8158-07c3f748e3d9">


## Additional context

There are a few TO DO's I have left in there that are in regards to updating the UI once we have the scraper completed. It is making sure that we have the correct image URL so we can use it-- right now it is hard coded since all libraries are Kiwix. I also would love some feedback on how we should implement different colors for different providers. Should this be a color stored in the database? It will need to be a consideration once we add a new open content provider. 

ALSO: I realize that the images look a little funky now. I am attempting to find a solution that makes images look better. Here is an alternative solution:
<img width="1512" alt="Screenshot 2024-10-09 at 12 20 04 PM" src="https://github.com/user-attachments/assets/02baa537-8ebb-474c-94fb-a3bd6f313533">
I don't think it is the best one either. Open to ideas!