### PR TITLE
Fixes issue with side navigation not coming back after hidden

### DIFF
--- a/frontend/src/Components/PageNav.tsx
+++ b/frontend/src/Components/PageNav.tsx
@@ -46,9 +46,7 @@ export default function PageNav({
                     {showOpenMenu ? (
                         <li>
                             <ULIComponent
-                                onClick={() => {
-                                    onShowNav;
-                                }}
+                                onClick={onShowNav}
                                 icon={Bars3Icon}
                                 iconClassName={'cursor-pointer'}
                             />
@@ -56,9 +54,7 @@ export default function PageNav({
                     ) : (
                         <li>
                             <ULIComponent
-                                onClick={() => {
-                                    onShowNav;
-                                }}
+                                onClick={onShowNav}
                                 icon={Bars3Icon}
                                 iconClassName={'lg:hidden cursor-pointer'}
                             />


### PR DESCRIPTION
## Description of the change

This change fixes #447. A user could hide the side navigation but once it was hidden, they couldn't click the hamburger bar icon to bring it back. 


