### PR TITLE
feat: add facility context switch and ui

### DIFF
--- a/backend/src/handlers/auth.go
+++ b/backend/src/handlers/auth.go
@@ -213,11 +213,15 @@ func (srv *Server) validateOrySession(r *http.Request) (*Claims, bool, error) {
 				if !ok {
 					passReset = true
 				}
+				var facilityName string
+				if err := srv.Db.Model(&models.Facility{}).Select("name").Where("id = ?", facilityId).Find(&facilityName).Error; err != nil {
+					return nil, hasCookie, err
+				}
 				claims := &Claims{
 					Username:      user.Username,
 					UserID:        user.ID,
 					FacilityID:    uint(facilityId),
-					FacilityName:  user.Facility.Name,
+					FacilityName:  facilityName,
 					PasswordReset: passReset,
 					KratosID:      kratosID,
 					Role:          user.Role,

--- a/frontend/src/Components/Navbar.tsx
+++ b/frontend/src/Components/Navbar.tsx
@@ -10,11 +10,16 @@ import {
     HomeIcon,
     RectangleStackIcon,
     TrophyIcon,
-    UsersIcon
+    UsersIcon,
+    ArrowRightEndOnRectangleIcon,
+    SunIcon,
+    MoonIcon,
+    UserCircleIcon
 } from '@heroicons/react/24/solid';
-import { useAuth } from '@/useAuth';
+import { useAuth, handleLogout } from '@/useAuth';
 import ULIComponent from './ULIComponent';
 import { Link } from 'react-router-dom';
+import ThemeToggle from './ThemeToggle';
 
 export default function Navbar({
     isPinned,
@@ -23,9 +28,10 @@ export default function Navbar({
     isPinned: boolean;
     onTogglePin: () => void;
 }) {
-    const user = useAuth();
+    const { user } = useAuth();
+
     return (
-        <div className="w-60 min-w-[240px] h-screen flex flex-col justify-start bg-background group">
+        <div className="w-60 min-w-[240px] flex flex-col bg-background group h-screen">
             <div className="hidden lg:flex self-end py-6 mr-4">
                 {isPinned ? (
                     <div
@@ -54,79 +60,129 @@ export default function Navbar({
                 <Brand />
             </Link>
 
-            <ul className="menu">
-                {user.user?.role == UserRole.Admin ? (
-                    <>
-                        {/* admin view */}
-                        <li className="mt-16">
-                            <Link to="/admin-dashboard">
-                                <ULIComponent icon={HomeIcon} /> Dashboard
-                            </Link>
-                        </li>
-                        <li>
-                            <Link to="/student-management">
-                                <ULIComponent icon={AcademicCapIcon} />
-                                Students
-                            </Link>
-                        </li>
-                        <li>
-                            <Link to="/admin-management">
-                                <ULIComponent icon={UsersIcon} />
-                                Admins
-                            </Link>
-                        </li>
-                        <li>
-                            <Link to="/open-content-management">
-                                <ULIComponent icon={BookOpenIcon} />
-                                Open Content
-                            </Link>
-                        </li>
-                        <li>
-                            <Link to="/resources-management">
-                                <ULIComponent icon={ArchiveBoxIcon} />
-                                Resources
-                            </Link>
-                        </li>
-                        <li>
-                            <Link to="/provider-platform-management">
-                                <ULIComponent icon={RectangleStackIcon} />
-                                Platforms
-                            </Link>
-                        </li>
-                    </>
-                ) : (
-                    <>
-                        {/* student view */}
-                        <li className="mt-16">
-                            <Link to="/student-dashboard">
-                                <ULIComponent icon={HomeIcon} /> Dashboard
-                            </Link>
-                        </li>
-                        <li className="">
-                            <Link to="/my-courses">
-                                <ULIComponent icon={BookOpenIcon} /> My Courses
-                            </Link>
-                        </li>
-                        <li className="">
-                            <Link to="/my-progress">
-                                <ULIComponent icon={TrophyIcon} /> My Progress
-                            </Link>
-                        </li>
-                        <li>
-                            <Link to="/open-content">
-                                <ULIComponent icon={BookOpenIcon} />
-                                Open Content
-                            </Link>
-                        </li>
-                        <li className="">
-                            <Link to="/course-catalog">
-                                <ULIComponent icon={BuildingStorefrontIcon} />
-                                Course Catalog
-                            </Link>
-                        </li>
-                    </>
-                )}
-            </ul>
+            <div className="h-full">
+                <ul className="menu h-full flex flex-col justify-between">
+                    <div>
+                        {user?.role == UserRole.Admin ? (
+                            <>
+                                {/* admin view */}
+                                <li className="mt-16">
+                                    <Link to="/admin-dashboard">
+                                        <ULIComponent icon={HomeIcon} />
+                                        Dashboard
+                                    </Link>
+                                </li>
+                                <li>
+                                    <Link to="/student-management">
+                                        <ULIComponent icon={AcademicCapIcon} />
+                                        Students
+                                    </Link>
+                                </li>
+                                <li>
+                                    <Link to="/admin-management">
+                                        <ULIComponent icon={UsersIcon} />
+                                        Admins
+                                    </Link>
+                                </li>
+                                <li>
+                                    <Link to="/open-content-management">
+                                        <ULIComponent icon={BookOpenIcon} />
+                                        Open Content
+                                    </Link>
+                                </li>
+                                <li>
+                                    <Link to="/resources-management">
+                                        <ULIComponent icon={ArchiveBoxIcon} />
+                                        Resources
+                                    </Link>
+                                </li>
+                                <li>
+                                    <Link to="/provider-platform-management">
+                                        <ULIComponent
+                                            icon={RectangleStackIcon}
+                                        />
+                                        Platforms
+                                    </Link>
+                                </li>
+                            </>
+                        ) : (
+                            <>
+                                {/* student view */}
+                                <li className="mt-16">
+                                    <Link to="/student-dashboard">
+                                        <ULIComponent icon={HomeIcon} />
+                                        Dashboard
+                                    </Link>
+                                </li>
+                                <li>
+                                    <Link to="/my-courses">
+                                        <ULIComponent icon={BookOpenIcon} /> My
+                                        Courses
+                                    </Link>
+                                </li>
+                                <li>
+                                    <Link to="/my-progress">
+                                        <ULIComponent icon={TrophyIcon} /> My
+                                        Progress
+                                    </Link>
+                                </li>
+                                <li>
+                                    <Link to="/open-content">
+                                        <ULIComponent icon={BookOpenIcon} />
+                                        Open Content
+                                    </Link>
+                                </li>
+                                <li>
+                                    <Link to="/course-catalog">
+                                        <ULIComponent
+                                            icon={BuildingStorefrontIcon}
+                                        />
+                                        Course Catalog
+                                    </Link>
+                                </li>
+                            </>
+                        )}
+                    </div>
+                    <li className="dropdown dropdown-right dropdown-end w-full">
+                        <div tabIndex={0} role="button">
+                            <ULIComponent
+                                icon={UserCircleIcon}
+                                iconClassName={'w-5 h-5'}
+                            />
+                            {user?.name_first} {user?.name_last}
+                        </div>
+                        <ul
+                            tabIndex={0}
+                            className="dropdown-content menu bg-grey-2 dark:bg-grey-1 rounded-box z-50 w-52 p-2 shadow"
+                        >
+                            <li className="self-center">
+                                <label className="flex cursor-pointer gap-2">
+                                    <ULIComponent
+                                        icon={SunIcon}
+                                        iconClassName={'w-6 h-6'}
+                                    />
+                                    <ThemeToggle />
+                                    <ULIComponent
+                                        icon={MoonIcon}
+                                        iconClassName={'w-6 h-6'}
+                                    />
+                                </label>
+                            </li>
+                            <div className="divider mt-0 mb-0"></div>
+                            <li className="self-center">
+                                <button
+                                    onClick={() => {
+                                        void handleLogout();
+                                    }}
+                                >
+                                    <ArrowRightEndOnRectangleIcon className="h-4" />
+                                    Logout
+                                </button>
+                            </li>
+                        </ul>
+                    </li>
+                </ul>
+            </div>
         </div>
     );
 }

--- a/frontend/src/Components/PageNav.tsx
+++ b/frontend/src/Components/PageNav.tsx
@@ -1,16 +1,15 @@
 import { useEffect, useRef, useState } from 'react';
-import { handleLogout, useAuth } from '@/useAuth';
+import { useAuth } from '@/useAuth';
 import {
-    ArrowRightEndOnRectangleIcon,
     Bars3Icon,
+    BuildingOffice2Icon,
     HomeIcon
 } from '@heroicons/react/24/solid';
-
-import { SunIcon, MoonIcon } from '@heroicons/react/24/outline';
-
-import ThemeToggle from './ThemeToggle';
 import ULIComponent from '@/Components/ULIComponent.tsx';
 import { usePathValue } from '@/PathValueCtx';
+import { Facility, UserRole } from '@/common';
+import { useLoaderData } from 'react-router-dom';
+import API from '@/api/api';
 
 export default function PageNav({
     path,
@@ -25,6 +24,7 @@ export default function PageNav({
     const detailsRef = useRef<HTMLDetailsElement>(null);
     const { pathVal } = usePathValue();
     const [customPath, setCustomPath] = useState<string[]>(path ?? []);
+    const facilityNames = useLoaderData() as Facility[] | null;
 
     useEffect(() => {
         const handlePathChange = () => {
@@ -59,6 +59,13 @@ export default function PageNav({
             window.removeEventListener('click', closeDropdown);
         };
     }, []);
+
+    const handleSwitchFacility = async (facility: Facility) => {
+        const resp = await API.put(`admin/facility-context/${facility.id}`, {});
+        if (resp.success) {
+            window.location.reload();
+        }
+    };
 
     return (
         <div className="px-8 flex justify-between items-center">
@@ -97,46 +104,42 @@ export default function PageNav({
                     ))}
                 </ul>
             </div>
-            <ul className="menu menu-horizontal px-1">
-                <li>
-                    <details className="dropdown dropdown-end" ref={detailsRef}>
-                        <summary>
-                            {user && (
+            {user?.role == UserRole.Admin ? (
+                <ul className="menu menu-horizontal px-1">
+                    <li>
+                        <details
+                            className="dropdown dropdown-end"
+                            ref={detailsRef}
+                        >
+                            <summary>
+                                <ULIComponent icon={BuildingOffice2Icon} />
                                 <span className="font-semibold">
-                                    {user.name_first} {user.name_last}
+                                    {user.facility_name}
                                 </span>
-                            )}
-                        </summary>
-                        <ul className="dropdown-content bg-grey-2 z-[1] dark:bg-grey-1">
-                            <li>
-                                <label className="flex cursor-pointer gap-2">
-                                    <ULIComponent
-                                        icon={SunIcon}
-                                        iconClassName={'w-6 h-6'}
-                                    />
-                                    <ThemeToggle />
-                                    <ULIComponent
-                                        icon={MoonIcon}
-                                        iconClassName={'w-6 h-6'}
-                                    />
-                                </label>
-                            </li>
-                            <div className="divider mt-0 mb-0"></div>
-
-                            <li>
-                                <button
-                                    onClick={() => {
-                                        void handleLogout();
-                                    }}
-                                >
-                                    <ArrowRightEndOnRectangleIcon className="h-4" />
-                                    Logout
-                                </button>
-                            </li>
-                        </ul>
-                    </details>
-                </li>
-            </ul>
+                            </summary>
+                            <ul className="dropdown-content w-max bg-grey-2 z-[1] dark:bg-grey-1 flex flex-col">
+                                {facilityNames?.map((facility: Facility) => (
+                                    <li
+                                        key={facility.id}
+                                        onClick={() => {
+                                            void handleSwitchFacility(facility);
+                                        }}
+                                    >
+                                        <label>{facility.name}</label>
+                                    </li>
+                                ))}
+                            </ul>
+                        </details>
+                    </li>
+                </ul>
+            ) : (
+                <div className="flex flex-row items-center gap-2 px-6 py-4">
+                    <ULIComponent icon={BuildingOffice2Icon} />
+                    <label className="font-semibold">
+                        {user?.facility_name}
+                    </label>
+                </div>
+            )}
         </div>
     );
 }

--- a/frontend/src/Layouts/AuthenticatedLayout.tsx
+++ b/frontend/src/Layouts/AuthenticatedLayout.tsx
@@ -62,7 +62,7 @@ export default function AuthenticatedLayout() {
                     checked={isNavOpen && !isNavPinned}
                     onChange={() => setIsNavOpen(!isNavOpen)}
                 />
-                <div className="drawer-side">
+                <div className="!overflow-visible drawer-side">
                     <label
                         htmlFor="nav-drawer"
                         className="drawer-overlay"

--- a/frontend/src/Pages/AdminDashboard.tsx
+++ b/frontend/src/Pages/AdminDashboard.tsx
@@ -11,10 +11,9 @@ import {
 } from '@/common';
 import useSWR from 'swr';
 import convertSeconds from '@/Components/ConvertSeconds';
-import { useContext, useEffect } from 'react';
+import { useContext } from 'react';
 import { ThemeContext } from '@/Components/ThemeContext';
 import { AxiosError } from 'axios';
-import { usePathValue } from '@/PathValueCtx';
 import UnauthorizedNotFound from './Unauthorized';
 
 export default function AdminDashboard() {
@@ -24,12 +23,7 @@ export default function AdminDashboard() {
         AxiosError
     >(`/api/users/${user?.id}/admin-dashboard`);
     const { theme } = useContext(ThemeContext);
-    const { setPathVal } = usePathValue();
-    useEffect(() => {
-        setPathVal([
-            { path_id: ':facility_name', value: user?.facility_name ?? '' }
-        ]);
-    }, [user]);
+
     if (error || isLoading) return <div></div>;
     if (user?.role !== UserRole.Admin) {
         return <UnauthorizedNotFound which="unauthorized" />;
@@ -39,7 +33,7 @@ export default function AdminDashboard() {
     const totalActivity = convertSeconds(activityData.total_weekly_activity);
     return (
         <div className="px-8 py-4">
-            <h1 className="text-5xl">{activityData.facility_name}</h1>
+            <h1 className="text-5xl">{user.facility_name}</h1>
             <div className="flex flex-row mt-12 gap-12">
                 <div className="flex flex-col gap-6 w-2/3">
                     <div className="card h-[240px]">

--- a/frontend/src/Pages/StudentManagement.tsx
+++ b/frontend/src/Pages/StudentManagement.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from 'react';
+import { useRef, useState } from 'react';
 import useSWR from 'swr';
 
 import {
@@ -30,8 +30,6 @@ import Pagination from '@/Components/Pagination';
 import API from '@/api/api';
 import ULIComponent from '@/Components/ULIComponent.tsx';
 import { AxiosError } from 'axios';
-import { usePathValue } from '@/PathValueCtx';
-import { useAuth } from '@/useAuth';
 
 export default function StudentManagement() {
     const addUserModal = useRef<HTMLDialogElement>(null);
@@ -43,8 +41,6 @@ export default function StudentManagement() {
     const [tempPassword, setTempPassword] = useState<string>('');
     const showUserPassword = useRef<HTMLDialogElement>(null);
     const [toast, setToast] = useState(defaultToast);
-    const { setPathVal } = usePathValue();
-    const { user } = useAuth();
     const [searchTerm, setSearchTerm] = useState('');
     const searchQuery = useDebounceValue(searchTerm, 300);
     const [pageQuery, setPageQuery] = useState(1);
@@ -67,11 +63,6 @@ export default function StudentManagement() {
             setTargetUser(undefined);
         }, 200);
     }
-    useEffect(() => {
-        setPathVal([
-            { path_id: ':facility_name', value: user?.facility_name ?? '' }
-        ]);
-    }, [user?.facility_name]);
     const deleteUser = async () => {
         if (targetUser?.id === DEFAULT_ADMIN_ID) {
             toaster(

--- a/frontend/src/app.tsx
+++ b/frontend/src/app.tsx
@@ -32,7 +32,7 @@ import AuthenticatedLayout from './Layouts/AuthenticatedLayout.tsx';
 import { PathValueProvider } from '@/PathValueCtx';
 import AdminDashboard from './Pages/AdminDashboard.tsx';
 import StudentDashboard from './Pages/StudentDashboard.tsx';
-import { getOpenContentProviders } from './routeLoaders.ts';
+import { getOpenContentProviders, getFacilities } from './routeLoaders.ts';
 
 const WithAuth: React.FC = () => {
     return (
@@ -156,6 +156,7 @@ const router = createBrowserRouter([
         children: [
             {
                 element: <AuthenticatedLayout />,
+                loader: getFacilities,
                 children: [
                     {
                         path: 'admin-dashboard',
@@ -163,7 +164,7 @@ const router = createBrowserRouter([
                         errorElement: <Error />,
                         handle: {
                             title: 'Admin Dashboard',
-                            path: ['admin-dashboard', ':facility_name']
+                            path: ['admin-dashboard']
                         }
                     },
                     {
@@ -172,7 +173,7 @@ const router = createBrowserRouter([
                         errorElement: <Error />,
                         handle: {
                             title: 'Student Management',
-                            path: ['student-management', ':facility_name']
+                            path: ['student-management']
                         }
                     },
                     {

--- a/frontend/src/routeLoaders.ts
+++ b/frontend/src/routeLoaders.ts
@@ -1,5 +1,10 @@
 import { json, LoaderFunction } from 'react-router-dom';
-import { OpenContentProvider, ServerResponseMany } from './common';
+import {
+    Facility,
+    OpenContentProvider,
+    ServerResponse,
+    ServerResponseMany
+} from './common';
 import API from './api/api';
 
 export const getOpenContentProviders: LoaderFunction = async () => {
@@ -10,4 +15,13 @@ export const getOpenContentProviders: LoaderFunction = async () => {
         return json<OpenContentProvider[]>(resp.data);
     }
     return json<OpenContentProvider[]>([]);
+};
+
+export const getFacilities: LoaderFunction = async () => {
+    const response: ServerResponse<Facility[]> =
+        await API.get<Facility[]>(`facilities`);
+    if (response.success) {
+        return json<Facility[]>(response.data as Facility[]);
+    }
+    return json<null>(null);
 };


### PR DESCRIPTION
## Description of the change
This adds facility context switching on the admin side. It also updates both the admin and student portal to display the current facility in the PageNav component, and moves the dropdown that contains logout and theme toggle to the Navbar component. Also updates the routes to not pass in the facility name in the path as it's not needed anymore. Adds loader to the admin Authentication Layout route to render facilities.

- **Related issues**: Closes #425 

## Screenshot(s)

https://github.com/user-attachments/assets/6b315b58-205a-4a68-b0ac-9e7106b4fae7

## Additional Notes
I want to make sure the UI aligns with what @chrissantillan was looking for.