### PR TITLE
feat: add library reverse proxy middleware and handler, update frontend

### DIFF
--- a/backend/src/handlers/proxy_handler.go
+++ b/backend/src/handlers/proxy_handler.go
@@ -42,8 +42,6 @@ func (srv *Server) handleForwardProxy(w http.ResponseWriter, r *http.Request) {
 
 			req.URL.Path = parsedURL.Path
 			req.URL.RawQuery = r.URL.RawQuery
-
-			// These headers come from my nginx configuration file that I had used
 			req.Header.Set("X-Real-IP", r.RemoteAddr)
 			req.Header.Set("X-Forwarded-For", r.RemoteAddr)
 			req.Header.Set("X-Forwarded-Proto", "https")

--- a/backend/src/handlers/proxy_handler.go
+++ b/backend/src/handlers/proxy_handler.go
@@ -1,0 +1,77 @@
+package handlers
+
+import (
+	"UnlockEdv2/src/models"
+	"crypto/tls"
+	"fmt"
+	"net/http"
+	"net/http/httputil"
+	"net/url"
+	"strings"
+)
+
+func (srv *Server) registerProxyRoutes() {
+	srv.Mux.Handle("GET /api/proxy/libraries/{id}/", srv.proxyMiddleware(http.HandlerFunc(srv.handleForwardProxy)))
+}
+
+func (srv *Server) handleForwardProxy(w http.ResponseWriter, r *http.Request) {
+	library, ok := r.Context().Value(libraryKey).(*models.Library)
+	if !ok {
+		srv.errorResponse(w, http.StatusNotFound, "Library context not found")
+		return
+	}
+	assetPath := strings.TrimPrefix(r.URL.Path, fmt.Sprintf("/api/proxy/libraries/%d", library.ID))
+	if assetPath != "" && assetPath != "/" {
+		assetPath = strings.TrimPrefix(assetPath, library.Path)
+	}
+	targetURL, err := url.JoinPath(library.OpenContentProvider.BaseUrl, library.Path, assetPath)
+	if err != nil {
+		srv.errorResponse(w, http.StatusBadRequest, "Malformed request to build targetURL")
+		return
+	}
+	parsedURL, err := url.Parse(targetURL)
+	if err != nil {
+		srv.errorResponse(w, http.StatusBadRequest, "Error parsing target URL")
+		return
+	}
+	proxy := httputil.ReverseProxy{
+		Director: func(req *http.Request) {
+			req.URL.Scheme = "https"
+			req.URL.Host = parsedURL.Host
+			req.Host = parsedURL.Host
+
+			req.URL.Path = parsedURL.Path
+			req.URL.RawQuery = r.URL.RawQuery
+
+			// These headers come from my nginx configuration file that I had used
+			req.Header.Set("X-Real-IP", r.RemoteAddr)
+			req.Header.Set("X-Forwarded-For", r.RemoteAddr)
+			req.Header.Set("X-Forwarded-Proto", "https")
+		},
+		Transport: &http.Transport{
+			Proxy: http.ProxyFromEnvironment,
+			TLSClientConfig: &tls.Config{
+				MinVersion:         tls.VersionTLS12,
+				InsecureSkipVerify: true, // Disable SSL verification for testing
+			},
+		},
+		ModifyResponse: func(res *http.Response) error {
+			if res.StatusCode == http.StatusFound || res.StatusCode == http.StatusSeeOther || res.StatusCode == http.StatusMovedPermanently {
+				location := res.Header.Get("Location")
+				if location != "" {
+					parsedLocation, err := url.Parse(location)
+					if err != nil {
+						return err
+					}
+					finalParsedLocation, err := url.JoinPath(fmt.Sprintf("/api/proxy/libraries/%d", library.ID), parsedLocation.Path)
+					if err != nil {
+						return err
+					}
+					res.Header.Set("Location", finalParsedLocation)
+				}
+			}
+			return nil
+		},
+	}
+	proxy.ServeHTTP(w, r)
+}

--- a/backend/src/handlers/server.go
+++ b/backend/src/handlers/server.go
@@ -51,6 +51,7 @@ func (srv *Server) RegisterRoutes() {
 	srv.registerFacilitiesRoutes()
 	srv.registerOpenContentRoutes()
 	srv.registerLibraryRoutes()
+	srv.registerProxyRoutes()
 	srv.registerProgramsRoutes()
 	srv.registerSectionsRoutes()
 	srv.registerSectionEventsRoutes()

--- a/backend/src/models/open_content.go
+++ b/backend/src/models/open_content.go
@@ -22,7 +22,7 @@ type OpenContentProvider struct {
 
 const (
 	KolibriThumbnailUrl string = "https://learningequality.org/static/assets/kolibri-ecosystem-logos/blob-logo.svg"
-	Kiwix               string = "kiwix"
+	Kiwix               string = "Kiwix"
 	KolibriDescription  string = "Kolibri provides an extensive library of educational content suitable for all learning levels."
 )
 

--- a/frontend/src/Components/LibraryCard.tsx
+++ b/frontend/src/Components/LibraryCard.tsx
@@ -9,8 +9,7 @@ import {
 } from '@/common';
 import API from '@/api/api';
 import { KeyedMutator } from 'swr';
-
-// TO DO: update URLS to refelct the actual URL rather than the half generated one
+import { useNavigate } from 'react-router-dom';
 
 export default function LibraryCard({
     library,
@@ -24,6 +23,7 @@ export default function LibraryCard({
     role: UserRole;
 }) {
     const [visible, setVisible] = useState<boolean>(library.visibility_status);
+    const navigate = useNavigate();
 
     function changeVisibility(visibilityStatus: boolean) {
         if (visibilityStatus == !visible) {
@@ -47,28 +47,29 @@ export default function LibraryCard({
             });
         }
     };
+    const openContentProviderName =
+        library?.open_content_provider.name.charAt(0).toUpperCase() +
+        library?.open_content_provider.name.slice(1);
 
     return (
-        <div className="card">
-            <figure className="h-[100px]">
-                {library.image_url ? (
+        <div
+            className="card overflow-hidden cursor-pointer"
+            onClick={() => navigate(`/viewer/libraries/${library.id}`)}
+        >
+            <div className="flex p-4 gap-2 border-b-2">
+                <figure className="w-[48px] h-[48px] bg-cover">
                     <img
-                        className="object-cover w-full h-full"
-                        // TO DO: make sure that scraper is grabbing the entire URL so we dont have to append this
-                        src={'https://library.kiwix.org' + library.image_url}
+                        src={
+                            library?.open_content_provider.url +
+                            library?.image_url
+                        }
                         alt={`${library.name} thumbnail`}
                     />
-                ) : (
-                    <div className="bg-teal-1 h-full w-full"></div>
-                )}
-            </figure>
+                </figure>
+                <h3 className="w-3/4 body my-auto">{library.name}</h3>
+            </div>
             <div className="p-4 space-y-2">
-                <p className="body-small">
-                    {library?.open_content_provider.name}
-                </p>
-                <h3 className="card-title text-sm line-clamp-1">
-                    {library.name}
-                </h3>
+                <p className="body-small">{openContentProviderName}</p>
                 <p className="body-small h-[40px] leading-5 line-clamp-2">
                     {library?.description}
                 </p>

--- a/frontend/src/Components/LibraryCard.tsx
+++ b/frontend/src/Components/LibraryCard.tsx
@@ -18,7 +18,7 @@ export default function LibraryCard({
     role
 }: {
     library: Library;
-    setToast: React.Dispatch<React.SetStateAction<ToastProps>>;
+    setToast?: React.Dispatch<React.SetStateAction<ToastProps>>;
     mutate: KeyedMutator<ServerResponseMany<Library>>;
     role: UserRole;
 }) {
@@ -35,16 +35,18 @@ export default function LibraryCard({
     const handleToggleVisibility = async () => {
         const response = await API.put(`libraries/${library.id}`, {});
         if (response.success) {
-            setToast({
-                state: ToastState.success,
-                message: response.message
-            });
+            if (setToast)
+                setToast({
+                    state: ToastState.success,
+                    message: response.message
+                });
             await mutate();
         } else {
-            setToast({
-                state: ToastState.error,
-                message: response.message
-            });
+            if (setToast)
+                setToast({
+                    state: ToastState.error,
+                    message: response.message
+                });
         }
     };
     const openContentProviderName =

--- a/frontend/src/Components/TabView.tsx
+++ b/frontend/src/Components/TabView.tsx
@@ -12,19 +12,23 @@ export default function TabView({
 }) {
     return (
         <div className="flex flex-row gap-16 w-100 border-b-2 border-grey-2 py-3">
-            {tabs.map((tab: Tab, index: number) => (
-                <button
-                    className={
-                        activeTab.value == tab.value
-                            ? 'text-teal-4 font-bold drop-shadow'
-                            : ''
-                    }
-                    onClick={() => setActiveTab(tab)}
-                    key={index}
-                >
-                    {tab.name}
-                </button>
-            ))}
+            {tabs.map((tab: Tab, index: number) => {
+                const tabName =
+                    tab.name.charAt(0).toUpperCase() + tab.name.slice(1);
+                return (
+                    <button
+                        className={
+                            activeTab.value == tab.value
+                                ? 'text-teal-4 font-bold drop-shadow'
+                                : ''
+                        }
+                        onClick={() => setActiveTab(tab)}
+                        key={index}
+                    >
+                        {tabName}
+                    </button>
+                );
+            })}
         </div>
     );
 }

--- a/frontend/src/Components/VisibleHiddenToggle.tsx
+++ b/frontend/src/Components/VisibleHiddenToggle.tsx
@@ -11,7 +11,10 @@ export default function VisibleHiddenToggle({
     const toggleClass =
         'py-1 rounded-lg inline-flex items-center justify-center gap-2';
     return (
-        <div className="bg-grey-1 rounded-lg border border-grey-2 w-full p-1 grid grid-cols-2 shadow-md justify-self-end">
+        <div
+            className="bg-grey-1 rounded-lg border border-grey-2 w-full p-1 grid grid-cols-2 shadow-md justify-self-end"
+            onClick={(e) => e.stopPropagation()}
+        >
             <button
                 className={`${toggleClass} ${visible ? 'bg-teal-3 text-white' : 'bg-transparent'}`}
                 onClick={() => changeVisibility(true)}

--- a/frontend/src/Pages/LibraryViewer.tsx
+++ b/frontend/src/Pages/LibraryViewer.tsx
@@ -23,13 +23,13 @@ export default function LibraryViewer() {
                 } else {
                     setError('Error loading library');
                 }
-            } catch (error) {
+            } catch {
                 setError('Error loading library');
             } finally {
                 setIsLoading(false);
             }
         };
-        fetchLibraryData();
+        void fetchLibraryData();
     }, [libraryId]);
 
     return (

--- a/frontend/src/Pages/LibraryViewer.tsx
+++ b/frontend/src/Pages/LibraryViewer.tsx
@@ -1,0 +1,59 @@
+import AuthenticatedLayout from '@/Layouts/AuthenticatedLayout';
+import { useEffect, useState } from 'react';
+import { useParams } from 'react-router-dom';
+import Error from './Error';
+
+export default function LibraryViewer() {
+    const { id: libraryId } = useParams();
+    const [src, setSrc] = useState<string>('');
+    const [error, setError] = useState<string | null>(null);
+    const [isLoading, setIsLoading] = useState<boolean>(true);
+
+    useEffect(() => {
+        const fetchLibraryData = async () => {
+            setIsLoading(true);
+            try {
+                const response = await fetch(
+                    `/api/proxy/libraries/${libraryId}/`
+                );
+                if (response.ok) {
+                    setSrc(response.url);
+                } else if (response.status === 404) {
+                    setError('Library not found');
+                } else {
+                    setError('Error loading library');
+                }
+            } catch (error) {
+                setError('Error loading library');
+            } finally {
+                setIsLoading(false);
+            }
+        };
+        fetchLibraryData();
+    }, [libraryId]);
+
+    return (
+        <AuthenticatedLayout title="Library Viewer" path={['Library Viewer']}>
+            <div className="px-8 pb-4">
+                <h1>Library Viewer</h1>
+                <div className="w-full pt-4 justify-center">
+                    {isLoading ? (
+                        <div className="flex h-screen gap-4 justify-center content-center">
+                            <span className="my-auto loading loading-spinner loading-lg"></span>
+                            <p className="my-auto text-lg">Loading...</p>
+                        </div>
+                    ) : src != '' ? (
+                        <iframe
+                            sandbox="allow-scripts allow-same-origin"
+                            className="w-full h-screen pt-4"
+                            id="library-viewer"
+                            src={src}
+                        />
+                    ) : (
+                        error && <Error />
+                    )}
+                </div>
+            </div>
+        </AuthenticatedLayout>
+    );
+}

--- a/frontend/src/api/api.ts
+++ b/frontend/src/api/api.ts
@@ -4,13 +4,11 @@ import {
     ServerResponseMany,
     ServerResponseOne
 } from '@/common';
-
 axios.defaults.withCredentials = true;
 axios.defaults.headers.common['X-Requested-With'] = 'XMLHttpRequest';
 axios.defaults.headers.common.Accept = 'application/json';
 axios.defaults.headers.common['Content-Type'] = 'application/json';
 
-// Interceptor to handle responses and errors
 axios.interceptors.response.use(
     (response) => response,
     (error: AxiosError) => {
@@ -25,13 +23,6 @@ axios.interceptors.response.use(
         const customError = new Error(message) as Error & {
             response: ServerResponse<null>;
         };
-        customError.response = {
-            type: 'one',
-            success: false,
-            message,
-            data: null
-        };
-
         return Promise.reject(customError);
     }
 );

--- a/frontend/src/app.tsx
+++ b/frontend/src/app.tsx
@@ -22,6 +22,7 @@ import OpenContentManagement from './Pages/OpenContentManagement';
 import OpenContent from './Pages/OpenContent';
 import { checkDefaultFacility, checkExistingFlow, useAuth } from '@/useAuth';
 import { UserRole } from '@/common';
+import LibraryViewer from './Pages/LibraryViewer';
 
 function WithAuth({ children }: { children: React.ReactNode }) {
     return <AuthProvider>{children}</AuthProvider>;
@@ -121,6 +122,11 @@ export default function App() {
         {
             path: '/open-content',
             element: WithAuth({ children: <OpenContent /> }),
+            errorElement: <Error />
+        },
+        {
+            path: '/viewer/libraries/:id',
+            element: WithAuth({ children: <LibraryViewer /> }),
             errorElement: <Error />
         },
         {

--- a/frontend/src/app.tsx
+++ b/frontend/src/app.tsx
@@ -20,8 +20,6 @@ import AdminManagement from '@/Pages/AdminManagement.tsx';
 import StudentManagement from '@/Pages/StudentManagement.tsx';
 import OpenContentManagement from './Pages/OpenContentManagement';
 import OpenContent from './Pages/OpenContent';
-import { checkDefaultFacility, checkExistingFlow, useAuth } from '@/useAuth';
-import { UserRole } from '@/common';
 import LibraryViewer from './Pages/LibraryViewer';
 import { checkDefaultFacility, checkExistingFlow, useAuth } from '@/useAuth';
 import { UserRole } from '@/common';

--- a/frontend/src/app.tsx
+++ b/frontend/src/app.tsx
@@ -23,6 +23,8 @@ import OpenContent from './Pages/OpenContent';
 import { checkDefaultFacility, checkExistingFlow, useAuth } from '@/useAuth';
 import { UserRole } from '@/common';
 import LibraryViewer from './Pages/LibraryViewer';
+import { checkDefaultFacility, checkExistingFlow, useAuth } from '@/useAuth';
+import { UserRole } from '@/common';
 
 function WithAuth({ children }: { children: React.ReactNode }) {
     return <AuthProvider>{children}</AuthProvider>;

--- a/frontend/src/common.ts
+++ b/frontend/src/common.ts
@@ -635,6 +635,6 @@ export enum FilterLibraries {
 }
 export enum FilterLibrariesAdmin {
     'All Libraries' = 'all',
-    'Visible' = '&visibility=visible',
-    'Hidden' = '&visibility=hidden'
+    'Visible' = 'visible',
+    'Hidden' = 'hidden'
 }

--- a/provider-middleware/handlers.go
+++ b/provider-middleware/handlers.go
@@ -29,7 +29,6 @@ func (sh *ServiceHandler) initSubscription() error {
 		{"tasks.get_activity", sh.handleAcitivityForCourse},
 		{"tasks.scrape_kiwix", sh.handleScrapeLibraries},
 	}
-
 	for _, sub := range subscriptions {
 		_, err := sh.nats.Subscribe(sub.topic, func(msg *nats.Msg) {
 			go sub.fn(sh.ctx, msg)

--- a/provider-middleware/middleware.go
+++ b/provider-middleware/middleware.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"net/http"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/nats-io/nats.go"
@@ -79,7 +80,7 @@ func (sh *ServiceHandler) initContentProviderService(msg *nats.Msg) (OpenContent
 		log.Printf("Error looking up content provider: %v", err)
 		return nil, fmt.Errorf("failed to find open content provider: %v", err)
 	}
-	if openContentProvider.Name == models.Kiwix {
+	if strings.ToLower(openContentProvider.Name) == strings.ToLower(models.Kiwix) {
 		return NewKiwixService(openContentProvider, &body), nil
 	}
 	return nil, fmt.Errorf("unsupported open content provider type: %s", openContentProvider.Name)

--- a/provider-middleware/middleware.go
+++ b/provider-middleware/middleware.go
@@ -80,7 +80,7 @@ func (sh *ServiceHandler) initContentProviderService(msg *nats.Msg) (OpenContent
 		log.Printf("Error looking up content provider: %v", err)
 		return nil, fmt.Errorf("failed to find open content provider: %v", err)
 	}
-	if strings.ToLower(openContentProvider.Name) == strings.ToLower(models.Kiwix) {
+	if strings.EqualFold(openContentProvider.Name, models.Kiwix) {
 		return NewKiwixService(openContentProvider, &body), nil
 	}
 	return nil, fmt.Errorf("unsupported open content provider type: %s", openContentProvider.Name)


### PR DESCRIPTION
## Description of the change

- adds proxy middleware and handler for forwarding requests to kiwix
- adds ui for library content
- updates the open content ui to display smaller images
- fixes filter on admin open content management that wasn't working properly
- adds pagination onto open content ui

- **Related issues**: Closes #431 

## Screenshot(s)
<img width="1512" alt="Screenshot 2024-10-16 at 12 12 44 PM" src="https://github.com/user-attachments/assets/f8cbc712-10d6-4fb1-b192-90d72ce4b034">
<img width="1512" alt="Screenshot 2024-10-16 at 12 12 59 PM" src="https://github.com/user-attachments/assets/a5176bfc-2332-44af-9422-afe100979166">

## Additional context

We need to make sure the headers are correct in production environment for the proxying.