### PR TITLE
fix: added_frontend_validation

### DIFF
--- a/backend/src/handlers/user_handler.go
+++ b/backend/src/handlers/user_handler.go
@@ -295,7 +295,7 @@ func (srv *Server) handleResetStudentPassword(w http.ResponseWriter, r *http.Req
 }
 
 func validateUser(user *models.User) string {
-	if strings.ContainsFunc(user.Username, func(r rune) bool { return !unicode.IsLetter(r) }) {
+	if strings.ContainsFunc(user.Username, func(r rune) bool { return !unicode.IsLetter(r) && !unicode.IsNumber(r) }) {
 		return "alphanum"
 	} else if strings.ContainsFunc(user.NameFirst, func(r rune) bool { return !unicode.IsLetter(r) && !unicode.IsSpace(r) }) {
 		return "alphanum"

--- a/frontend/src/Components/forms/AddUserForm.tsx
+++ b/frontend/src/Components/forms/AddUserForm.tsx
@@ -3,13 +3,13 @@ import {
     ProviderPlatform,
     ToastState,
     UserRole
-} from '../../common';
+} from '@/common.ts';
 import { useEffect, useState } from 'react';
 import { SubmitHandler, useForm } from 'react-hook-form';
 import { CloseX } from '../inputs/CloseX';
 import { TextInput } from '../inputs/TextInput';
-import { DropdownInput } from '../inputs/DropdownInput';
-import { SubmitButton } from '../inputs/SubmitButton';
+import { DropdownInput } from '@/Components/inputs';
+import { SubmitButton } from '@/Components/inputs';
 import API from '@/api/api';
 
 interface Inputs {
@@ -18,7 +18,6 @@ interface Inputs {
     username: string;
     role: UserRole;
 }
-
 interface Form {
     user: Inputs;
     provider_platforms: number[];
@@ -61,7 +60,7 @@ export default function AddUserForm({
                     setError('username', {
                         type: 'custom',
                         message:
-                            'First/Last and Username must contain letters and numbers only'
+                            'Username must contain only letters and numbers'
                     });
                     break;
                 }
@@ -117,6 +116,11 @@ export default function AddUserForm({
                     length={25}
                     errors={errors}
                     register={register}
+                    pattern={{
+                        value: /^[A-Za-z\s]+$/,
+                        message:
+                            'First name can only contain letters and spaces'
+                    }}
                 />
                 <TextInput
                     label={'Last Name'}
@@ -125,7 +129,13 @@ export default function AddUserForm({
                     length={25}
                     errors={errors}
                     register={register}
+                    pattern={{
+                        value: /^[A-Za-z\s]+$/,
+                        message: 'Last name can only contain letters and spaces'
+                    }}
                 />
+                {/*Proper regEx applied for expected validation*/}
+                {/*Backend error handling throws: "Username must contain only letters and numbers"*/}
                 <TextInput
                     label={'Username'}
                     interfaceRef={'username'}
@@ -133,14 +143,20 @@ export default function AddUserForm({
                     length={50}
                     errors={errors}
                     register={register}
+                    pattern={{
+                        value: /^[A-Za-z0-9]+$/,
+                        message:
+                            'Username can only contain letters and numbers without spaces'
+                    }}
                 />
+
                 <DropdownInput
                     label={'Role'}
                     interfaceRef={'role'}
-                    required
                     errors={errors}
                     register={register}
                     enumType={UserRole}
+                    required={true}
                 />
                 <br />
                 {providers?.map((provider: ProviderPlatform) => (

--- a/frontend/src/Components/inputs/TextInput.tsx
+++ b/frontend/src/Components/inputs/TextInput.tsx
@@ -3,25 +3,29 @@ import { FieldErrors, UseFormRegister } from 'react-hook-form';
 interface TextProps {
     label: string;
     interfaceRef: string;
-    required: boolean;
+    required?: boolean;
     length: number | undefined;
     errors: FieldErrors<any>; // eslint-disable-line
     register: UseFormRegister<any>; // eslint-disable-line
     password?: boolean;
     isFocused?: boolean;
     autoComplete?: string;
+    pattern?: {
+        value: RegExp;
+        message: string;
+    };
 }
-
 export function TextInput({
     label,
     interfaceRef,
-    required,
+    required = false,
     length,
     errors,
     register,
     password = false,
     isFocused = false,
-    autoComplete = 'on'
+    autoComplete = 'on',
+    pattern
 }: TextProps) {
     const options = {
         required: {
@@ -33,7 +37,8 @@ export function TextInput({
                 value: length,
                 message: `${label} should be ${length} characters or less`
             }
-        })
+        }),
+        ...(pattern && { pattern })
     };
     return (
         <label className="form-control">


### PR DESCRIPTION
**Key Changes Implemented to Support Requirements:**

1. **Pattern Prop Addition:**
   - Added a new `pattern` prop to the `TextInput` component to support different validation patterns for different fields.

2. **Validation Pattern Modifications:**
   - **First and Last Names:** `^[A-Za-z\s]+$` – allows only letters and spaces.
   - **Username:** `^[A-Za-z0-9]+$` – allows only letters and numbers (no spaces).

3. **Updated Error Messages:**
   - Replaced the generic error message "First/Last and Username must contain letters and numbers only" with field-specific messages.
   - **Username Error:** Now says "Username can only contain letters and numbers."
   - **Name Fields:** Show "can only contain letters and spaces."

**Benefits of These Changes:**

- **Allow Spaces in Names:** Users can now include spaces in first and last names (e.g., "Sara Beth" or "Smith Jones").
- **Maintain Strict Alphanumeric Validation:** Usernames continue to be strictly alphanumeric.
- **Clearer Error Messages:** Users receive more specific and helpful error messages.
- **Backend Compatibility:** The changes are compatible with the backend validation.
- **Enhanced User Experience:** Frontend validation now catches invalid inputs before they reach the backend, improving the user experience while maintaining security.