### PR TITLE
Nav link and course name length fixes

### DIFF
--- a/backend/migrations/00009_increase_name_length_courses_table.sql
+++ b/backend/migrations/00009_increase_name_length_courses_table.sql
@@ -1,0 +1,9 @@
+-- +goose Up
+-- +goose StatementBegin
+ALTER TABLE courses ALTER COLUMN name TYPE character varying(255);
+-- +goose StatementEnd
+
+-- +goose Down
+-- +goose StatementBegin
+ALTER TABLE courses ALTER COLUMN name TYPE character varying (60);
+-- +goose StatementEnd

--- a/frontend/src/Components/PageNav.tsx
+++ b/frontend/src/Components/PageNav.tsx
@@ -2,6 +2,7 @@ import { UserRole } from '../common';
 import { useEffect, useRef } from 'react';
 import { handleLogout, useAuth } from '@/useAuth';
 import {
+    AcademicCapIcon,
     ArchiveBoxIcon,
     ArrowRightEndOnRectangleIcon,
     Bars3Icon,
@@ -113,9 +114,15 @@ export default function PageNav({
                                 ) : (
                                     <>
                                         <li>
-                                            <a href="/users">
+                                            <a href="/student-management">
+                                                <AcademicCapIcon className="h-4" />
+                                                Students
+                                            </a>
+                                        </li>
+                                        <li>
+                                            <a href="/admin-management">
                                                 <UsersIcon className="h-4" />
-                                                Users
+                                                Admins
                                             </a>
                                         </li>
                                         <li>

--- a/provider-middleware/kolibri_data.go
+++ b/provider-middleware/kolibri_data.go
@@ -92,6 +92,9 @@ func (kc *KolibriService) IntoCourse(data map[string]interface{}) *models.Course
 	id := data["id"].(string)
 	name := data["name"].(string)
 	description := data["description"].(string)
+	if len(description) > 255 {
+		description = description[:255]
+	}
 	totalResourceCount := data["total_resource_count"].(int64)
 	course := models.Course{
 		ProviderPlatformID:      kc.ProviderPlatformID,


### PR DESCRIPTION
quick fixes to ensure we can pull kolibri data w/ longer course names and I need to push this change to the demo branch so we don't have a broken link