### PR TITLE
feat: add internal link component, make static content card use it

### DIFF
--- a/frontend/src/Components/InternalLink.tsx
+++ b/frontend/src/Components/InternalLink.tsx
@@ -1,0 +1,21 @@
+import { ArrowTopRightOnSquareIcon } from '@heroicons/react/24/outline';
+import { ReactNode } from 'react';
+import { Link } from 'react-router-dom';
+
+export default function InternalLink({
+    children,
+    url
+}: {
+    children: ReactNode;
+    url: string;
+}) {
+    return (
+        <Link
+            className="flex gap-2 body-small text-body-text items-center"
+            to={url}
+        >
+            <ArrowTopRightOnSquareIcon className="w-4" />
+            {children}
+        </Link>
+    );
+}

--- a/frontend/src/Components/StaticContentCard.tsx
+++ b/frontend/src/Components/StaticContentCard.tsx
@@ -1,4 +1,4 @@
-import ExternalLink from './ExternalLink';
+import InternalLink from './InternalLink';
 
 interface StaticContentCardProps {
     title: string;
@@ -28,7 +28,7 @@ export default function StaticContentCard({
                 <h3 className="card-title text-sm">{title}</h3>
                 <p className="body-small">{description}</p>
 
-                <ExternalLink url={linkUrl}>{linkText}</ExternalLink>
+                <InternalLink url={linkUrl}>{linkText}</InternalLink>
             </div>
         </div>
     );


### PR DESCRIPTION
The static content card has links that direct internally, using the external link opens it up in another window. This PR gives us an internal link component, and makes the static content card use it