### PR TITLE
feat: add GetUsers, IntoImportUsers in provider-middleware

### DIFF
--- a/provider-middleware/brightspace_data.go
+++ b/provider-middleware/brightspace_data.go
@@ -55,8 +55,15 @@ type BrightspaceEnrollment struct {
 	EnrollmentType string `csv:"EnrollmentType"`
 }
 
-func (srv *BrightspaceService) IntoImportUser(bsUser BrightspaceUser) *models.ImportUser {
-	return nil
+func (kc *BrightspaceService) IntoImportUser(bsUser BrightspaceUser) *models.ImportUser {
+	user := models.ImportUser{
+		Username:       bsUser.UserName,
+		NameFirst:      bsUser.FirstName,
+		NameLast:       bsUser.LastName,
+		Email:          bsUser.ExternalEmail,
+		ExternalUserID: bsUser.UserId,
+	}
+	return &user
 }
 
 func (srv *BrightspaceService) IntoCourse(bsCourse BrightspaceCourse) *models.Course {


### PR DESCRIPTION
## Description of the change
Two methods to import Brightspace users from a CSV file downloaded from the Brightspaces datahub. The GetUsers method downloads the data, imports it into a slice of BrightSpace user models, loops through the slice, serializes the BrightSpace user slice into the UnlockEd ImportUser model type, and then returns a slice of ImportUser. 

- **Related issues**: Part of [#430](https://github.com/UnlockedLabs/UnlockEdv2/issues/430)

## Screenshot(s)

![image](https://github.com/user-attachments/assets/1aed333d-381d-4f62-a13b-9a42bff13b21)



