### PR TITLE
Track open content library activity #490

### DIFF
--- a/backend/migrations/00021_add_open_content_activity_tables.sql
+++ b/backend/migrations/00021_add_open_content_activity_tables.sql
@@ -1,0 +1,36 @@
+-- +goose Up
+-- +goose StatementBegin
+CREATE TABLE open_content_urls (
+        id SERIAL NOT NULL, 
+        content_url CHARACTER VARYING(255) NOT NULL, 
+        PRIMARY KEY (id)
+);
+
+CREATE TABLE open_content_activities (
+        id SERIAL NOT NULL, 
+        request_ts TIMESTAMP(0) WITHOUT TIME ZONE DEFAULT CURRENT_TIMESTAMP, 
+        open_content_provider_id INTEGER NOT NULL, 
+        facility_id INTEGER NOT NULL,
+        user_id INTEGER NOT NULL, 
+        content_id INTEGER NOT NULL, 
+        open_content_url_id INTEGER NOT NULL, 
+        PRIMARY KEY (id), 
+
+        CONSTRAINT open_content_activities_open_content_provider_id_fkey FOREIGN KEY (open_content_provider_id) REFERENCES "open_content_providers" ("id") ON DELETE CASCADE ON UPDATE CASCADE, 
+        CONSTRAINT open_content_activities_facility_id_fkey FOREIGN KEY (facility_id) REFERENCES "facilities" ("id") ON DELETE CASCADE ON UPDATE CASCADE,
+        CONSTRAINT open_content_activities_user_id_fkey FOREIGN KEY (user_id) REFERENCES "users" ("id") ON DELETE CASCADE ON UPDATE CASCADE, 
+        CONSTRAINT open_content_activities_open_content_url_id_fkey FOREIGN KEY (open_content_url_id) REFERENCES "open_content_urls" ("id") ON DELETE CASCADE ON UPDATE CASCADE, 
+        CONSTRAINT unique_user_facility_library_url_timestamp UNIQUE (user_id, facility_id, content_id, open_content_url_id, request_ts)
+);
+
+CREATE INDEX idx_open_content_activities_user_id ON public.open_content_activities USING btree (user_id);
+CREATE INDEX idx_open_content_activities_open_content_url_id ON public.open_content_activities USING btree (open_content_url_id);
+CREATE INDEX idx_open_content_activities_user_id_content_id_facility_id ON public.open_content_activities USING btree (user_id, content_id, facility_id);
+CREATE INDEX idx_open_content_activities_content_id_open_content_provider_id_facility_id ON public.open_content_activities USING btree (content_id, open_content_provider_id, facility_id);
+-- +goose StatementEnd
+
+-- +goose Down
+-- +goose StatementBegin
+DROP TABLE open_content_activities;
+DROP TABLE open_content_urls;
+-- +goose StatementEnd

--- a/backend/migrations/00021_add_open_content_activity_tables.sql
+++ b/backend/migrations/00021_add_open_content_activity_tables.sql
@@ -31,6 +31,6 @@ CREATE INDEX idx_open_content_activities_content_id_open_content_provider_id_fac
 
 -- +goose Down
 -- +goose StatementBegin
-DROP TABLE open_content_activities;
-DROP TABLE open_content_urls;
+DROP TABLE IF EXISTS open_content_activities CASCADE;
+DROP TABLE IF EXISTS open_content_urls CASCADE;
 -- +goose StatementEnd

--- a/backend/src/database/DB.go
+++ b/backend/src/database/DB.go
@@ -116,6 +116,8 @@ func MigrateTesting(db *gorm.DB) {
 		&models.ProgramFavorite{},
 		&models.Facility{},
 		&models.OpenContentProvider{},
+		&models.OpenContentUrl{},
+		&models.OpenContentActivity{},
 		&models.CronJob{},
 		&models.RunnableTask{},
 		&models.Library{},

--- a/backend/src/database/libraries.go
+++ b/backend/src/database/libraries.go
@@ -46,7 +46,7 @@ func (db *DB) GetLibraryByID(id int) (*models.Library, error) {
 
 func (db *DB) ToggleVisibilityAndRetrieveLibrary(id int) (*models.Library, error) {
 	var library models.Library
-	if err := db.Find(&library, "id = ?", id).Error; err != nil {
+	if err := db.Preload("OpenContentProvider").Find(&library, "id = ?", id).Error; err != nil {
 		log.Errorln("Unable to find library with that ID")
 		return nil, newNotFoundDBError(err, "libraries")
 	}

--- a/backend/src/database/libraries.go
+++ b/backend/src/database/libraries.go
@@ -44,15 +44,15 @@ func (db *DB) GetLibraryByID(id int) (*models.Library, error) {
 	return &library, nil
 }
 
-func (db *DB) ToggleLibraryVisibility(id int) (models.Library, error) {
+func (db *DB) ToggleVisibilityAndRetrieveLibrary(id int) (*models.Library, error) {
 	var library models.Library
 	if err := db.Find(&library, "id = ?", id).Error; err != nil {
 		log.Errorln("Unable to find library with that ID")
-		return library, newNotFoundDBError(err, "libraries")
+		return nil, newNotFoundDBError(err, "libraries")
 	}
 	library.VisibilityStatus = !library.VisibilityStatus
 	if err := db.Save(&library).Error; err != nil {
-		return library, newUpdateDBError(err, "libraries")
+		return nil, newUpdateDBError(err, "libraries")
 	}
-	return library, nil
+	return &library, nil
 }

--- a/backend/src/database/libraries.go
+++ b/backend/src/database/libraries.go
@@ -44,15 +44,15 @@ func (db *DB) GetLibraryByID(id int) (*models.Library, error) {
 	return &library, nil
 }
 
-func (db *DB) ToggleLibraryVisibility(id int) error {
+func (db *DB) ToggleLibraryVisibility(id int) (models.Library, error) {
 	var library models.Library
 	if err := db.Find(&library, "id = ?", id).Error; err != nil {
 		log.Errorln("Unable to find library with that ID")
-		return newNotFoundDBError(err, "libraries")
+		return library, newNotFoundDBError(err, "libraries")
 	}
 	library.VisibilityStatus = !library.VisibilityStatus
 	if err := db.Save(&library).Error; err != nil {
-		return newUpdateDBError(err, "libraries")
+		return library, newUpdateDBError(err, "libraries")
 	}
-	return nil
+	return library, nil
 }

--- a/backend/src/database/open_content.go
+++ b/backend/src/database/open_content.go
@@ -53,3 +53,18 @@ func (db *DB) FindKolibriInstance() (*models.ProviderPlatform, error) {
 	}
 	return &kolibri, nil
 }
+
+func (db *DB) CreateContentActivity(urlString string, activity *models.OpenContentActivity) {
+	url := models.OpenContentUrl{}
+	if db.Where("content_url = ?", urlString).First(&url).RowsAffected == 0 {
+		url.ContentURL = urlString
+		if err := db.Create(&url).Error; err != nil {
+			log.Warn("unable to create content url for activity")
+			return
+		}
+	}
+	activity.OpenContentUrlID = url.ID
+	if err := db.Create(&activity).Error; err != nil {
+		log.Warn("unable to create content activity for url, ", urlString)
+	}
+}

--- a/backend/src/handlers/libraries_handler.go
+++ b/backend/src/handlers/libraries_handler.go
@@ -68,7 +68,7 @@ func (srv *Server) handleToggleLibraryVisibility(w http.ResponseWriter, r *http.
 }
 
 func (srv *Server) updateLibraryBucket(key string, library *models.Library, log sLog) {
-	var proxyParams models.LibraryProxyPO
+	var proxyParams *models.LibraryProxyPO
 	libraryBucket := srv.buckets[LibraryPaths]
 	entry, err := libraryBucket.Get(key)
 	if err == nil {
@@ -79,13 +79,7 @@ func (srv *Server) updateLibraryBucket(key string, library *models.Library, log 
 		}
 		proxyParams.VisibilityStatus = library.VisibilityStatus
 	} else { //build a one for the bucket
-		proxyParams = models.LibraryProxyPO{
-			ID:                    library.ID,
-			Path:                  library.Path,
-			BaseUrl:               library.OpenContentProvider.BaseUrl,
-			OpenContentProviderID: library.OpenContentProvider.ID,
-			VisibilityStatus:      library.VisibilityStatus,
-		}
+		proxyParams = library.IntoProxyPO()
 	}
 	marshaledParams, err := json.Marshal(proxyParams)
 	if err != nil {

--- a/backend/src/handlers/libraries_handler.go
+++ b/backend/src/handlers/libraries_handler.go
@@ -2,8 +2,11 @@ package handlers
 
 import (
 	"UnlockEdv2/src/models"
+	"encoding/json"
 	"net/http"
 	"strconv"
+
+	"github.com/nats-io/nats.go"
 )
 
 func (srv *Server) registerLibraryRoutes() []routeDef {
@@ -55,9 +58,43 @@ func (srv *Server) handleToggleLibraryVisibility(w http.ResponseWriter, r *http.
 	if err != nil {
 		return newInvalidIdServiceError(err, "library id")
 	}
-	if err := srv.Db.ToggleLibraryVisibility(id); err != nil {
+	library, err := srv.Db.ToggleLibraryVisibility(id)
+	if err != nil {
 		log.add("library_id", id)
 		return newDatabaseServiceError(err)
 	}
+	if srv.buckets != nil { //make sure to update value in bucket if exists
+		libraryBucket := srv.buckets[LibraryPaths]
+		updateLibraryBucket(libraryBucket, r.PathValue("id"), library, log)
+	}
 	return writeJsonResponse(w, http.StatusOK, "Library visibility updated successfully")
+}
+
+func updateLibraryBucket(libraryBucket nats.KeyValue, key string, library models.Library, log sLog) {
+	var proxyParams models.LibraryProxyPO
+	entry, err := libraryBucket.Get(key)
+	if err == nil {
+		err = json.Unmarshal(entry.Value(), &proxyParams)
+		if err != nil {
+			log.warn("unable to unmarshal value from LibaryPaths bucket")
+			return
+		}
+		proxyParams.VisibilityStatus = library.VisibilityStatus
+	} else { //build a one for the bucket
+		proxyParams = models.LibraryProxyPO{
+			ID:                    library.ID,
+			Path:                  library.Path,
+			BaseUrl:               library.OpenContentProvider.BaseUrl,
+			OpenContentProviderID: library.OpenContentProvider.ID,
+			VisibilityStatus:      library.VisibilityStatus,
+		}
+	}
+	marshaledParams, err := json.Marshal(proxyParams)
+	if err != nil {
+		log.warn("unable to marshal value to put into the LibaryPaths bucket")
+		return
+	}
+	if _, err := libraryBucket.Put(key, marshaledParams); err != nil {
+		log.warnf("unable to update value within LibaryPaths bucket, error is %v", err)
+	}
 }

--- a/backend/src/handlers/middleware.go
+++ b/backend/src/handlers/middleware.go
@@ -115,26 +115,11 @@ func (srv *Server) libraryProxyMiddleware(next http.Handler) http.Handler {
 				UserID:                user.UserID,
 				ContentID:             proxyParams.ID,
 			}
-			srv.createActivity(urlString, activity)
+			srv.Db.CreateContentActivity(urlString, &activity)
 		}
 		ctx := context.WithValue(r.Context(), libraryKey, &proxyParams)
 		next.ServeHTTP(w, r.WithContext(ctx))
 	}))
-}
-
-func (srv *Server) createActivity(urlString string, activity models.OpenContentActivity) {
-	url := models.OpenContentUrl{}
-	if srv.Db.Where("content_url = ?", urlString).First(&url).RowsAffected == 0 {
-		url.ContentURL = urlString
-		if err := srv.Db.Create(&url).Error; err != nil {
-			log.Warn("unable to create content url for activity")
-			return
-		}
-	}
-	activity.OpenContentUrlID = url.ID
-	if err := srv.Db.Create(&activity).Error; err != nil {
-		log.Warn("unable to create content activity for url, ", urlString)
-	}
 }
 
 func corsMiddleware(next http.Handler) http.HandlerFunc {

--- a/backend/src/handlers/proxy_handler.go
+++ b/backend/src/handlers/proxy_handler.go
@@ -25,7 +25,7 @@ func (srv *Server) registerProxyRoutes() {
 }
 
 func (srv *Server) handleForwardKiwixProxy(w http.ResponseWriter, r *http.Request) {
-	library, ok := r.Context().Value(libraryKey).(*models.Library)
+	library, ok := r.Context().Value(libraryKey).(*models.LibraryProxyPO)
 	if !ok {
 		srv.errorResponse(w, http.StatusNotFound, "Library context not found")
 		return
@@ -34,7 +34,7 @@ func (srv *Server) handleForwardKiwixProxy(w http.ResponseWriter, r *http.Reques
 	if assetPath != "" && assetPath != "/" {
 		assetPath = strings.TrimPrefix(assetPath, library.Path)
 	}
-	targetURL, err := url.JoinPath(library.OpenContentProvider.BaseUrl, library.Path, assetPath)
+	targetURL, err := url.JoinPath(library.BaseUrl, library.Path, assetPath)
 	if err != nil {
 		srv.errorResponse(w, http.StatusBadRequest, "Malformed request to build targetURL")
 		return
@@ -64,6 +64,11 @@ func (srv *Server) handleForwardKiwixProxy(w http.ResponseWriter, r *http.Reques
 			},
 		},
 		ModifyResponse: func(res *http.Response) error {
+			//MAKE SURE TO NOT CACHE MAIN HTML CONTENT | WE MAY NEED TO ADD OTHER CONTENT TYPE TO NOT CACHE
+			contentType := res.Header.Get("Content-Type")
+			if contentType == "text/html" || contentType == "" {
+				res.Header.Set("Cache-Control", "no-store, no-cache, must-revalidate, private")
+			}
 			if res.StatusCode == http.StatusFound || res.StatusCode == http.StatusSeeOther || res.StatusCode == http.StatusMovedPermanently {
 				location := res.Header.Get("Location")
 				if location != "" {

--- a/backend/src/handlers/proxy_handler.go
+++ b/backend/src/handlers/proxy_handler.go
@@ -68,6 +68,7 @@ func (srv *Server) handleForwardKiwixProxy(w http.ResponseWriter, r *http.Reques
 			contentType := res.Header.Get("Content-Type")
 			if contentType == "text/html" || contentType == "" {
 				res.Header.Set("Cache-Control", "no-store, no-cache, must-revalidate, private")
+				res.Header.Set("Pragma", "no-cache") //setting this in case HTTP/1.1 is not supported
 			}
 			if res.StatusCode == http.StatusFound || res.StatusCode == http.StatusSeeOther || res.StatusCode == http.StatusMovedPermanently {
 				location := res.Header.Get("Location")

--- a/backend/src/handlers/server.go
+++ b/backend/src/handlers/server.go
@@ -187,6 +187,7 @@ func oryConfig() *ory.Configuration {
 
 const (
 	CachedUsers string = "cache_users"
+	LibraryPaths string = "library_paths"
 )
 
 func (srv *Server) setupBucket() error {
@@ -196,7 +197,7 @@ func (srv *Server) setupBucket() error {
 		return err
 	}
 	buckets := map[string]nats.KeyValue{}
-	for _, bucket := range []string{CachedUsers} {
+	for _, bucket := range []string{CachedUsers, LibraryPaths} {
 		kv, err := js.KeyValue(bucket)
 		if err == nats.ErrBucketNotFound {
 			kv, err = js.CreateKeyValue(&nats.KeyValueConfig{

--- a/backend/src/handlers/video_handler.go
+++ b/backend/src/handlers/video_handler.go
@@ -57,7 +57,7 @@ func (srv *Server) handleGetVideoById(w http.ResponseWriter, r *http.Request, lo
 		UserID:                user.UserID,
 		ContentID:             video.ID,
 	}
-	srv.createActivity(videoViewerUrl, activity)
+	srv.Db.CreateContentActivity(videoViewerUrl, &activity)
 	return writeJsonResponse(w, http.StatusOK, video)
 }
 

--- a/backend/src/handlers/video_handler.go
+++ b/backend/src/handlers/video_handler.go
@@ -4,6 +4,7 @@ import (
 	"UnlockEdv2/src/models"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"net/http"
 	"strconv"
 
@@ -49,6 +50,14 @@ func (srv *Server) handleGetVideoById(w http.ResponseWriter, r *http.Request, lo
 	if !user.isAdmin() && !video.VisibilityStatus || video.Availability != models.VideoAvailable {
 		return newForbiddenServiceError(errors.New("video not visible"), "you are not authorized to view this content")
 	}
+	videoViewerUrl := fmt.Sprintf("/viewer/videos/%d", video.ID)
+	activity := models.OpenContentActivity{
+		OpenContentProviderID: video.OpenContentProviderID,
+		FacilityID:            user.FacilityID,
+		UserID:                user.UserID,
+		ContentID:             video.ID,
+	}
+	srv.createActivity(videoViewerUrl, activity)
 	return writeJsonResponse(w, http.StatusOK, video)
 }
 

--- a/backend/src/models/library.go
+++ b/backend/src/models/library.go
@@ -16,6 +16,17 @@ type Library struct {
 
 func (Library) TableName() string { return "libraries" }
 
+func (lib *Library) IntoProxyPO() *LibraryProxyPO {
+	proxyParams := LibraryProxyPO{
+		ID:                    lib.ID,
+		Path:                  lib.Path,
+		BaseUrl:               lib.OpenContentProvider.BaseUrl,
+		OpenContentProviderID: lib.OpenContentProvider.ID,
+		VisibilityStatus:      lib.VisibilityStatus,
+	}
+	return &proxyParams
+}
+
 type LibraryProxyPO struct {
 	ID                    uint
 	OpenContentProviderID uint

--- a/backend/src/models/library.go
+++ b/backend/src/models/library.go
@@ -15,3 +15,11 @@ type Library struct {
 }
 
 func (Library) TableName() string { return "libraries" }
+
+type LibraryProxyPO struct {
+	ID                    uint
+	OpenContentProviderID uint
+	Path                  string
+	BaseUrl               string
+	VisibilityStatus      bool
+}

--- a/backend/src/models/open_content.go
+++ b/backend/src/models/open_content.go
@@ -3,6 +3,7 @@ package models
 import (
 	"fmt"
 	"strings"
+	"time"
 
 	"gorm.io/gorm"
 )
@@ -18,6 +19,28 @@ type OpenContentProvider struct {
 	Videos []Video        `gorm:"foreignKey:OpenContentProviderID" json:"-"`
 	Tasks  []RunnableTask `gorm:"foreignKey:OpenContentProviderID" json:"-"`
 }
+
+type OpenContentActivity struct {
+	OpenContentProviderID uint      `gorm:"not null" json:"open_content_provider_id"`
+	FacilityID            uint      `gorm:"not null" json:"facility_id"`
+	UserID                uint      `gorm:"not null" json:"user_id"`
+	ContentID             uint      `gorm:"not null" json:"content_id"`
+	OpenContentUrlID      uint      `gorm:"not null" json:"open_content_url_id"`
+	RequestTS             time.Time `gorm:"type:timestamp(0);default:CURRENT_TIMESTAMP" json:"request_ts"`
+
+	User                *User                `gorm:"foreignKey:UserID" json:"-"`
+	OpenContentProvider *OpenContentProvider `gorm:"foreignKey:OpenContentProviderID;constraint:OnUpdate:CASCADE,OnDelete:SET NULL" json:"open_content_provider"`
+	Facility            *Facility            `json:"-" gorm:"foreignKey:FacilityID;references:ID"`
+}
+
+func (OpenContentActivity) TableName() string { return "open_content_activities" }
+
+type OpenContentUrl struct {
+	ID         uint   `gorm:"primaryKey" json:"-"`
+	ContentURL string `gorm:"size:255" json:"content_url"`
+}
+
+func (OpenContentUrl) TableName() string { return "open_content_urls" }
 
 const (
 	KolibriThumbnailUrl string = "https://learningequality.org/static/assets/kolibri-ecosystem-logos/blob-logo.svg"


### PR DESCRIPTION
Added feature to track users (students/admins) viewing activity when interacting with open content (videos and libraries). A couple of details follow:

Two tables were created to track open content library activity.
1. open_content_urls - This table is used as a lookup table for when a user clicks an open content link. If the url that the user requested does not exist then it is created and the ID is used for the saving in the open_content_activities table. This table is used for improving query performance.  
2. open_content_activities - This table is used to track all user open content activity, basically tracks user requests for all open content.  
