### PR TITLE
feat: add open content dashboard ui and activity apis

### DIFF
--- a/backend/src/database/open_content.go
+++ b/backend/src/database/open_content.go
@@ -165,3 +165,42 @@ func (db *DB) GetUserFavorites(userID uint, page, perPage int) (int64, []models.
 	paginatedFavorites := allFavorites[offset:end]
 	return total, paginatedFavorites, nil
 }
+
+func (db *DB) GetTopFacilityOpenContent(id int) ([]models.OpenContentItem, error) {
+	var content []models.OpenContentItem
+	if err := db.Raw("? UNION ? ORDER BY visits DESC LIMIT 5",
+		db.Select("v.title as name, v.url, v.thumbnail_url, v.open_content_provider_id, v.id as content_id, 'video' as type, count(v.id) as visits").
+			Table("open_content_activities oca").
+			Joins("LEFT JOIN videos v ON v.id = oca.content_id AND v.open_content_provider_id = oca.open_content_provider_id AND v.visibility_status = TRUE").
+			Where("oca.facility_id = ?", id).
+			Group("v.title, v.url, v.thumbnail_url, v.open_content_provider_id, v.id"),
+		db.Select("l.name, l.path as url, l.image_url as thumbnail_url, l.open_content_provider_id, l.id as content_id, 'library' as type, count(l.id) as visits").
+			Table("open_content_activities oca").
+			Joins("LEFT JOIN libraries l on l.id = oca.content_id AND l.open_content_provider_id = oca.open_content_provider_id AND l.visibility_status = TRUE").
+			Where("oca.facility_id = ?", id).
+			Group("l.name, l.path, l.image_url, l.open_content_provider_id, l.id"),
+	).Find(&content).Error; err != nil {
+		return nil, newGetRecordsDBError(err, "open_content_items")
+	}
+	return content, nil
+}
+
+func (db *DB) GetTopUserOpenContent(id int) ([]models.OpenContentItem, error) {
+	var content []models.OpenContentItem
+	log.Println(id)
+	if err := db.Raw("? UNION ? ORDER BY visits DESC LIMIT 5",
+		db.Select("v.title as name, v.url, v.thumbnail_url, v.open_content_provider_id, v.id as content_id, 'video' as type, count(v.id) as visits").
+			Table("open_content_activities oca").
+			Joins("LEFT JOIN videos v ON v.id = oca.content_id AND v.open_content_provider_id = oca.open_content_provider_id AND v.visibility_status = TRUE").
+			Where("oca.user_id = ?", id).
+			Group("v.title, v.url, v.thumbnail_url, v.open_content_provider_id, v.id"),
+		db.Select("l.name, l.path as url, l.image_url as thumbnail_url, l.open_content_provider_id, l.id as content_id, 'library' as type, count(l.id) as visits").
+			Table("open_content_activities oca").
+			Joins("LEFT JOIN libraries l on l.id = oca.content_id AND l.open_content_provider_id = oca.open_content_provider_id AND l.visibility_status = TRUE").
+			Where("oca.user_id = ?", id).
+			Group("l.name, l.path, l.image_url, l.open_content_provider_id, l.id"),
+	).Find(&content).Error; err != nil {
+		return nil, newGetRecordsDBError(err, "open_content_items")
+	}
+	return content, nil
+}

--- a/backend/src/database/open_content.go
+++ b/backend/src/database/open_content.go
@@ -193,12 +193,14 @@ func (db *DB) GetTopUserOpenContent(id int) ([]models.OpenContentItem, error) {
 			Table("open_content_activities oca").
 			Joins("LEFT JOIN videos v ON v.id = oca.content_id AND v.open_content_provider_id = oca.open_content_provider_id AND v.visibility_status = TRUE").
 			Where("oca.user_id = ?", id).
-			Group("v.title, v.url, v.thumbnail_url, v.open_content_provider_id, v.id"),
+			Group("v.title, v.url, v.thumbnail_url, v.open_content_provider_id, v.id").
+			Having("count(v.id) > 0"),
 		db.Select("l.name, l.path as url, l.image_url as thumbnail_url, l.open_content_provider_id, l.id as content_id, 'library' as type, count(l.id) as visits").
 			Table("open_content_activities oca").
 			Joins("LEFT JOIN libraries l on l.id = oca.content_id AND l.open_content_provider_id = oca.open_content_provider_id AND l.visibility_status = TRUE").
 			Where("oca.user_id = ?", id).
-			Group("l.name, l.path, l.image_url, l.open_content_provider_id, l.id"),
+			Group("l.name, l.path, l.image_url, l.open_content_provider_id, l.id").
+			Having("count(l.id) > 0"),
 	).Find(&content).Error; err != nil {
 		return nil, newGetRecordsDBError(err, "open_content_items")
 	}

--- a/backend/src/handlers/open_content_activity_handler.go
+++ b/backend/src/handlers/open_content_activity_handler.go
@@ -10,7 +10,7 @@ func (srv *Server) registerOpenContentActivityRoutes() []routeDef {
 	axx := models.Feature(models.OpenContentAccess)
 	return []routeDef{
 		{"GET /api/open-content/activity", srv.handleGetTopFacilityOpenContent, false, axx},
-		{"PUT /api/open-content/activity/{id}", srv.handleGetTopUserOpenContent, false, axx},
+		{"GET /api/open-content/activity/{id}", srv.handleGetTopUserOpenContent, false, axx},
 	}
 }
 

--- a/backend/src/handlers/open_content_activity_handler.go
+++ b/backend/src/handlers/open_content_activity_handler.go
@@ -1,0 +1,36 @@
+package handlers
+
+import (
+	"UnlockEdv2/src/models"
+	"net/http"
+	"strconv"
+)
+
+func (srv *Server) registerOpenContentActivityRoutes() []routeDef {
+	axx := models.Feature(models.OpenContentAccess)
+	return []routeDef{
+		{"GET /api/open-content/activity", srv.handleGetTopFacilityOpenContent, false, axx},
+		{"PUT /api/open-content/activity/{id}", srv.handleGetTopUserOpenContent, false, axx},
+	}
+}
+
+func (srv *Server) handleGetTopFacilityOpenContent(w http.ResponseWriter, r *http.Request, log sLog) error {
+	facilityId := srv.getFacilityID(r)
+	topOpenContent, err := srv.Db.GetTopFacilityOpenContent(int(facilityId))
+	if err != nil {
+		return newDatabaseServiceError(err)
+	}
+	return writeJsonResponse(w, http.StatusOK, topOpenContent)
+}
+
+func (srv *Server) handleGetTopUserOpenContent(w http.ResponseWriter, r *http.Request, log sLog) error {
+	id, err := strconv.Atoi(r.PathValue("id"))
+	if err != nil {
+		return newInvalidIdServiceError(err, "user ID")
+	}
+	topOpenContent, err := srv.Db.GetTopUserOpenContent(id)
+	if err != nil {
+		return newDatabaseServiceError(err)
+	}
+	return writeJsonResponse(w, http.StatusOK, topOpenContent)
+}

--- a/backend/src/handlers/open_content_activity_handler_test.go
+++ b/backend/src/handlers/open_content_activity_handler_test.go
@@ -1,0 +1,82 @@
+package handlers
+
+import (
+	"UnlockEdv2/src/models"
+	"encoding/json"
+	"net/http"
+	"slices"
+	"strconv"
+	"testing"
+)
+
+func TestTopFacilityOpenContentHandler(t *testing.T) {
+	httpTests := []httpTest{
+		{"TestGetOpenContentActivityAsUser", "student", map[string]any{"id": "1"}, http.StatusOK, ""},
+	}
+	for _, test := range httpTests {
+		t.Run(test.testName, func(t *testing.T) {
+			req, err := http.NewRequest(http.MethodGet, "/api/open-content/activity", nil)
+			if err != nil {
+				t.Fatalf("unable to create new request, error is %v", err)
+			}
+			req.SetPathValue("id", test.mapKeyValues["id"].(string))
+			handler := getHandlerByRole(server.handleGetTopFacilityOpenContent, test.role)
+			rr := executeRequest(t, req, handler, test)
+			if test.expectedStatusCode == http.StatusOK {
+				id, _ := strconv.Atoi(test.mapKeyValues["id"].(string))
+				expectedOpenContent, err := server.Db.GetTopFacilityOpenContent(id)
+				if err != nil {
+					t.Fatalf("unable to get open content, error is %v", err)
+				}
+				data := models.Resource[[]models.OpenContentItem]{}
+				received := rr.Body.String()
+				if err = json.Unmarshal([]byte(received), &data); err != nil {
+					t.Errorf("failed to unmarshal resource, error is %v", err)
+				}
+				for _, expectedContent := range expectedOpenContent {
+					if !slices.ContainsFunc(data.Data, func(opi models.OpenContentItem) bool {
+						return opi.ContentId == expectedContent.ContentId && opi.OpenContentProviderId == expectedContent.OpenContentProviderId
+					}) {
+						t.Error("library not found, out of sync")
+					}
+				}
+			}
+		})
+	}
+}
+
+func TestTopUserOpenContentHandler(t *testing.T) {
+	httpTests := []httpTest{
+		{"TestGetOpenContentActivityAsUser", "student", map[string]any{"id": "4"}, http.StatusOK, ""},
+	}
+	for _, test := range httpTests {
+		t.Run(test.testName, func(t *testing.T) {
+			req, err := http.NewRequest(http.MethodGet, "/api/open-content/activity", nil)
+			if err != nil {
+				t.Fatalf("unable to create new request, error is %v", err)
+			}
+			req.SetPathValue("id", test.mapKeyValues["id"].(string))
+			handler := getHandlerByRole(server.handleGetTopUserOpenContent, test.role)
+			rr := executeRequest(t, req, handler, test)
+			if test.expectedStatusCode == http.StatusOK {
+				id, _ := strconv.Atoi(test.mapKeyValues["id"].(string))
+				expectedOpenContent, err := server.Db.GetTopUserOpenContent(id)
+				if err != nil {
+					t.Fatalf("unable to get open content, error is %v", err)
+				}
+				data := models.Resource[[]models.OpenContentItem]{}
+				received := rr.Body.String()
+				if err = json.Unmarshal([]byte(received), &data); err != nil {
+					t.Errorf("failed to unmarshal resource, error is %v", err)
+				}
+				for _, expectedContent := range expectedOpenContent {
+					if !slices.ContainsFunc(data.Data, func(opi models.OpenContentItem) bool {
+						return opi.ContentId == expectedContent.ContentId && opi.OpenContentProviderId == expectedContent.OpenContentProviderId
+					}) {
+						t.Error("library not found, out of sync")
+					}
+				}
+			}
+		})
+	}
+}

--- a/backend/src/handlers/server.go
+++ b/backend/src/handlers/server.go
@@ -79,7 +79,6 @@ func (srv *Server) RegisterRoutes() {
 		srv.registerOryRoutes,
 		srv.registerFacilitiesRoutes,
 		srv.registerOpenContentRoutes,
-		srv.registerOpenContentActivityRoutes,
 		srv.registerLibraryRoutes,
 		srv.registerProgramsRoutes,
 		srv.registerSectionsRoutes,
@@ -88,6 +87,7 @@ func (srv *Server) RegisterRoutes() {
 		srv.registerAttendanceRoutes,
 		srv.registerVideoRoutes,
 		srv.registerFeatureFlagRoutes,
+		srv.registerOpenContentActivityRoutes,
 	} {
 		srv.register(route)
 	}

--- a/backend/src/handlers/server.go
+++ b/backend/src/handlers/server.go
@@ -79,6 +79,7 @@ func (srv *Server) RegisterRoutes() {
 		srv.registerOryRoutes,
 		srv.registerFacilitiesRoutes,
 		srv.registerOpenContentRoutes,
+		srv.registerOpenContentActivityRoutes,
 		srv.registerLibraryRoutes,
 		srv.registerProgramsRoutes,
 		srv.registerSectionsRoutes,

--- a/backend/src/handlers/test_data/libraries.json
+++ b/backend/src/handlers/test_data/libraries.json
@@ -1,32 +1,247 @@
 [
   {
-    "open_content_provider_id": 3,
-    "external_id": "urn:uuid:67440563-a62b-fabe-415c-4c3ee4546f78",
-    "name": "TED ted connects",
-    "language": "eng,spa,ara",
-    "description": "A collection of TED videos about ted connects",
-    "url": "/content/ted_mul_ted-connects_2024-08",
-    "image_url": "/catalog/v2/illustration/67440563-a62b-fabe-415c-4c3ee4546f78/?size=48",
-    "visibility_status": true
+     "external_id":"urn:uuid:d03be720-2865-892c-b474-d821091fe989",
+     "name":"\u30B9\u30BF\u30C3\u30AF\u30FB\u30AA\u30FC\u30D0\u30FC\u30D5\u30ED\u30FC",
+     "language":"eng, jpn",
+     "description":"\u30D7\u30ED\u30B0\u30E9\u30DE\u30FC\u3068\u30D7\u30ED\u30B0\u30E9\u30DF\u30F3\u30B0\u306B\u71B1\u5FC3\u306A\u4EBA\u3005\u306E\u305F\u3081\u306E\u8CEA\u554F\u3068\u56DE\u7B54",
+     "path":"\/content\/ja.stackoverflow.com_mul_all_2024-06",
+     "image_url":"\/api\/photos\/\u30B9\u30BF\u30C3\u30AF\u30FB\u30AA\u30FC\u30D0\u30FC\u30D5\u30ED\u30FC.png",
+     "visibility_status":false
+    },
+    
+  {
+     "external_id":"urn:uuid:d2fe3e62-a39d-401d-3ce9-275c29cbb74e",
+     "name":"RationalWiki",
+     "language":"eng",
+     "description":"From RationalWiki",
+     "path":"\/content\/rationalwiki_en_all_maxi_2021-03",
+     "image_url":"\/api\/photos\/RationalWiki.png",
+     "visibility_status":true
+    },
+    
+  {
+     "external_id":"urn:uuid:5ac8d4fc-e699-bdf7-bbfb-7c7bd3365a26",
+     "name":"MediaWiki",
+     "language":"eng",
+     "description":"From mediawiki.org",
+     "path":"\/content\/mediawiki_en_all_2023-07",
+     "image_url":"\/api\/photos\/MediaWiki.png",
+     "visibility_status":false
+    },
+    
+  {
+     "external_id":"urn:uuid:99b68dd3-8e85-0669-dff7-9adcf4d0c950",
+     "name":"ArchWiki",
+     "language":"eng",
+     "description":"Arch Linux documentation",
+     "path":"\/content\/archlinux_en_all_nopic_2022-12",
+     "image_url":"\/api\/photos\/ArchWiki.png",
+     "visibility_status":false
+    },
+    
+  {
+     "external_id":"urn:uuid:0474d4a1-c018-5d14-bb92-5fa05f1c89ca",
+     "name":"Wikiversity",
+     "language":"eng",
+     "description":"From Wikiversity",
+     "path":"\/content\/wikiversity_en_all_maxi_2021-03",
+     "image_url":"\/api\/photos\/Wikiversity.png",
+     "visibility_status":true
+    },
+    
+  {
+     "external_id":"urn:uuid:ef75389a-c1d9-6f07-424f-96bed9d888df",
+     "name":"Stack Overflow \u043D\u0430 \u0440\u0443\u0441\u0441\u043A\u043E\u043C",
+     "language":"eng, rus",
+     "description":"\u0412\u043E\u043F\u0440\u043E\u0441\u044B \u0438 \u043E\u0442\u0432\u0435\u0442\u044B \u0434\u043B\u044F \u043F\u0440\u043E\u0433\u0440\u0430\u043C\u043C\u0438\u0441\u0442\u043E\u0432",
+     "path":"\/content\/ru.stackoverflow.com_mul_all_2024-10",
+     "image_url":"\/api\/photos\/Stack Overflow \u043D\u0430 \u0440\u0443\u0441\u0441\u043A\u043E\u043C.png",
+     "visibility_status":false
+    },
+    
+  {
+     "external_id":"urn:uuid:c4ba7540-693f-3fe7-a211-b71091409c24",
+     "name":"TED veganism",
+     "language":"eng,fra,ita,zho,kor,ind,spa,ara,zho,deu",
+     "description":"A collection of TED videos about veganism",
+     "path":"\/content\/ted_mul_veganism_2024-11",
+     "image_url":"\/api\/photos\/TED veganism.png",
+     "visibility_status":false
+    },
+    
+  {
+     "external_id":"urn:uuid:c4841079-cef5-0d1e-0666-19d25da6cde9",
+     "name":"Prunelle books",
+     "language":"eng",
+     "description":"Books for children",
+     "path":"\/content\/prunelle_interactive_books_en_2024-05",
+     "image_url":"\/api\/photos\/Prunelle books.png",
+     "visibility_status":false
+    },
+    
+  {
+     "external_id":"urn:uuid:ada09bae-8e7e-547b-35ba-f75e9ca2af8c",
+     "name":"Wikipedia",
+     "language":"eng",
+     "description":"The free encyclopedia",
+     "path":"\/content\/wikipedia_en_all_maxi_2024-01",
+     "image_url":"\/api\/photos\/Wikipedia.png",
+     "visibility_status":false
+    },
+    
+  {
+     "external_id":"urn:uuid:67440563-a62b-fabe-415c-4c3ee4546f78",
+     "name":"TED ted connects",
+     "language":"eng,spa,ara",
+     "description":"A collection of TED videos about ted connects",
+     "path":"\/content\/ted_mul_ted-connects_2024-08",
+     "image_url":"\/catalog\/v2\/illustration\/67440563-a62b-fabe-415c-4c3ee4546f78\/?size=48",
+     "visibility_status":true
+    },
+    
+  {
+     "external_id":"urn:uuid:19e6fe12-09a9-0a38-5be4-71c0eba0a72d",
+     "name":"Finiki",
+     "language":"eng",
+     "description":"The Canadian financial wiki",
+     "path":"\/content\/finiki_en_all_maxi_2024-06",
+     "image_url":"\/api\/photos\/Finiki.png",
+     "visibility_status":true
+    },
+    
+  {
+     "external_id":"urn:uuid:84812c13-fa65-feb7-c206-4f22cc2e0f9a",
+     "name":"Python Documentation",
+     "language":"eng",
+     "description":"All documentation for Python",
+     "path":"\/content\/docs.python.org_en_2024-09",
+     "image_url":"\/catalog\/v2\/illustration\/84812c13-fa65-feb7-c206-4f22cc2e0f9a\/?size=48",
+     "visibility_status":true
+    },
+    
+  {
+     "external_id":"urn:uuid:f04a17e5-e11c-8c4e-6be8-e98568f124f9",
+     "name":"ArchWiki",
+     "language":"eng",
+     "description":"Arch Linux documentation",
+     "path":"\/content\/archlinux_en_all_maxi_2022-12",
+     "image_url":"\/api\/photos\/ArchWiki.png",
+     "visibility_status":true
+    },
+    
+  {
+     "external_id":"urn:uuid:600c47c6-a792-0f78-8fcc-9c05cf1c556b",
+     "name":"PHP Manual",
+     "language":"eng",
+     "description":"PHP Manual",
+     "path":"\/content\/php.net_en_all_2024-08",
+     "image_url":"\/api\/photos\/PHP Manual.png",
+     "visibility_status":true
+    },
+    
+  {
+     "external_id":"urn:uuid:9b4bc967-1063-0ad2-f446-10721f452930",
+     "name":"RationalWiki",
+     "language":"eng",
+     "description":"From RationalWiki",
+     "path":"\/content\/rationalwiki_en_all_nopic_2021-03",
+     "image_url":"\/api\/photos\/RationalWiki.png",
+     "visibility_status":true
+    },
+    
+  {
+     "external_id":"urn:uuid:d2fe3e62-a39d-401d-3ce9-275c29cbb74e",
+     "name":"RationalWiki",
+     "language":"eng",
+     "description":"From RationalWiki",
+     "path":"\/content\/rationalwiki_en_all_maxi_2021-03",
+     "image_url":"\/api\/photos\/RationalWiki.png",
+     "visibility_status":false
+    },
+    
+  {
+     "external_id":"urn:uuid:c405e855-e5ba-4dd7-f261-47a00731ffa8",
+     "name":"Wikiversity",
+     "language":"eng",
+     "description":"From Wikiversity",
+     "path":"\/content\/wikiversity_en_all_nopic_2021-03",
+     "image_url":"\/api\/photos\/Wikiversity.png",
+     "visibility_status":true
   },
   {
-    "open_content_provider_id": 3,
-    "external_id": "urn:uuid:84812c13-fa65-feb7-c206-4f22cc2e0f9a",
-    "name": "Python Documentation",
-    "language": "eng",
-    "description": "All documentation for Python",
-    "url": "/content/docs.python.org_en_2024-09",
-    "image_url": "/catalog/v2/illustration/84812c13-fa65-feb7-c206-4f22cc2e0f9a/?size=48",
-    "visibility_status": true
-  },
+     "external_id":"urn:uuid:9d1667aa-5180-4573-ddc2-16396e1bb27c",
+     "name":"RagaGunglism",
+     "language":"eng",
+     "description":"Indian Classical Music Theory",
+     "path":"\/content\/ragajunglism.org_en_all_2024-11",
+     "image_url":"\/api\/photos\/RagaGunglism.png",
+     "visibility_status":true
+    },
+    
   {
-    "open_content_provider_id": 3,
-    "external_id": "urn:uuid:19e6fe12-09a9-0a38-5be4-71c0eba0a72d",
-    "name": "Finiki",
-    "language": "eng",
-    "description": "The Canadian financial wiki",
-    "url": "/content/finiki_en_all_maxi_2024-06",
-    "image_url": "/catalog/v2/illustration/19e6fe12-09a9-0a38-5be4-71c0eba0a72d/?size=48",
-    "visibility_status": false
-  }
+     "external_id":"urn:uuid:c0f8a4de-03e7-2ae1-156b-c9b0a36a082b",
+     "name":"Football(s)",
+     "language":"fra,eng,spa",
+     "description":"Football(s). Histoire, culture, \u00E9conomie, soci\u00E9t\u00E9", 
+     "path":"\/content\/u-bourgogne.fr_mul_football-s_2024-11",
+     "image_url":"\/api\/photos\/Football(s).png",
+     "visibility_status":false
+    },
+    
+  {
+     "external_id":"urn:uuid:600c47c6-a792-0f78-8fcc-9c05cf1c556b",
+     "name":"PHP Manual",
+     "language":"eng",
+     "description":"PHP Manual",
+     "path":"\/content\/php.net_en_all_2024-08",
+     "image_url":"\/api\/photos\/PHP Manual.png",
+     "visibility_status":true
+    },
+    
+  {
+     "external_id":"urn:uuid:ada09bae-8e7e-547b-35ba-f75e9ca2af8c",
+     "name":"Wikipedia",
+     "language":"eng",
+     "description":"The free encyclopedia",
+     "path":"\/content\/wikipedia_en_all_maxi_2024-01",
+     "image_url":"\/api\/photos\/Wikipedia.png",
+     "visibility_status":false
+    },
+    
+  {
+     "external_id":"urn:uuid:c4841079-cef5-0d1e-0666-19d25da6cde9",
+     "name":"Prunelle books",
+     "language":"eng",
+     "description":"Books for children",
+     "path":"\/content\/prunelle_interactive_books_en_2024-05",
+     "image_url":"\/api\/photos\/Prunelle books.png",
+     "visibility_status":true
+    },
+  {
+     "external_id":"urn:uuid:9b4bc967-1063-0ad2-f446-10721f452930",
+     "name":"RationalWiki",
+     "language":"eng",
+     "description":"From RationalWiki",
+     "path":"\/content\/rationalwiki_en_all_nopic_2021-03",
+     "image_url":"\/api\/photos\/RationalWiki.png",
+     "visibility_status":true
+    },
+  {
+     "external_id":"urn:uuid:e86ed0fa-bf87-d533-2967-5ffeee353e64",
+     "name":"Esperanto Language",
+     "language":"eng,  epo",
+     "description":"Q&A for teachers and students of the Esperanto language",
+     "path":"\/content\/esperanto.stackexchange.com_mul_all_2024-11",
+     "image_url":"\/api\/photos\/Esperanto Language.png",
+     "visibility_status":false
+    },
+  {
+     "external_id":"urn:uuid:99b68dd3-8e85-0669-dff7-9adcf4d0c950",
+     "name":"ArchWiki",
+     "language":"eng",
+     "description":"Arch Linux documentation",
+     "path":"\/content\/archlinux_en_all_nopic_2022-12",
+     "image_url":"\/api\/photos\/ArchWiki.png",
+     "visibility_status":false
+    }
 ]

--- a/backend/src/models/library.go
+++ b/backend/src/models/library.go
@@ -4,11 +4,11 @@ type Library struct {
 	DatabaseFields
 	OpenContentProviderID uint    `gorm:"not null" json:"open_content_provider_id"`
 	ExternalID            *string `json:"external_id"`
-	Name                  string  `gorm:"size:255;not null" json:"name"`
+	Name                  string  `gorm:"size:255;not null" json:"title"`
 	Language              *string `gorm:"size:255" json:"language"`
 	Description           *string `json:"description"`
 	Path                  string  `gorm:"not null" json:"url"`
-	ImageUrl              *string `json:"image_url"`
+	ImageUrl              *string `json:"thumbnail_url"`
 	VisibilityStatus      bool    `gorm:"default:false;not null" json:"visibility_status"`
 
 	OpenContentProvider *OpenContentProvider `gorm:"foreignKey:OpenContentProviderID;constraint:OnUpdate:CASCADE,OnDelete:SET NULL" json:"open_content_provider"`

--- a/backend/src/models/open_content.go
+++ b/backend/src/models/open_content.go
@@ -64,6 +64,15 @@ type OpenContentParams struct {
 	ContentUrl            string `json:"content_url"`
 }
 
+type OpenContentItem struct {
+	Name                  string `json:"name"`
+	Url                   string `json:"url"`
+	ThumbnailUrl          string `json:"thumbnail_url"`
+	OpenContentProviderId uint   `json:"open_content_provider_id"`
+	ContentId             uint   `json:"content_id"`
+	Type                  string `json:"type"`
+}
+
 const (
 	KolibriThumbnailUrl string = "https://learningequality.org/static/assets/kolibri-ecosystem-logos/blob-logo.svg"
 	Kiwix               string = "Kiwix"

--- a/frontend/src/Components/LibraryCard.tsx
+++ b/frontend/src/Components/LibraryCard.tsx
@@ -79,7 +79,7 @@ export default function LibraryCard({
             <div className="flex p-4 gap-2 border-b-2">
                 <figure className="w-[48px] h-[48px] bg-cover">
                     <img
-                        src={library.image_url ?? ''}
+                        src={library.thumbnail_url ?? ''}
                         alt={`${library.name} thumbnail`}
                     />
                 </figure>

--- a/frontend/src/Components/LibraryCard.tsx
+++ b/frontend/src/Components/LibraryCard.tsx
@@ -79,7 +79,7 @@ export default function LibraryCard({
             <div className="flex p-4 gap-2 border-b-2">
                 <figure className="w-[48px] h-[48px] bg-cover">
                     <img
-                        src={library.thumbnail_url ?? ''}
+                        src={library.image_url ?? ''}
                         alt={`${library.name} thumbnail`}
                     />
                 </figure>
@@ -89,7 +89,7 @@ export default function LibraryCard({
                 <div onClick={(e: MouseEvent) => void toggleFavorite(e)}>
                     <ULIComponent
                         tooltipClassName={'absolute right-2 top-2 z-100'}
-                        iconClassName={`w-6 h-6 ${library.is_favorited ? 'text-primary-yellow' : ''}`}
+                        iconClassName={`w-5 h-5 ${library.is_favorited ? 'text-primary-yellow' : ''}`}
                         icon={library.is_favorited ? StarIcon : StarIconOutline}
                         dataTip="Favorite Library"
                     />

--- a/frontend/src/Components/LibraryLayout.tsx
+++ b/frontend/src/Components/LibraryLayout.tsx
@@ -77,7 +77,7 @@ export default function LibaryLayout({
     }, [filterLibrariesAdmin, filterLibraries, searchTerm]);
 
     return (
-        <div className="px-8">
+        <div className="flex flex-col gap-8">
             <div className="flex flex-row gap-4">
                 <SearchBar
                     searchTerm={searchTerm}
@@ -97,7 +97,7 @@ export default function LibaryLayout({
                     />
                 )}
             </div>
-            <div className="grid grid-cols-4 pb-8 pt-8 gap-6">
+            <div className="grid grid-cols-4 gap-6">
                 {libraries?.data.map((library) => (
                     <LibraryCard
                         key={library.id}

--- a/frontend/src/Components/Navbar.tsx
+++ b/frontend/src/Components/Navbar.tsx
@@ -72,24 +72,24 @@ export default function Navbar({
                         {user && isAdministrator(user) ? (
                             <>
                                 {/* admin view */}
-                                <li className="mt-16">
-                                    <Link to="/admin-dashboard">
-                                        <ULIComponent icon={HomeIcon} />
-                                        Dashboard
-                                    </Link>
-                                </li>
-                                <li>
-                                    <Link to="/student-management">
-                                        <ULIComponent icon={AcademicCapIcon} />
-                                        Students
-                                    </Link>
-                                </li>
-                                <li>
-                                    <Link to="/admin-management">
-                                        <ULIComponent icon={UsersIcon} />
-                                        Admins
-                                    </Link>
-                                </li>
+                                {hasFeature(
+                                    user,
+                                    FeatureAccess.OpenContentAccess
+                                ) && user.feature_access.length === 1 ? (
+                                    <li className="mt-16">
+                                        <Link to="/open-content-dashboard">
+                                            <ULIComponent icon={HomeIcon} />
+                                            Dashboard
+                                        </Link>
+                                    </li>
+                                ) : (
+                                    <li className="mt-16">
+                                        <Link to="/admin-dashboard">
+                                            <ULIComponent icon={HomeIcon} />
+                                            Dashboard
+                                        </Link>
+                                    </li>
+                                )}
                                 {hasFeature(
                                     user,
                                     FeatureAccess.OpenContentAccess
@@ -105,12 +105,6 @@ export default function Navbar({
                                         </li>
                                     </>
                                 )}
-                                <li>
-                                    <Link to="/resources-management">
-                                        <ULIComponent icon={ArchiveBoxIcon} />
-                                        Resources
-                                    </Link>
-                                </li>
                                 {hasFeature(
                                     user,
                                     FeatureAccess.ProviderAccess
@@ -148,6 +142,24 @@ export default function Navbar({
                                     </li>
                                 )}
                                 <li>
+                                    <Link to="/student-management">
+                                        <ULIComponent icon={AcademicCapIcon} />
+                                        Students
+                                    </Link>
+                                </li>
+                                <li>
+                                    <Link to="/admin-management">
+                                        <ULIComponent icon={UsersIcon} />
+                                        Admins
+                                    </Link>
+                                </li>
+                                <li>
+                                    <Link to="/resources-management">
+                                        <ULIComponent icon={ArchiveBoxIcon} />
+                                        Resources
+                                    </Link>
+                                </li>
+                                <li>
                                     <Link to="/facilities-management">
                                         <ULIComponent
                                             icon={BuildingStorefrontIcon}
@@ -158,13 +170,24 @@ export default function Navbar({
                             </>
                         ) : (
                             <>
-                                {/* student view */}
-                                <li className="mt-16">
-                                    <Link to="/student-dashboard">
-                                        <ULIComponent icon={HomeIcon} />
-                                        Dashboard
-                                    </Link>
-                                </li>
+                                {hasFeature(
+                                    user,
+                                    FeatureAccess.OpenContentAccess
+                                ) && user.feature_access.length === 1 ? (
+                                    <li className="mt-16">
+                                        <Link to="/open-content-dashboard">
+                                            <ULIComponent icon={HomeIcon} />
+                                            Dashboard
+                                        </Link>
+                                    </li>
+                                ) : (
+                                    <li className="mt-16">
+                                        <Link to="/student-dashboard">
+                                            <ULIComponent icon={HomeIcon} />
+                                            Dashboard
+                                        </Link>
+                                    </li>
+                                )}
                                 {hasFeature(
                                     user,
                                     FeatureAccess.ProviderAccess

--- a/frontend/src/Components/PageNav.tsx
+++ b/frontend/src/Components/PageNav.tsx
@@ -71,7 +71,7 @@ export default function PageNav({
     };
 
     return (
-        <div className="px-8 flex justify-between items-center">
+        <div className="px-6 py-3 flex justify-between items-center">
             <div className="breadcrumbs">
                 <ul>
                     {showOpenMenu ? (
@@ -101,7 +101,7 @@ export default function PageNav({
                     )}
 
                     {customPath?.map((p) => (
-                        <li className="capitalize" key={p}>
+                        <li className="capitalize body" key={p}>
                             {p}
                         </li>
                     ))}
@@ -128,7 +128,9 @@ export default function PageNav({
                                             void handleSwitchFacility(facility);
                                         }}
                                     >
-                                        <label>{facility.name}</label>
+                                        <label className="body">
+                                            {facility.name}
+                                        </label>
                                     </li>
                                 ))}
                             </ul>
@@ -138,7 +140,7 @@ export default function PageNav({
             ) : (
                 <div className="flex flex-row items-center gap-2 px-6 py-4">
                     <ULIComponent icon={BuildingOffice2Icon} />
-                    <label className="font-semibold">
+                    <label className="font-semibold body">
                         {user?.facility_name}
                     </label>
                 </div>

--- a/frontend/src/Components/ResourcesSideBar.tsx
+++ b/frontend/src/Components/ResourcesSideBar.tsx
@@ -1,26 +1,13 @@
-import {
-    OpenContentProvider,
-    ResourceCategory,
-    ServerResponse
-} from '@/common';
-import Error from '@/Pages/Error';
-import useSWR from 'swr';
+import { OpenContentProvider, ResourceCategory } from '@/common';
 import StaticContentCard from './StaticContentCard';
 import ResourcesCategoryCard from './ResourcesCategoryCard';
-import { AxiosError } from 'axios';
+import { useLoaderData } from 'react-router-dom';
 
-interface ResourcesSideBarProps {
-    providers: OpenContentProvider[];
-}
-export default function ResourcesSideBar({ providers }: ResourcesSideBarProps) {
-    const { data, isLoading, error } = useSWR<
-        ServerResponse<ResourceCategory>,
-        AxiosError
-    >('/api/left-menu');
-
-    if (isLoading) return <div>Loading...</div>;
-    if (error) return <Error />;
-    const categoryData = data?.data as ResourceCategory[];
+export default function ResourcesSideBar() {
+    const { providers, resources } = useLoaderData() as {
+        providers: OpenContentProvider[];
+        resources: ResourceCategory[];
+    };
     const getUrl = (prov: OpenContentProvider): string => {
         switch (prov.name.toLowerCase()) {
             case 'kiwix':
@@ -31,7 +18,7 @@ export default function ResourcesSideBar({ providers }: ResourcesSideBarProps) {
         return '/open-content/libraries';
     };
     return (
-        <div className="w-[409px] min-[1400px]:min-w-[409px] bg-background py-4 px-9">
+        <div className="min-[1400px]:min-w-[300px] bg-background border-l border-grey-1">
             <div className="p-4 space-y-4">
                 <h2>Open Content</h2>
                 {providers?.map((provider: OpenContentProvider) => {
@@ -51,7 +38,7 @@ export default function ResourcesSideBar({ providers }: ResourcesSideBarProps) {
             <div className="p-4 space-y-4">
                 <h2>Resources</h2>
                 <div className="flex flex-col gap-4">
-                    {categoryData?.map(
+                    {resources?.map(
                         (category: ResourceCategory, index: number) => {
                             return (
                                 <ResourcesCategoryCard

--- a/frontend/src/Components/VideoContent.tsx
+++ b/frontend/src/Components/VideoContent.tsx
@@ -53,56 +53,51 @@ export default function VideoContent() {
     };
 
     return (
-        <div>
-            <div className="flex flex-col space-y-6 overflow-x-auto rounded-lg p-4 px-8">
-                <h1>Videos</h1>
-                <div className="flex justify-between">
-                    <div className="flex flex-row gap-x-2">
-                        <SearchBar
-                            searchTerm={searchTerm}
-                            changeCallback={handleChange}
-                        />
-                        <DropdownControl
-                            label="Order by"
-                            setState={setSortQuery}
-                            enumType={{
-                                'Title (A-Z)': 'title ASC',
-                                'Title (Z-A)': 'title DESC',
-                                'Date Added ↓': 'created_at DESC',
-                                'Date Added ↑': 'created_at ASC',
-                                Favorited: 'favorited'
-                            }}
-                        />
-                    </div>
-                </div>
-                <div className="grid grid-cols-4 gap-6">
-                    {videoData.map((video) => (
-                        <VideoCard
-                            key={video.id}
-                            video={video}
-                            mutate={mutate}
-                            role={UserRole.Student}
-                        />
-                    ))}
-                </div>
-                {!isLoading && !error && meta && (
-                    <div className="flex justify-center">
-                        <Pagination
-                            meta={meta}
-                            setPage={setPageQuery}
-                            setPerPage={handleSetPerPage}
-                        />
-                    </div>
-                )}
-                {error && (
-                    <span className="text-center text-error">
-                        Failed to load videos.
-                    </span>
-                )}
-                {!isLoading && !error && videoData.length === 0 && (
-                    <span className="text-center text-warning">No results</span>
-                )}
+        <div className="flex flex-col gap-8">
+            <div className="flex flex-row gap-4">
+                <SearchBar
+                    searchTerm={searchTerm}
+                    changeCallback={handleChange}
+                />
+                <DropdownControl
+                    label="Order by"
+                    setState={setSortQuery}
+                    enumType={{
+                        'Title (A-Z)': 'title ASC',
+                        'Title (Z-A)': 'title DESC',
+                        'Date Added ↓': 'created_at DESC',
+                        'Date Added ↑': 'created_at ASC',
+                        Favorited: 'favorited'
+                    }}
+                />
             </div>
+            <div className="grid grid-cols-4 gap-6">
+                {videoData.map((video) => (
+                    <VideoCard
+                        key={video.id}
+                        video={video}
+                        mutate={mutate}
+                        role={UserRole.Student}
+                    />
+                ))}
+            </div>
+            {!isLoading && !error && meta && (
+                <div className="flex justify-center">
+                    <Pagination
+                        meta={meta}
+                        setPage={setPageQuery}
+                        setPerPage={handleSetPerPage}
+                    />
+                </div>
+            )}
+            {error && (
+                <span className="text-center text-error">
+                    Failed to load videos.
+                </span>
+            )}
+            {!isLoading && !error && videoData.length === 0 && (
+                <span className="text-center text-warning">No results</span>
+            )}
         </div>
     );
 }

--- a/frontend/src/Components/cards/OpenContentCard.tsx
+++ b/frontend/src/Components/cards/OpenContentCard.tsx
@@ -1,0 +1,34 @@
+import { OpenContentFavorite, OpenContentItem } from '@/common';
+import { useNavigate } from 'react-router-dom';
+
+export default function OpenContentCardRow({
+    content
+}: {
+    content: OpenContentItem | OpenContentFavorite;
+}) {
+    const navigate = useNavigate();
+    function redirectToViewer() {
+        if ('url' in content) {
+            if (content.type === 'video') {
+                navigate(`/viewer/videos/${content.content_id}`);
+            } else if (content.type === 'library') {
+                navigate(`/viewer/libraries/${content.content_id}`);
+            }
+        }
+    }
+
+    return (
+        <div
+            className="card flex flex-row w-full gap-3 px-4 py-2"
+            onClick={redirectToViewer}
+        >
+            <div className="w-[100px]">
+                <img
+                    className="h-12 mx-auto object-contain"
+                    src={content.thumbnail_url ?? ''}
+                ></img>
+            </div>
+            <h3 className="my-auto w-full">{content.name ?? 'Untitled'}</h3>
+        </div>
+    );
+}

--- a/frontend/src/Components/cards/OpenContentCard.tsx
+++ b/frontend/src/Components/cards/OpenContentCard.tsx
@@ -8,13 +8,14 @@ export default function OpenContentCardRow({
 }) {
     const navigate = useNavigate();
     function redirectToViewer() {
-        if ('url' in content) {
-            if (content.type === 'video') {
-                navigate(`/viewer/videos/${content.content_id}`);
-            } else if (content.type === 'library') {
-                navigate(`/viewer/libraries/${content.content_id}`);
-            }
-        }
+        const isFavorite = !('url' in content);
+        const type = isFavorite ? content.content_type : content.type;
+        const basePath =
+            type === 'video'
+                ? `/viewer/videos/${content.content_id}`
+                : `/viewer/libraries/${content.content_id}`;
+
+        navigate(basePath);
     }
 
     return (

--- a/frontend/src/Components/dashboard/CurrentlyEnrolledCourses.tsx
+++ b/frontend/src/Components/dashboard/CurrentlyEnrolledCourses.tsx
@@ -1,0 +1,29 @@
+import { CurrentEnrollment, StudentDashboardJoin } from '@/common';
+import CurrentlyEnrolledClass from '../CurrentlyEnrolledClass';
+
+export default function CurrentlyEnrolledCourses({
+    userData
+}: {
+    userData: StudentDashboardJoin;
+}) {
+    return (
+        <div className="mt-3 bg-base-teal p-6 card">
+            <div className="flex flex-col gap-3">
+                {userData.enrollments ? (
+                    userData?.enrollments?.map(
+                        (course: CurrentEnrollment, index: number) => (
+                            <CurrentlyEnrolledClass
+                                course={course}
+                                key={index}
+                            />
+                        )
+                    )
+                ) : (
+                    <p className="body-small">
+                        You are currently not enrolled in any courses.
+                    </p>
+                )}
+            </div>
+        </div>
+    );
+}

--- a/frontend/src/Components/dashboard/ExploreCourseCatalogCard.tsx
+++ b/frontend/src/Components/dashboard/ExploreCourseCatalogCard.tsx
@@ -1,0 +1,30 @@
+import {
+    ArrowRightIcon,
+    BuildingStorefrontIcon
+} from '@heroicons/react/24/outline';
+import { Link } from 'react-router-dom';
+const ExploreCourseCatalogCard = () => {
+    return (
+        <div className="card card-compact bg-inner-background relative">
+            <figure className="h-[124px] bg-teal-3">
+                <BuildingStorefrontIcon className="h-20 text-background" />
+            </figure>
+            <div className="card-body gap-0.5">
+                <h3 className="card-title text-sm">Explore Course Catalog</h3>
+                <p className="body-small line-clamp-4">
+                    Looking for more content to engage with? Browse courses
+                    offered at your facility.
+                </p>
+                <Link
+                    className="flex flex-row gap-1 body-small text-teal-3 mt-2"
+                    to={`/course-catalog`}
+                >
+                    Explore courses
+                    <ArrowRightIcon className="w-4" />
+                </Link>
+            </div>
+        </div>
+    );
+};
+
+export default ExploreCourseCatalogCard;

--- a/frontend/src/Components/dashboard/PopularCoursesCard.tsx
+++ b/frontend/src/Components/dashboard/PopularCoursesCard.tsx
@@ -1,0 +1,33 @@
+import { StudentDashboardJoin } from '@/common';
+import { AcademicCapIcon } from '@heroicons/react/24/outline';
+
+export default function PopularCoursesCard({
+    userData
+}: {
+    userData: StudentDashboardJoin;
+}) {
+    return (
+        <div
+            className={`card card-compact bg-inner-background overflow-hidden relative`}
+        >
+            <div className="card-body gap-0.5">
+                <h3 className="card-title text-sm">
+                    Popular Courses on UnlockEd
+                </h3>
+                <ul className="space-y-3 mt-3">
+                    {userData.top_courses.map((name: string, idx: number) => {
+                        return (
+                            <li
+                                className="body-small flex flex-row gap-2 content-center"
+                                key={idx}
+                            >
+                                <AcademicCapIcon className="w-4" />
+                                <p className="line-clamp-1">{name}</p>
+                            </li>
+                        );
+                    })}
+                </ul>
+            </div>
+        </div>
+    );
+}

--- a/frontend/src/Components/dashboard/ResidentRecentCourses.tsx
+++ b/frontend/src/Components/dashboard/ResidentRecentCourses.tsx
@@ -1,0 +1,26 @@
+import { RecentCourse, StudentDashboardJoin } from '@/common';
+import ExploreCourseCatalogCard from './ExploreCourseCatalogCard';
+import CourseCard from '../EnrolledCourseCard';
+import PopularCoursesCard from './PopularCoursesCard';
+
+export default function ResidentRecentCourses({
+    userData
+}: {
+    userData: StudentDashboardJoin;
+}) {
+    return (
+        <div
+            className={`gap-5 grid grid-cols-3 ${userData.recent_courses.length < 2 ? '!grid-cols-2' : ''}`}
+        >
+            {userData?.recent_courses.map(
+                (course: RecentCourse, index: number) => {
+                    return <CourseCard course={course} recent key={index} />;
+                }
+            )}
+            {userData.recent_courses.length < 3 && <ExploreCourseCatalogCard />}
+            {userData.recent_courses.length < 2 && (
+                <PopularCoursesCard userData={userData} />
+            )}
+        </div>
+    );
+}

--- a/frontend/src/Components/dashboard/ResidentWeeklyActivityTable.tsx
+++ b/frontend/src/Components/dashboard/ResidentWeeklyActivityTable.tsx
@@ -1,0 +1,52 @@
+import { CurrentEnrollment, StudentDashboardJoin } from '@/common';
+import convertSeconds from '../ConvertSeconds';
+
+export default function ResidentWeeklyActivityTable({
+    userData
+}: {
+    userData: StudentDashboardJoin;
+}) {
+    return (
+        <div className="w-1/2 h-[254px] bg-base-teal card">
+            <h2 className="mt-4 ml-4">Learning Time</h2>
+            <div className="px-4">
+                <table className="w-full">
+                    <thead>
+                        <tr className="flex flex-row justify-between border border-x-0 border-t-0 mt-2">
+                            <th className="body text-grey-4">Course Name</th>
+                            <th className="body text-grey-4">Hours Spent</th>
+                        </tr>
+                    </thead>
+                    <tbody className="flex flex-col gap-4 mt-4 overflow-auto h-36 scrollbar">
+                        {userData.enrollments ? (
+                            userData?.enrollments?.map(
+                                (course: CurrentEnrollment, index: number) => {
+                                    const totalTime = convertSeconds(
+                                        course.total_activity_time
+                                    );
+                                    return (
+                                        <tr
+                                            className="flex flex-row justify-between mr-3"
+                                            key={index}
+                                        >
+                                            <td className="body-small">
+                                                {course.name}
+                                            </td>
+                                            <td className="body-small">
+                                                {totalTime.number +
+                                                    ' ' +
+                                                    totalTime.label}
+                                            </td>
+                                        </tr>
+                                    );
+                                }
+                            )
+                        ) : (
+                            <p className="body-small">No activity to show.</p>
+                        )}
+                    </tbody>
+                </table>
+            </div>
+        </div>
+    );
+}

--- a/frontend/src/Components/dashboard/ResourcesSection.tsx
+++ b/frontend/src/Components/dashboard/ResourcesSection.tsx
@@ -1,0 +1,3 @@
+export default function ResourcesSection() {
+    return <div className="card card-row-padding"></div>;
+}

--- a/frontend/src/Components/dashboard/index.ts
+++ b/frontend/src/Components/dashboard/index.ts
@@ -1,0 +1,6 @@
+export { default as PopularCoursesCard } from './PopularCoursesCard';
+export { default as ExploreCourseCatalogCard } from './ExploreCourseCatalogCard';
+export { default as ResidentWeeklyActivityTable } from './ResidentWeeklyActivityTable';
+export { default as CurrentlyEnrolledCourses } from './CurrentlyEnrolledCourses';
+export { default as ResidentRecentCourses } from './ResidentRecentCourses';
+export { default as ResourcesSection } from './ResourcesSection';

--- a/frontend/src/Pages/Favorites.tsx
+++ b/frontend/src/Pages/Favorites.tsx
@@ -30,8 +30,7 @@ export default function FavoritesPage() {
     };
 
     return (
-        <div className="w-full p-8 ">
-            My Favorites
+        <div className="flex flex-col gap-8">
             <div className="grid grid-cols-4 gap-6">
                 {favorites.map((favorite) => (
                     <FavoriteCard
@@ -53,7 +52,7 @@ export default function FavoritesPage() {
                 <p>No favorites found.</p>
             )}
             {!isLoading && !error && meta && (
-                <div className="flex justify-center mt-4">
+                <div className="flex justify-center">
                     <Pagination
                         meta={meta}
                         setPage={setPageQuery}

--- a/frontend/src/Pages/LibraryViewer.tsx
+++ b/frontend/src/Pages/LibraryViewer.tsx
@@ -21,7 +21,7 @@ export default function LibraryViewer() {
                 )) as ServerResponseOne<Library>;
                 if (resp.success) {
                     setPathVal([
-                        { path_id: ':library_name', value: resp.data.name }
+                        { path_id: ':library_name', value: resp.data.title }
                     ]);
                 }
                 const response = await fetch(

--- a/frontend/src/Pages/OpenContentLevelDashboard.tsx
+++ b/frontend/src/Pages/OpenContentLevelDashboard.tsx
@@ -1,0 +1,82 @@
+import {
+    OpenContentFavorite,
+    OpenContentItem,
+    ResourceCategory
+} from '@/common';
+import OpenContentCard from '@/Components/cards/OpenContentCard';
+import ResourcesCategoryCard from '@/Components/ResourcesCategoryCard';
+import { useAuth } from '@/useAuth';
+import { useLoaderData } from 'react-router-dom';
+
+export default function OpenContentLevelDashboard() {
+    const { user } = useAuth();
+    const { resources, topUserContent, topFacilityContent, favorites } =
+        useLoaderData() as {
+            resources: ResourceCategory[];
+            topUserContent: OpenContentItem[];
+            topFacilityContent: OpenContentItem[];
+            favorites: OpenContentFavorite[];
+        };
+
+    return (
+        <div className="flex flex-row h-full">
+            {/* main section */}
+            <div className="w-full flex flex-col gap-6 px-6 pb-4">
+                <h1 className="text-5xl">
+                    Hi, {user?.name_first ?? 'Student'}!
+                </h1>
+                <h2> Pick Up Where You Left Off</h2>
+                <div className="grid grid-cols-2 gap-6">
+                    <div className="card card-row-padding flex flex-col gap-3">
+                        <h2>Your Top Open Content</h2>
+                        {topUserContent.map((item: OpenContentItem) => {
+                            return (
+                                <OpenContentCard
+                                    key={item.content_id}
+                                    content={item}
+                                />
+                            );
+                        })}
+                    </div>
+                    <div className="card card-row-padding flex flex-col gap-3">
+                        <h2>Popular Open Content</h2>
+                        {topFacilityContent.map((item: OpenContentItem) => {
+                            return (
+                                <OpenContentCard
+                                    key={item.content_id}
+                                    content={item}
+                                />
+                            );
+                        })}
+                    </div>
+                </div>
+                <h2>Resources</h2>
+                <div className="card card-row-padding overflow-x-scroll no-scrollbar">
+                    {resources.map((resource: ResourceCategory) => (
+                        <div key={resource.id} className="w-[252px]">
+                            <ResourcesCategoryCard category={resource} />
+                        </div>
+                    ))}
+                </div>
+            </div>
+            {/* right sidebar */}
+            <div className="min-w-[300px] border-l border-grey-1 flex flex-col gap-6 px-6 py-4">
+                <h2>Favorites</h2>
+                <div className="space-y-3 w-full">
+                    {favorites ? (
+                        favorites.map((favorite: OpenContentFavorite) => {
+                            return (
+                                <OpenContentCard
+                                    key={favorite.content_id}
+                                    content={favorite}
+                                />
+                            );
+                        })
+                    ) : (
+                        <div>No Favorites</div>
+                    )}
+                </div>
+            </div>
+        </div>
+    );
+}

--- a/frontend/src/Pages/OpenContentLevelDashboard.tsx
+++ b/frontend/src/Pages/OpenContentLevelDashboard.tsx
@@ -1,15 +1,19 @@
 import {
     OpenContentFavorite,
     OpenContentItem,
-    ResourceCategory
+    ResourceCategory,
+    UserRole
 } from '@/common';
 import OpenContentCard from '@/Components/cards/OpenContentCard';
 import ResourcesCategoryCard from '@/Components/ResourcesCategoryCard';
+import ULIComponent from '@/Components/ULIComponent';
 import { useAuth } from '@/useAuth';
-import { useLoaderData } from 'react-router-dom';
+import { ArrowTopRightOnSquareIcon } from '@heroicons/react/24/outline';
+import { useLoaderData, useNavigate } from 'react-router-dom';
 
 export default function OpenContentLevelDashboard() {
     const { user } = useAuth();
+    const navigate = useNavigate();
     const { resources, topUserContent, topFacilityContent, favorites } =
         useLoaderData() as {
             resources: ResourceCategory[];
@@ -17,6 +21,14 @@ export default function OpenContentLevelDashboard() {
             topFacilityContent: OpenContentItem[];
             favorites: OpenContentFavorite[];
         };
+
+    function navigateToOpenContent() {
+        if (user?.role == UserRole.Student) {
+            navigate(`/open-content/libraries`);
+        } else {
+            navigate(`/open-content-management/libraries`);
+        }
+    }
 
     return (
         <div className="flex flex-row h-full">
@@ -37,6 +49,19 @@ export default function OpenContentLevelDashboard() {
                                 />
                             );
                         })}
+                        {topUserContent.length < 5 && (
+                            <div
+                                className="card px-4 py-2 flex flex-row gap-2 items-center"
+                                onClick={navigateToOpenContent}
+                            >
+                                <ULIComponent
+                                    tooltipClassName="h-12 flex items-center"
+                                    iconClassName="w-5 h-5"
+                                    icon={ArrowTopRightOnSquareIcon}
+                                />
+                                <h3>Explore open content offered</h3>
+                            </div>
+                        )}
                     </div>
                     <div className="card card-row-padding flex flex-col gap-3">
                         <h2>Popular Open Content</h2>

--- a/frontend/src/Pages/StudentDashboard.tsx
+++ b/frontend/src/Pages/StudentDashboard.tsx
@@ -1,28 +1,18 @@
-import CourseCard from '@/Components/EnrolledCourseCard';
-import CurrentlyEnrolledClass from '@/Components/CurrentlyEnrolledClass';
 import { isAdministrator, useAuth } from '@/useAuth';
 import useSWR from 'swr';
-import convertSeconds from '@/Components/ConvertSeconds';
-import ResourcesSideBar from '@/Components/ResourcesSideBar';
 import WeekActivityChart from '@/Components/WeeklyActivity';
 import Error from './Error';
-import { Link, useLoaderData, useNavigate } from 'react-router-dom';
-import {
-    AcademicCapIcon,
-    ArrowRightIcon,
-    BuildingStorefrontIcon
-} from '@heroicons/react/24/outline';
-import {
-    CurrentEnrollment,
-    OpenContentProvider,
-    RecentCourse,
-    ServerResponse,
-    StudentDashboardJoin
-} from '@/common';
+import { useNavigate } from 'react-router-dom';
+import { ServerResponse, StudentDashboardJoin } from '@/common';
 import { AxiosError } from 'axios';
+import {
+    CurrentlyEnrolledCourses,
+    ResidentRecentCourses,
+    ResidentWeeklyActivityTable
+} from '@/Components/dashboard';
+import ResourcesSideBar from '@/Components/ResourcesSideBar';
 
 export default function StudentDashboard() {
-    const loaderData = useLoaderData() as OpenContentProvider[];
     const { user } = useAuth();
     const navigate = useNavigate();
     if (!user) {
@@ -40,175 +30,29 @@ export default function StudentDashboard() {
     if (isLoading) return <div>Loading...</div>;
     if (error) return <Error />;
 
-    const ExploreCourseCatalogCard = () => {
-        return (
-            <div className="card card-compact bg-inner-background relative">
-                <figure className="h-[124px] bg-teal-3">
-                    <BuildingStorefrontIcon className="h-20 text-background" />
-                </figure>
-                <div className="card-body gap-0.5">
-                    <h3 className="card-title text-sm">
-                        Explore Course Catalog
-                    </h3>
-                    <p className="body-small line-clamp-4">
-                        Looking for more content to engage with? Browse courses
-                        offered at your facility.
-                    </p>
-                    <Link
-                        to="/course-catalog"
-                        className="flex flex-row gap-1 body-small text-teal-3 mt-2"
-                    >
-                        Explore courses
-                        <ArrowRightIcon className="w-4" />
-                    </Link>
-                </div>
-            </div>
-        );
-    };
-
-    const PopularCoursesCard = () => {
-        return (
-            <div
-                className={`card card-compact bg-inner-background overflow-hidden relative`}
-            >
-                <div className="card-body gap-0.5">
-                    <h3 className="card-title text-sm">
-                        Popular Courses on UnlockEd
-                    </h3>
-                    <ul className="space-y-3 mt-3">
-                        {userData.top_courses.map(
-                            (name: string, idx: number) => {
-                                return (
-                                    <li
-                                        className="body-small flex flex-row gap-2 content-center"
-                                        key={idx}
-                                    >
-                                        <AcademicCapIcon className="w-4" />
-                                        <p className="line-clamp-1">{name}</p>
-                                    </li>
-                                );
-                            }
-                        )}
-                    </ul>
-                </div>
-            </div>
-        );
-    };
-
     return (
-        <div className="flex w-full">
-            <div className="px-8 py-4">
-                <h1 className="text-5xl">Hi, {user?.name_first}!</h1>
-                <h2 className="mt-7"> Pick Up Where You Left Off</h2>
-                <div className="mt-3 bg-base-teal p-6 card">
-                    <div
-                        className={`gap-5 grid grid-cols-3 ${userData.recent_courses.length < 2 ? '!grid-cols-2' : ''}`}
-                    >
-                        {userData?.recent_courses.map(
-                            (course: RecentCourse, index: number) => {
-                                return (
-                                    <CourseCard
-                                        course={course}
-                                        recent
-                                        key={index}
-                                    />
-                                );
-                            }
-                        )}
-                        {userData.recent_courses.length < 3 && (
-                            <ExploreCourseCatalogCard />
-                        )}
-                        {userData.recent_courses.length < 2 && (
-                            <PopularCoursesCard />
-                        )}
-                    </div>
+        <div className="flex flex-row">
+            {/* main section */}
+            <div className="w-full flex flex-col gap-6 px-6 pb-4">
+                <h1 className="text-5xl">
+                    Hi, {user.name_first ?? 'Student'}!
+                </h1>
+                <h2> Pick Up Where You Left Off</h2>
+                <div className="card card-row-padding">
+                    <ResidentRecentCourses userData={userData} />
                 </div>
-                <div className="flex flex-row gap-12 mt-12">
+                <div className="flex flex-row gap-12">
                     <div className="w-1/2 h-[254px] bg-base-teal card">
                         <h2 className="mt-4 ml-4">My Activity</h2>
                         <WeekActivityChart data={userData?.week_activity} />
                     </div>
-                    <div className="w-1/2 h-[254px] bg-base-teal card">
-                        <h2 className="mt-4 ml-4">Learning Time</h2>
-                        <div className="px-4">
-                            <table className="w-full">
-                                <thead>
-                                    <tr className="flex flex-row justify-between border border-x-0 border-t-0 mt-2">
-                                        <th className="body text-grey-4">
-                                            Course Name
-                                        </th>
-                                        <th className="body text-grey-4">
-                                            Hours Spent
-                                        </th>
-                                    </tr>
-                                </thead>
-                                <tbody className="flex flex-col gap-4 mt-4 overflow-auto h-36 scrollbar">
-                                    {!error &&
-                                    !isLoading &&
-                                    userData.enrollments ? (
-                                        userData?.enrollments?.map(
-                                            (
-                                                course: CurrentEnrollment,
-                                                index: number
-                                            ) => {
-                                                const totalTime =
-                                                    convertSeconds(
-                                                        course.total_activity_time
-                                                    );
-                                                return (
-                                                    <tr
-                                                        className="flex flex-row justify-between mr-3"
-                                                        key={index}
-                                                    >
-                                                        <td className="body-small">
-                                                            {course.name}
-                                                        </td>
-                                                        <td className="body-small">
-                                                            {totalTime.number +
-                                                                ' ' +
-                                                                totalTime.label}
-                                                        </td>
-                                                    </tr>
-                                                );
-                                            }
-                                        )
-                                    ) : (
-                                        <tr className="body-small">
-                                            <td className="text-center">
-                                                No activity to show.
-                                            </td>
-                                        </tr>
-                                    )}
-                                </tbody>
-                            </table>
-                        </div>
-                    </div>
+                    <ResidentWeeklyActivityTable userData={userData} />
                 </div>
-                <h2 className="mt-12">Currently Enrolled Classes</h2>
-                <div className="mt-3 bg-base-teal p-6 card">
-                    {!error && !isLoading && (
-                        <div className="flex flex-col gap-3">
-                            {userData.enrollments ? (
-                                userData?.enrollments?.map(
-                                    (course: CurrentEnrollment, index) => (
-                                        <CurrentlyEnrolledClass
-                                            course={course}
-                                            key={index}
-                                        />
-                                    )
-                                )
-                            ) : (
-                                <p className="body-small">
-                                    You are currently not enrolled in any
-                                    courses.
-                                </p>
-                            )}
-                        </div>
-                    )}
-                </div>
+                <h2>Currently Enrolled Classes</h2>
+                <CurrentlyEnrolledCourses userData={userData} />
             </div>
-            <div className="min-w-px bg-grey-1"></div>
-            <ResourcesSideBar providers={loaderData} />
+            {/* right sidebar */}
+            <ResourcesSideBar />
         </div>
     );
 }

--- a/frontend/src/Pages/VideoManagement.tsx
+++ b/frontend/src/Pages/VideoManagement.tsx
@@ -100,10 +100,9 @@ export default function VideoManagement() {
 
     return (
         <div>
-            <div className="flex flex-col space-y-6 overflow-x-auto rounded-lg p-4 px-8">
-                <h1>Video Management</h1>
+            <div className="flex flex-col gap-8">
                 <div className="flex justify-between">
-                    <div className="flex flex-row gap-x-2">
+                    <div className="flex flex-row gap-4">
                         <SearchBar
                             searchTerm={searchTerm}
                             changeCallback={handleChange}
@@ -120,7 +119,7 @@ export default function VideoManagement() {
                         />
                     </div>
                     <button
-                        className="button"
+                        className="button items-center"
                         onClick={() => addVideoModal.current?.showModal()}
                     >
                         <PlusCircleIcon className="w-4 my-auto" />

--- a/frontend/src/app.tsx
+++ b/frontend/src/app.tsx
@@ -133,18 +133,6 @@ const router = createBrowserRouter([
                         loader: checkRole
                     },
                     {
-                        path: 'student-dashboard',
-                        element: <StudentDashboard />,
-                        loader: getRightSidebarData,
-                        handle: { title: 'Dashboard', path: ['dashboard'] }
-                    },
-                    {
-                        path: 'open-content-dashboard',
-                        element: <OpenContentLevelDashboard />,
-                        loader: getOpenContentDashboardData,
-                        handle: { title: 'Dashboard', path: ['dashboard'] }
-                    },
-                    {
                         path: 'consent',
                         element: <Consent />,
                         handle: {
@@ -162,6 +150,15 @@ const router = createBrowserRouter([
                             />
                         ),
                         children: [
+                            {
+                                path: 'open-content-dashboard',
+                                element: <OpenContentLevelDashboard />,
+                                loader: getOpenContentDashboardData,
+                                handle: {
+                                    title: 'Dashboard',
+                                    path: ['dashboard']
+                                }
+                            },
                             {
                                 path: 'open-content',
                                 element: <OpenContent />,
@@ -233,6 +230,15 @@ const router = createBrowserRouter([
                         errorElement: <Error />,
                         children: [
                             {
+                                path: 'student-dashboard',
+                                element: <StudentDashboard />,
+                                loader: getRightSidebarData,
+                                handle: {
+                                    title: 'Dashboard',
+                                    path: ['dashboard']
+                                }
+                            },
+                            {
                                 path: 'my-courses',
                                 element: <MyCourses />,
                                 handle: {
@@ -268,6 +274,15 @@ const router = createBrowserRouter([
                         errorElement: <Error />,
                         children: [
                             {
+                                path: 'student-dashboard',
+                                element: <StudentDashboard />,
+                                loader: getRightSidebarData,
+                                handle: {
+                                    title: 'Dashboard',
+                                    path: ['dashboard']
+                                }
+                            },
+                            {
                                 path: 'programs',
                                 element: <Programs />,
                                 loader: getFacilities,
@@ -296,15 +311,6 @@ const router = createBrowserRouter([
                 element: <AuthenticatedLayout />,
                 loader: getFacilities,
                 children: [
-                    {
-                        path: 'admin-dashboard',
-                        element: <AdminDashboard />,
-                        errorElement: <Error />,
-                        handle: {
-                            title: 'Admin Dashboard',
-                            path: ['admin-dashboard']
-                        }
-                    },
                     {
                         path: 'student-management',
                         element: <StudentManagement />,
@@ -341,6 +347,15 @@ const router = createBrowserRouter([
                         ),
                         errorElement: <Error />,
                         children: [
+                            {
+                                path: 'admin-dashboard',
+                                element: <AdminDashboard />,
+                                errorElement: <Error />,
+                                handle: {
+                                    title: 'Admin Dashboard',
+                                    path: ['admin-dashboard']
+                                }
+                            },
                             {
                                 path: 'provider-platform-management',
                                 element: <ProviderPlatformManagement />,
@@ -389,6 +404,15 @@ const router = createBrowserRouter([
                         ),
                         errorElement: <Error />,
                         children: [
+                            {
+                                path: 'open-content-dashboard',
+                                element: <OpenContentLevelDashboard />,
+                                loader: getOpenContentDashboardData,
+                                handle: {
+                                    title: 'Dashboard',
+                                    path: ['dashboard']
+                                }
+                            },
                             {
                                 path: 'open-content-management',
                                 element: <OpenContentManagement />,

--- a/frontend/src/app.tsx
+++ b/frontend/src/app.tsx
@@ -40,7 +40,11 @@ import AuthenticatedLayout from './Layouts/AuthenticatedLayout.tsx';
 import { PathValueProvider } from '@/Context/PathValueCtx';
 import AdminDashboard from './Pages/AdminDashboard.tsx';
 import StudentDashboard from './Pages/StudentDashboard.tsx';
-import { getOpenContentProviders, getFacilities } from './routeLoaders.ts';
+import {
+    getFacilities,
+    getOpenContentDashboardData,
+    getRightSidebarData
+} from './routeLoaders.ts';
 
 import FacilityManagement from '@/Pages/FacilityManagement.tsx';
 
@@ -50,6 +54,7 @@ import VideoContent from './Components/VideoContent.tsx';
 import OpenContentManagement from './Pages/OpenContentManagement.tsx';
 import { FeatureAccess, INIT_KRATOS_LOGIN_FLOW } from './common.ts';
 import FavoritesPage from './Pages/Favorites.tsx';
+import OpenContentLevelDashboard from './Pages/OpenContentLevelDashboard.tsx';
 
 const WithAuth: React.FC = () => {
     return (
@@ -130,7 +135,13 @@ const router = createBrowserRouter([
                     {
                         path: 'student-dashboard',
                         element: <StudentDashboard />,
-                        loader: getOpenContentProviders,
+                        loader: getRightSidebarData,
+                        handle: { title: 'Dashboard', path: ['dashboard'] }
+                    },
+                    {
+                        path: 'open-content-dashboard',
+                        element: <OpenContentLevelDashboard />,
+                        loader: getOpenContentDashboardData,
                         handle: { title: 'Dashboard', path: ['dashboard'] }
                     },
                     {

--- a/frontend/src/common.ts
+++ b/frontend/src/common.ts
@@ -707,9 +707,9 @@ export interface Library {
     description: string | null;
     external_id: string | null;
     id: number;
-    image_url: string | null;
+    thumbnail_url: string | null;
     language: string | null;
-    name: string;
+    title: string;
     open_content_provider_id: number;
     updated_at: string;
     url: string;
@@ -783,4 +783,13 @@ export enum Timezones {
     'america/los_angeles' = 'America/Los_Angeles',
     'america/denver' = 'America/Denver',
     'america/phoenix' = 'America/Phoenix'
+}
+
+export interface OpenContentItem {
+    name: string;
+    url: string;
+    thumbnail_url: string | null;
+    open_content_provider_id: number;
+    content_id: number;
+    type: string;
 }

--- a/frontend/src/css/app.css
+++ b/frontend/src/css/app.css
@@ -30,6 +30,9 @@
     .card {
         @apply shadow-md rounded-lg border border-black border-opacity-[10%] bg-base-teal;
     }
+    .card-row-padding {
+        @apply px-6 py-4;
+    }
     .card-h-padding {
         @apply mt-4 ml-4;
     }
@@ -75,6 +78,15 @@
     .scrollbar {
         scrollbar-width: thin;
         scrollbar-color: var(--grey-2) transparent;
+    }
+    /* Hide scrollbar for Chrome, Safari and Opera */
+    .no-scrollbar::-webkit-scrollbar {
+        display: none;
+    }
+    /* Hide scrollbar for IE, Edge and Firefox */
+    .no-scrollbar {
+        -ms-overflow-style: none; /* IE and Edge */
+        scrollbar-width: none; /* Firefox */
     }
 }
 

--- a/frontend/src/routeLoaders.ts
+++ b/frontend/src/routeLoaders.ts
@@ -1,20 +1,60 @@
 import { json, LoaderFunction } from 'react-router-dom';
 import {
+    OpenContentFavorite,
     Facility,
+    OpenContentItem,
     OpenContentProvider,
-    ServerResponse,
-    ServerResponseMany
+    ResourceCategory,
+    ServerResponse
 } from './common';
 import API from './api/api';
+import { fetchUser } from './useAuth';
 
-export const getOpenContentProviders: LoaderFunction = async () => {
-    const resp = (await API.get(
-        `open-content`
-    )) as ServerResponseMany<OpenContentProvider>;
-    if (resp.success) {
-        return json<OpenContentProvider[]>(resp.data);
-    }
-    return json<OpenContentProvider[]>([]);
+export const getOpenContentDashboardData: LoaderFunction = async () => {
+    const user = await fetchUser();
+    const [resourcesResp, userContentResp, facilityContentResp, favoritesResp] =
+        await Promise.all([
+            API.get(`left-menu`),
+            API.get(`open-content/activity/${user?.id}`),
+            API.get(`open-content/activity`),
+            API.get(`open-content/favorites`)
+        ]);
+
+    const resourcesData = resourcesResp.success
+        ? (resourcesResp.data as ResourceCategory[])
+        : [];
+    const topUserOpenContent = userContentResp.success
+        ? (userContentResp.data as OpenContentItem[])
+        : [];
+    const topFacilityOpenContent = facilityContentResp.success
+        ? (facilityContentResp.data as OpenContentItem[])
+        : [];
+    const favoriteOpenContent = favoritesResp.success
+        ? (favoritesResp.data as OpenContentFavorite[])
+        : [];
+
+    return json({
+        resources: resourcesData,
+        topUserContent: topUserOpenContent,
+        topFacilityContent: topFacilityOpenContent,
+        favorites: favoriteOpenContent
+    });
+};
+
+export const getRightSidebarData: LoaderFunction = async () => {
+    const [resourcesResp, openContentResp] = await Promise.all([
+        API.get(`left-menu`),
+        API.get(`open-content`)
+    ]);
+
+    const resourcesData = resourcesResp.success
+        ? (resourcesResp.data as ResourceCategory[])
+        : [];
+    const openContentData = openContentResp.success
+        ? (openContentResp.data as OpenContentProvider[])
+        : [];
+
+    return json({ resources: resourcesData, providers: openContentData });
 };
 
 export const getFacilities: LoaderFunction = async () => {

--- a/frontend/src/routeLoaders.ts
+++ b/frontend/src/routeLoaders.ts
@@ -12,10 +12,11 @@ import { fetchUser } from './useAuth';
 
 export const getOpenContentDashboardData: LoaderFunction = async () => {
     const user = await fetchUser();
+    if (!user) return;
     const [resourcesResp, userContentResp, facilityContentResp, favoritesResp] =
         await Promise.all([
             API.get(`left-menu`),
-            API.get(`open-content/activity/${user?.id}`),
+            API.get(`open-content/activity/${user.id}`),
             API.get(`open-content/activity`),
             API.get(`open-content/favorites`)
         ]);

--- a/frontend/src/useAuth.ts
+++ b/frontend/src/useAuth.ts
@@ -30,9 +30,13 @@ export const getDashboard = (user?: User): string => {
     if (!user) {
         return INIT_KRATOS_LOGIN_FLOW;
     } else {
-        return isAdministrator(user)
-            ? '/admin-dashboard'
-            : '/student-dashboard';
+        if (user.feature_access.includes(FeatureAccess.OpenContentAccess)) {
+            return '/open-content-dashboard';
+        } else {
+            return isAdministrator(user)
+                ? '/admin-dashboard'
+                : '/student-dashboard';
+        }
     }
 };
 


### PR DESCRIPTION
## Description of the change

- Adds open content dashboard ui and corresponding apis to grab data to populate it.
- cleans up some of the open content pages so they all look identical as you navigate through tabs
- cleans up some styling in page nav
- removes components from the dashboard into their own files, starts organizing frontend into folders and adds an `index.ts` file to consolidate exports

- **Related issues**: Closes #491, #492, #494 

## Screenshot(s)

If only open content is turned on, the user will see the open content dashboard. If something else is also turned on, they will see the admin/student dashboard- this will be changed as we add the dashboards for different levels.

<img width="1512" alt="Screenshot 2024-11-25 at 4 31 49 PM" src="https://github.com/user-attachments/assets/b269a5fd-735c-4d9f-85f0-e74fa9efc184">

## Additional context

In sprint planning today I mentioned I would filter the top 5 resources, but I have decided to do that in a different PR since I will have to change the handler and the DB call. This PR just grabs all resources and displays them on the dashboard.