### PR TITLE
Kolibri Logic Enhancement and Fixes

### DIFF
--- a/provider-middleware/kolibri.go
+++ b/provider-middleware/kolibri.go
@@ -124,7 +124,7 @@ func (ks *KolibriService) ImportCourses(db *gorm.DB) error { //add more to this:
 	for _, course := range courses {
 		id := course["id"].(string)
 		if db.Where("provider_platform_id = ? AND external_id = ?", ks.ProviderPlatformID, id).First(&models.Course{}).Error == nil {
-			if course["thumbnail"].(string) == "" {
+			if course["course_type"].(string) == "class" {
 				updateTotalProgress(db, ks.ProviderPlatformID, course)
 			}
 			continue


### PR DESCRIPTION
@PThorpe92 Changed inner join on exams_exam to be left outer joins as exams_exam doesn't exist until teacher activates it. Also, added logic for when a teacher adds more lessons/assignments or quizzes to a class after the class has existed for sometime. Basically logic that monitors the total_progress_milestones for kolibri classes to make sure to account for any additional content added by teachers.