### PR TITLE
feat: add Programs page and 'tags' to seed data

### DIFF
--- a/backend/seeder/main.go
+++ b/backend/seeder/main.go
@@ -286,6 +286,7 @@ func seedTestData(db *gorm.DB) {
 func createFacilityPrograms(db *gorm.DB) ([]models.ProgramSection, error) {
 	facilities := []models.Facility{}
 	randNames := []string{"Anger Management", "Substance Abuse Treatment", "AA/NA", "Thinking for a Change", "A New Freedom", "Dog Training", "A New Path", "GED/Hi-SET", "Parenting", "Employment", "Life Skills", "Health and Wellness", "Financial Literacy", "Computer Skills", "Parenting", "Employment", "Life Skills"}
+	randTags := []string{"Rehabilitation", "Life-Skills", "12-step", "Required", "Recovery", "DV-Requirement", "10-Weeks", "Addiction"}
 	if err := db.Find(&facilities).Error; err != nil {
 		return nil, err
 	}
@@ -312,6 +313,16 @@ func createFacilityPrograms(db *gorm.DB) ([]models.ProgramSection, error) {
 		for i := range prog {
 			if err := db.Create(&prog[i]).Error; err != nil {
 				log.Fatalf("Failed to create program: %v", err)
+			}
+			numTags := rand.Intn(3) + 1
+			for j := 0; j < numTags; j++ {
+				tag := models.ProgramTag{
+					ProgramID: prog[i].ID,
+					Value:     randTags[rand.Intn(len(randTags))],
+				}
+				if err := db.Create(&tag).Error; err != nil {
+					log.Fatalf("Failed to create tag: %v", err)
+				}
 			}
 			section := models.ProgramSection{
 				FacilityID: facilities[idx].ID,

--- a/backend/src/handlers/programs_handler.go
+++ b/backend/src/handlers/programs_handler.go
@@ -9,7 +9,7 @@ import (
 )
 
 func (srv *Server) registerProgramsRoutes() {
-	srv.Mux.Handle("GET /api/programs", srv.applyAdminMiddleware(srv.handleIndexPrograms))
+	srv.Mux.Handle("GET /api/programs", srv.applyMiddleware(srv.handleIndexPrograms))
 	srv.Mux.Handle("GET /api/programs/{id}", srv.applyMiddleware(srv.handleShowProgram))
 	srv.Mux.Handle("POST /api/programs", srv.applyAdminMiddleware(srv.handleCreateProgram))
 	srv.Mux.Handle("DELETE /api/programs/{id}", srv.applyAdminMiddleware(srv.handleDeleteProgram))

--- a/frontend/src/Components/Navbar.tsx
+++ b/frontend/src/Components/Navbar.tsx
@@ -11,17 +11,11 @@ import {
     RectangleStackIcon,
     TrophyIcon,
     UsersIcon,
-    ArrowRightEndOnRectangleIcon,
-    SunIcon,
-    MoonIcon,
-    UserCircleIcon,
-    BuildingOffice2Icon
+    DocumentTextIcon
 } from '@heroicons/react/24/solid';
-import { useAuth, handleLogout } from '@/useAuth';
+import { useAuth } from '@/useAuth';
 import ULIComponent from './ULIComponent';
 import { Link } from 'react-router-dom';
-import ThemeToggle from './ThemeToggle';
-
 export default function Navbar({
     isPinned,
     onTogglePin
@@ -60,138 +54,97 @@ export default function Navbar({
             <Link to="/" className="mt-16">
                 <Brand />
             </Link>
-
-            <div className="h-full">
-                <ul className="menu h-full flex flex-col justify-between">
-                    <div>
-                        {user?.role == UserRole.Admin ? (
-                            <>
-                                {/* admin view */}
-                                <li className="mt-16">
-                                    <Link to="/admin-dashboard">
-                                        <ULIComponent icon={HomeIcon} />
-                                        Dashboard
-                                    </Link>
-                                </li>
-                                <li>
-                                    <Link to="/student-management">
-                                        <ULIComponent icon={AcademicCapIcon} />
-                                        Students
-                                    </Link>
-                                </li>
-                                <li>
-                                    <Link to="/admin-management">
-                                        <ULIComponent icon={UsersIcon} />
-                                        Admins
-                                    </Link>
-                                </li>
-                                <li>
-                                    <Link to="/open-content-management">
-                                        <ULIComponent icon={BookOpenIcon} />
-                                        Open Content
-                                    </Link>
-                                </li>
-                                <li>
-                                    <Link to="/resources-management">
-                                        <ULIComponent icon={ArchiveBoxIcon} />
-                                        Resources
-                                    </Link>
-                                </li>
-                                <li>
-                                    <Link to="/provider-platform-management">
-                                        <ULIComponent
-                                            icon={RectangleStackIcon}
-                                        />
-                                        Platforms
-                                    </Link>
-                                </li>
-                                <li>
-                                    <Link to="/facilities-management">
-                                        <ULIComponent
-                                            icon={BuildingOffice2Icon}
-                                        />
-                                        Facilities
-                                    </Link>
-                                </li>
-                            </>
-                        ) : (
-                            <>
-                                {/* student view */}
-                                <li className="mt-16">
-                                    <Link to="/student-dashboard">
-                                        <ULIComponent icon={HomeIcon} />
-                                        Dashboard
-                                    </Link>
-                                </li>
-                                <li>
-                                    <Link to="/my-courses">
-                                        <ULIComponent icon={BookOpenIcon} /> My
-                                        Courses
-                                    </Link>
-                                </li>
-                                <li>
-                                    <Link to="/my-progress">
-                                        <ULIComponent icon={TrophyIcon} /> My
-                                        Progress
-                                    </Link>
-                                </li>
-                                <li>
-                                    <Link to="/open-content">
-                                        <ULIComponent icon={BookOpenIcon} />
-                                        Open Content
-                                    </Link>
-                                </li>
-                                <li>
-                                    <Link to="/course-catalog">
-                                        <ULIComponent
-                                            icon={BuildingStorefrontIcon}
-                                        />
-                                        Course Catalog
-                                    </Link>
-                                </li>
-                            </>
-                        )}
-                    </div>
-                    <li className="dropdown dropdown-right dropdown-end w-full">
-                        <div tabIndex={0} role="button">
-                            <ULIComponent
-                                icon={UserCircleIcon}
-                                iconClassName={'w-5 h-5'}
-                            />
-                            {user?.name_first} {user?.name_last}
-                        </div>
-                        <ul
-                            tabIndex={0}
-                            className="dropdown-content menu bg-grey-2 dark:bg-grey-1 rounded-box z-50 w-52 p-2 shadow"
-                        >
-                            <li className="self-center">
-                                <label className="flex cursor-pointer gap-2">
-                                    <ULIComponent
-                                        icon={SunIcon}
-                                        iconClassName={'w-6 h-6'}
-                                    />
-                                    <ThemeToggle />
-                                    <ULIComponent
-                                        icon={MoonIcon}
-                                        iconClassName={'w-6 h-6'}
-                                    />
-                                </label>
-                            </li>
-                            <div className="divider mt-0 mb-0"></div>
-                            <li className="self-center">
-                                <button
-                                    onClick={() => {
-                                        void handleLogout();
-                                    }}
-                                >
-                                    <ArrowRightEndOnRectangleIcon className="h-4" />
-                                    Logout
-                                </button>
-                            </li>
-                        </ul>
-                    </li>
-                </ul>
-            </div>
+            <ul className="menu">
+                {user && user.role == UserRole.Admin ? (
+                    <>
+                        {/* admin view */}
+                        <li className="mt-16">
+                            <Link to="/admin-dashboard">
+                                <ULIComponent icon={HomeIcon} /> Dashboard
+                            </Link>
+                        </li>
+                        <li>
+                            <Link to="/student-management">
+                                <ULIComponent icon={AcademicCapIcon} />
+                                Students
+                            </Link>
+                        </li>
+                        <li>
+                            <Link to="/admin-management">
+                                <ULIComponent icon={UsersIcon} />
+                                Admins
+                            </Link>
+                        </li>
+                        <li>
+                            <Link to="/open-content-management">
+                                <ULIComponent icon={BookOpenIcon} />
+                                Open Content
+                            </Link>
+                        </li>
+                        <li>
+                            <Link to="/resources-management">
+                                <ULIComponent icon={ArchiveBoxIcon} />
+                                Resources
+                            </Link>
+                        </li>
+                        <li>
+                            <Link to="/provider-platform-management">
+                                <ULIComponent icon={RectangleStackIcon} />
+                                Platforms
+                            </Link>
+                        </li>
+                        <li className="">
+                            <Link to="/course-catalog-admin">
+                                <ULIComponent icon={BuildingStorefrontIcon} />
+                                Course Catalog
+                            </Link>
+                        </li>
+                        <li className="">
+                            <Link to="/programs">
+                                <ULIComponent icon={DocumentTextIcon} />
+                                Programs
+                            </Link>
+                        </li>
+                    </>
+                ) : (
+                    <>
+                        {/* student view */}
+                        <li className="mt-16">
+                            <Link to="/student-dashboard">
+                                <ULIComponent icon={HomeIcon} /> Dashboard
+                            </Link>
+                        </li>
+                        <li className="">
+                            <Link to="/my-courses">
+                                <ULIComponent icon={BookOpenIcon} /> My Courses
+                            </Link>
+                        </li>
+                        <li className="">
+                            <Link to="/my-progress">
+                                <ULIComponent icon={TrophyIcon} /> My Progress
+                            </Link>
+                        </li>
+                        <li>
+                            <Link to="/open-content">
+                                <ULIComponent icon={BookOpenIcon} />
+                                Open Content
+                            </Link>
+                        </li>
+                        <li className="">
+                            <Link to="/course-catalog">
+                                <ULIComponent icon={BuildingStorefrontIcon} />
+                                Course Catalog
+                            </Link>
+                        </li>
+                        <li className="">
+                            <Link to="/programs">
+                                <ULIComponent icon={DocumentTextIcon} />
+                                Programs
+                            </Link>
+                        </li>
+                    </>
+                )}
+            </ul>
         </div>
     );
 }

--- a/frontend/src/Components/ProgramCard.tsx
+++ b/frontend/src/Components/ProgramCard.tsx
@@ -25,16 +25,13 @@ export default function ProgramCard({
             });
     }
 
-    let bookmark: JSX.Element;
-    if (program.is_favorited) {
-        bookmark = <BookmarkIcon className="h-5 text-primary-yellow" />;
-    } else {
-        bookmark = (
-            <BookmarkIconOutline
-                className={`h-5 ${view === ViewType.List ? 'text-header-text' : 'text-white'}`}
-            />
-        );
-    }
+    const bookmark: JSX.Element = program.is_favorited ? (
+        <BookmarkIcon className="h-5 text-primary-yellow" />
+    ) : (
+        <BookmarkIconOutline
+            className={`h-5 ${view === ViewType.List ? 'text-header-text' : 'text-white'}`}
+        />
+    );
 
     const tagPills = program.tags.map((tag) => (
         <LightGreenPill key={tag.id}>{tag.value.toString()}</LightGreenPill>
@@ -45,7 +42,7 @@ export default function ProgramCard({
             <a
                 className="card bg-base-teal body-small p-6 flex flex-row items-center"
                 href="#"
-                onClick={(e) => e.preventDefault()} // No link available yet
+                onClick={(e) => e.preventDefault()}
             >
                 <div className="flex flex-col justify-between gap-3">
                     <div className="flex flex-row gap-3 items-center">

--- a/frontend/src/Components/ProgramCard.tsx
+++ b/frontend/src/Components/ProgramCard.tsx
@@ -1,0 +1,84 @@
+import { BookmarkIcon } from '@heroicons/react/24/solid';
+import { BookmarkIcon as BookmarkIconOutline } from '@heroicons/react/24/outline';
+import LightGreenPill from './pill-labels/LightGreenPill';
+import { MouseEvent } from 'react';
+import { Program, ViewType } from '@/common';
+import API from '@/api/api';
+
+export default function ProgramCard({
+    program,
+    callMutate,
+    view
+}: {
+    program: Program;
+    callMutate: () => void;
+    view?: ViewType;
+}) {
+    function updateFavorite(e: MouseEvent) {
+        e.preventDefault();
+        API.put(`programs/${program.id}/save`, {})
+            .then(() => {
+                callMutate();
+            })
+            .catch((error) => {
+                console.log(error);
+            });
+    }
+
+    let bookmark: JSX.Element;
+    if (program.is_favorited) {
+        bookmark = <BookmarkIcon className="h-5 text-primary-yellow" />;
+    } else {
+        bookmark = (
+            <BookmarkIconOutline
+                className={`h-5 ${view === ViewType.List ? 'text-header-text' : 'text-white'}`}
+            />
+        );
+    }
+
+    const tagPills = program.tags.map((tag) => (
+        <LightGreenPill key={tag.id}>{tag.value.toString()}</LightGreenPill>
+    ));
+
+    if (view === ViewType.List) {
+        return (
+            <a
+                className="card bg-base-teal body-small p-6 flex flex-row items-center"
+                href="#"
+                onClick={(e) => e.preventDefault()} // No link available yet
+            >
+                <div className="flex flex-col justify-between gap-3">
+                    <div className="flex flex-row gap-3 items-center">
+                        <div onClick={(e) => updateFavorite(e)}>{bookmark}</div>
+                        <h2>{program.name}</h2>
+                        <p className="body">|</p>
+                        <div className="flex flex-wrap gap-2">{tagPills}</div>
+                    </div>
+                    <p className="body-small h-[1rem] line-clamp-2 overflow-hidden">
+                        {program.description}
+                    </p>
+                </div>
+            </a>
+        );
+    } else {
+        return (
+            <div className="card card-compact bg-base-teal overflow-hidden relative">
+                <div
+                    className="absolute top-2 right-2 cursor-pointer"
+                    onClick={(e) => updateFavorite(e)}
+                >
+                    {bookmark}
+                </div>
+                <div className="card-body gap-0.2">
+                    <h3 className="card-title text-sm">{program.name}</h3>
+                    <p className="body-small line-clamp-2">
+                        {program.description}
+                    </p>
+                    <div className="flex flex-wrap py-1 mt-2 space-y-2 sm:space-y-0 gap-x-1 gap-y-2">
+                        {tagPills}
+                    </div>
+                </div>
+            </div>
+        );
+    }
+}

--- a/frontend/src/Pages/Programs.tsx
+++ b/frontend/src/Pages/Programs.tsx
@@ -1,0 +1,101 @@
+import { useAuth } from '@/useAuth';
+import { useState, useRef } from 'react';
+import ProgramCard from '@/Components/ProgramCard';
+import SearchBar from '@/Components/inputs/SearchBar';
+import { Program, ServerResponse, ViewType, UserRole } from '@/common';
+import useSWR from 'swr';
+import DropdownControl from '@/Components/inputs/DropdownControl';
+import { AxiosError } from 'axios';
+import { PlusCircleIcon } from '@heroicons/react/24/outline';
+import ToggleView from '@/Components/ToggleView';
+
+export default function Programs() {
+    const { user } = useAuth();
+    const addProgramModal = useRef<HTMLDialogElement>(null);
+
+    if (!user) {
+        return null;
+    }
+
+    const [activeView, setActiveView] = useState<ViewType>(ViewType.Grid);
+    const [searchTerm, setSearchTerm] = useState('');
+    const [order, setOrder] = useState('asc');
+    const { data, error, mutate } = useSWR<ServerResponse<Program>, AxiosError>(
+        `/api/programs?search=${searchTerm}&order=${order}`
+    );
+    const programData = data?.data as Program[];
+
+    function handleSearch(newSearch: string) {
+        setSearchTerm(newSearch);
+    }
+
+    return (
+        <div className="px-8 py-4">
+            <div className="flex flex-row justify-between items-center mb-4">
+                <div className="flex flex-row items-center space-x-4">
+                    <SearchBar
+                        searchTerm={searchTerm}
+                        changeCallback={handleSearch}
+                    />
+                    <DropdownControl
+                        label="order"
+                        setState={setOrder}
+                        enumType={{
+                            Ascending: 'asc',
+                            Descending: 'desc'
+                        }}
+                    />
+                </div>
+                <div className="flex items-center space-x-4">
+                    <ToggleView
+                        activeView={activeView}
+                        setActiveView={setActiveView}
+                    />
+                    {user.role === UserRole.Admin && (
+                        <button
+                            className="button flex items-center space-x-2"
+                            onClick={() => {
+                                addProgramModal.current?.showModal();
+                            }}
+                        >
+                            <PlusCircleIcon className="w-4 my-auto" />
+                            <span>Add Program</span>
+                        </button>
+                    )}
+                </div>
+            </div>
+            <div
+                className={`mt-8 ${activeView === ViewType.Grid ? 'grid grid-cols-4 gap-6' : 'space-y-4'}`}
+            >
+                {error ? (
+                    <p className="text-error">Error loading programs.</p>
+                ) : programData?.length === 0 ? (
+                    <p className="text-error">No programs to display.</p>
+                ) : (
+                    programData?.map((program: Program) => {
+                        return (
+                            <ProgramCard
+                                program={program}
+                                callMutate={() => void mutate()}
+                                view={activeView}
+                                key={program.id}
+                            />
+                        );
+                    })
+                )}
+            </div>
+
+            <dialog ref={addProgramModal} className="modal">
+                <form method="dialog" className="modal-box">
+                    <h3 className="font-bold text-lg">Add New Program</h3>
+                    <p className="py-4">
+                        This feature will be implemented soon.
+                    </p>
+                    <div className="modal-action">
+                        <button className="btn">Close</button>
+                    </div>
+                </form>
+            </dialog>
+        </div>
+    );
+}

--- a/frontend/src/app.tsx
+++ b/frontend/src/app.tsx
@@ -20,6 +20,7 @@ import StudentManagement from '@/Pages/StudentManagement.tsx';
 import OpenContentManagement from './Pages/OpenContentManagement';
 import OpenContent from './Pages/OpenContent';
 import LibraryViewer from './Pages/LibraryViewer';
+import Programs from './Pages/Programs.tsx';
 import {
     checkDefaultFacility,
     checkExistingFlow,
@@ -147,6 +148,15 @@ const router = createBrowserRouter([
                             title: 'Library Viewer',
                             path: ['viewer', 'libraries', ':library_name']
                         }
+                    },
+                    {
+                        path: 'programs',
+                        element: <Programs />,
+                        errorElement: <Error />,
+                        handle: {
+                            title: 'Programs',
+                            path: ['programs']
+                        }
                     }
                 ]
             },
@@ -233,10 +243,6 @@ const router = createBrowserRouter([
                         }
                     },
                     {
-                        path: '*',
-                        element: <UnauthorizedNotFound which="notFound" />
-                    },
-                    {
                         path: 'facilities-management',
                         element: <FacilityManagement />,
                         handle: {
@@ -244,6 +250,27 @@ const router = createBrowserRouter([
                             path: ['facilities-management']
                         },
                         errorElement: <Error />
+                    },
+                    {
+                        path: 'course-catalog-admin',
+                        element: <CourseCatalog />,
+                        handle: {
+                            title: 'Course Catalog',
+                            path: ['course-catalog']
+                        }
+                    },
+                    {
+                        path: 'programs',
+                        element: <Programs />,
+                        errorElement: <Error />,
+                        handle: {
+                            title: 'Programs',
+                            path: ['programs']
+                        }
+                    },
+                    {
+                        path: '*',
+                        element: <UnauthorizedNotFound which="notFound" />
                     }
                 ]
             }

--- a/frontend/src/common.ts
+++ b/frontend/src/common.ts
@@ -631,6 +631,21 @@ export interface Library {
     open_content_provider: OpenContentProvider;
 }
 
+export interface Program {
+    id: number;
+    created_at: Date;
+    updated_at: Date;
+    name: string;
+    description: string;
+    tags: ProgramTag[];
+    is_favorited: boolean;
+}
+
+export interface ProgramTag {
+    id: string;
+    value: number;
+}
+
 export interface OpenContentProvider {
     id: number;
     name: string;


### PR DESCRIPTION
## Description of the change
Added the Programs page, in the Admin view there is a Add Program button, in the User view the Add Program button is removed. Added Course Catalog view for Admin users to view courses. Added program tags in the seeder functions for Programs. 

- **Related issues**: Related to issue #465, Closes #446. 

## Screenshot(s)
Admin View Grid 
![image](https://github.com/user-attachments/assets/9b38569a-34b5-4a5e-beec-49bb60ddd26c)
Admin View List 
![image](https://github.com/user-attachments/assets/952007a8-d924-4aeb-b03d-b7d9ee9df601)
User View Grid
![image](https://github.com/user-attachments/assets/196a5e42-da6d-4372-b139-f13b3909454a)
User View List 
![image](https://github.com/user-attachments/assets/d5e2eb81-bbfa-4e29-aed0-f6e7247a79ef)


## Additional context
A base implementation of the Programs Page without the ability to explicitly add or edit a program, if Add Program is clicked the user is prompted that the feature will be implemented soon. 