### PR TITLE
fix: update condition to check for active link deletion for the first index

### DIFF
--- a/frontend/src/Pages/ResourcesManagement.tsx
+++ b/frontend/src/Pages/ResourcesManagement.tsx
@@ -683,7 +683,7 @@ const ResourceCollectionEditor = ({
                         item="Link"
                         onCancel={() => setActiveLinkToDelete(undefined)}
                         onSuccess={() =>
-                            activeLinkToDelete &&
+                            activeLinkToDelete != undefined &&
                             deleteLink(collection, activeLinkToDelete)
                         }
                     />


### PR DESCRIPTION
## Description of the change

Updated `activeLinkToDelete` check from a boolean to an explicit undefined check to correctly include the first index.

- **Related issues**: #467 

## Screenshot(s)

https://github.com/user-attachments/assets/2406a467-80a2-4787-a6ad-67adbb0df866



## Additional context

The issue in `ResourcesManagement.tsx` is that `activeLinkToDelete` is set to 0 when attempting to delete the first link in a collection. Since 0 is treated as a falsy value in JavaScript, the condition `activeLinkToDelete && deleteLink(collection, activeLinkToDelete)` fails, preventing the deletion of the first link. In this case, replacing the condition with an explicit check for `undefined` (to align with the author's intent) would resolve the issue and allow deletion of the first link.