### PR TITLE
Replace Open Content with Knowledge Center

### DIFF
--- a/frontend/src/Components/FeatureLevelCheckboxes.tsx
+++ b/frontend/src/Components/FeatureLevelCheckboxes.tsx
@@ -68,7 +68,7 @@ export default function FeatureLevelCheckboxes({
         <>
             <CheckboxGeneric
                 name="open_content"
-                label="Open Content"
+                label="Knowledge Center"
                 checked={getCheckboxChecked(FeatureAccess.OpenContentAccess)}
                 onChange={handleFeatureToggle}
             />

--- a/frontend/src/Components/Navbar.tsx
+++ b/frontend/src/Components/Navbar.tsx
@@ -77,7 +77,7 @@ export default function Navbar({
                                     FeatureAccess.OpenContentAccess
                                 ) && user.feature_access.length === 1 ? (
                                     <li className="mt-16">
-                                        <Link to="/open-content-dashboard">
+                                        <Link to="/knowledge-center-dashboard">
                                             <ULIComponent icon={HomeIcon} />
                                             Dashboard
                                         </Link>
@@ -96,11 +96,11 @@ export default function Navbar({
                                 ) && (
                                     <>
                                         <li>
-                                            <Link to="/open-content-management/libraries">
+                                            <Link to="/knowledge-center-management/libraries">
                                                 <ULIComponent
                                                     icon={BookOpenIcon}
                                                 />
-                                                Open Content
+                                                Knowledge Center
                                             </Link>
                                         </li>
                                     </>
@@ -175,7 +175,7 @@ export default function Navbar({
                                     FeatureAccess.OpenContentAccess
                                 ) && user.feature_access.length === 1 ? (
                                     <li className="mt-16">
-                                        <Link to="/open-content-dashboard">
+                                        <Link to="/knowledge-center-dashboard">
                                             <ULIComponent icon={HomeIcon} />
                                             Dashboard
                                         </Link>
@@ -224,9 +224,9 @@ export default function Navbar({
                                     FeatureAccess.OpenContentAccess
                                 ) && (
                                     <li>
-                                        <Link to="/open-content/libraries">
+                                        <Link to="/knowledge-center/libraries">
                                             <ULIComponent icon={BookOpenIcon} />
-                                            Open Content
+                                            Knowledge Center
                                         </Link>
                                     </li>
                                 )}

--- a/frontend/src/Components/ResourcesSideBar.tsx
+++ b/frontend/src/Components/ResourcesSideBar.tsx
@@ -11,16 +11,16 @@ export default function ResourcesSideBar() {
     const getUrl = (prov: OpenContentProvider): string => {
         switch (prov.name.toLowerCase()) {
             case 'kiwix':
-                return '/open-content/libraries';
+                return '/knowledge-center/libraries';
             case 'youtube':
-                return '/open-content/videos';
+                return '/knowledge-center/videos';
         }
-        return '/open-content/libraries';
+        return '/knowledge-center/libraries';
     };
     return (
         <div className="min-[1400px]:min-w-[300px] bg-background border-l border-grey-1">
             <div className="p-4 space-y-4">
-                <h2>Open Content</h2>
+                <h2>Knowledge Center</h2>
                 {providers?.map((provider: OpenContentProvider) => {
                     return (
                         <StaticContentCard

--- a/frontend/src/Pages/OpenContent.tsx
+++ b/frontend/src/Pages/OpenContent.tsx
@@ -42,23 +42,23 @@ export default function OpenContent() {
 
     const handlePageChange = (tab: Tab) => {
         setActiveTab(tab);
-        navigate(`/open-content/${String(tab.value).toLowerCase()}`);
+        navigate(`/knowledge-center/${String(tab.value).toLowerCase()}`);
     };
     const handleReturnToAdminView = () => {
         if (currentTabValue === 'favorites') {
-            navigate('/open-content-management/libraries');
+            navigate('/knowledge-center-management/libraries');
         } else if (
             currentTabValue === 'libraries' ||
             currentTabValue === 'videos'
         ) {
-            navigate('/open-content-management/' + currentTabValue);
+            navigate('/knowledge-center-management/' + currentTabValue);
         }
     };
 
     return (
         <div className="px-8 pb-4">
             <div className="flex flex-row justify-between">
-                <h1>Open Content</h1>
+                <h1>Knowledge Center</h1>
                 {user && isAdministrator(user) && (
                     <button
                         className="button border border-primary bg-transparent text-body-text"

--- a/frontend/src/Pages/OpenContentLevelDashboard.tsx
+++ b/frontend/src/Pages/OpenContentLevelDashboard.tsx
@@ -24,9 +24,9 @@ export default function OpenContentLevelDashboard() {
 
     function navigateToOpenContent() {
         if (user?.role == UserRole.Student) {
-            navigate(`/open-content/libraries`);
+            navigate(`/knowledge-center/libraries`);
         } else {
-            navigate(`/open-content-management/libraries`);
+            navigate(`/knowledge-center-management/libraries`);
         }
     }
 
@@ -40,7 +40,7 @@ export default function OpenContentLevelDashboard() {
                 <h2> Pick Up Where You Left Off</h2>
                 <div className="grid grid-cols-2 gap-6">
                     <div className="card card-row-padding flex flex-col gap-3">
-                        <h2>Your Top Open Content</h2>
+                        <h2>Your Content</h2>
                         {topUserContent.map((item: OpenContentItem) => {
                             return (
                                 <OpenContentCard
@@ -59,12 +59,12 @@ export default function OpenContentLevelDashboard() {
                                     iconClassName="w-5 h-5"
                                     icon={ArrowTopRightOnSquareIcon}
                                 />
-                                <h3>Explore open content offered</h3>
+                                <h3>Explore content offered</h3>
                             </div>
                         )}
                     </div>
                     <div className="card card-row-padding flex flex-col gap-3">
-                        <h2>Popular Open Content</h2>
+                        <h2>Popular Knowledge-Center Content</h2>
                         {topFacilityContent.map((item: OpenContentItem) => {
                             return (
                                 <OpenContentCard

--- a/frontend/src/Pages/OpenContentManagement.tsx
+++ b/frontend/src/Pages/OpenContentManagement.tsx
@@ -27,16 +27,18 @@ export default function OpenContentManagement() {
 
     const handlePageChange = (tab: Tab) => {
         setActiveTab(tab);
-        navigate(`/open-content-management/${tab.value}`);
+        navigate(`/knowledge-center-management/${tab.value}`);
     };
 
     return (
         <div className="px-8 pb-4">
             <div className="flex flex-row justify-between">
-                <h1>Open Content Management</h1>
+                <h1>Knowledge Center Management</h1>
                 <button
                     className="button border border-primary bg-transparent text-body-text"
-                    onClick={() => navigate(`/open-content/${activeTab.value}`)}
+                    onClick={() =>
+                        navigate(`/knowledge-center/${activeTab.value}`)
+                    }
                 >
                     Preview Student View
                 </button>

--- a/frontend/src/Pages/VideoManagement.tsx
+++ b/frontend/src/Pages/VideoManagement.tsx
@@ -50,7 +50,7 @@ export default function VideoManagement() {
         return null;
     }
     if (user.role === UserRole.Student) {
-        navigate('/open-content/videos', { replace: true });
+        navigate('/knowledge-center/videos', { replace: true });
     }
 
     const pollVideos = (delay: number) => {
@@ -60,7 +60,6 @@ export default function VideoManagement() {
                 setPolling(false);
                 return;
             }
-            console.log('****polling****');
             delay *= 2;
             setTimeout((delay: number) => pollVideos(delay), delay, delay);
         });

--- a/frontend/src/app.tsx
+++ b/frontend/src/app.tsx
@@ -151,7 +151,7 @@ const router = createBrowserRouter([
                         ),
                         children: [
                             {
-                                path: 'open-content-dashboard',
+                                path: 'knowledge-center-dashboard',
                                 element: <OpenContentLevelDashboard />,
                                 loader: getOpenContentDashboardData,
                                 handle: {
@@ -160,11 +160,11 @@ const router = createBrowserRouter([
                                 }
                             },
                             {
-                                path: 'open-content',
+                                path: 'knowledge-center',
                                 element: <OpenContent />,
                                 handle: {
-                                    title: 'Open Content',
-                                    path: ['open-content', ':kind']
+                                    title: 'Knowledge Center',
+                                    path: ['knowledge-center', ':kind']
                                 },
                                 children: [
                                     {
@@ -173,7 +173,10 @@ const router = createBrowserRouter([
                                         errorElement: <Error />,
                                         handle: {
                                             title: 'Libraries',
-                                            path: ['open-content', 'libraries']
+                                            path: [
+                                                'knowledge-center',
+                                                'libraries'
+                                            ]
                                         }
                                     },
                                     {
@@ -182,7 +185,7 @@ const router = createBrowserRouter([
                                         errorElement: <Error />,
                                         handle: {
                                             title: 'Videos',
-                                            path: ['open-content', 'videos']
+                                            path: ['knowledge-center', 'videos']
                                         }
                                     },
                                     {
@@ -191,7 +194,10 @@ const router = createBrowserRouter([
                                         errorElement: <Error />,
                                         handle: {
                                             title: 'Favorites',
-                                            path: ['open-content', 'favorites']
+                                            path: [
+                                                'knowledge-center',
+                                                'favorites'
+                                            ]
                                         }
                                     }
                                 ]
@@ -405,7 +411,7 @@ const router = createBrowserRouter([
                         errorElement: <Error />,
                         children: [
                             {
-                                path: 'open-content-dashboard',
+                                path: 'knowledge-center-dashboard',
                                 element: <OpenContentLevelDashboard />,
                                 loader: getOpenContentDashboardData,
                                 handle: {
@@ -414,11 +420,11 @@ const router = createBrowserRouter([
                                 }
                             },
                             {
-                                path: 'open-content-management',
+                                path: 'knowledge-center-management',
                                 element: <OpenContentManagement />,
                                 handle: {
-                                    title: 'Open Content Management',
-                                    path: ['open-content-management', ':kind']
+                                    title: 'Knowledge Center',
+                                    path: ['knowledge-center', ':kind']
                                 },
                                 children: [
                                     {
@@ -427,7 +433,10 @@ const router = createBrowserRouter([
                                         errorElement: <Error />,
                                         handle: {
                                             title: 'Libraries',
-                                            path: ['open-content', 'libraries']
+                                            path: [
+                                                'knowledge-center-management',
+                                                'libraries'
+                                            ]
                                         }
                                     },
                                     {
@@ -436,7 +445,7 @@ const router = createBrowserRouter([
                                         handle: {
                                             title: 'Videos',
                                             path: [
-                                                'open-content-management',
+                                                'knowledge-center-management',
                                                 'videos'
                                             ]
                                         }

--- a/frontend/src/common.ts
+++ b/frontend/src/common.ts
@@ -34,8 +34,8 @@ export const providerRoutes = [
 ];
 
 export const openContentRoutes = [
-    'open-content',
-    'open-content-management',
+    'knowledge-center',
+    'knowledge-center-management',
     'viewer'
 ];
 

--- a/frontend/src/useAuth.ts
+++ b/frontend/src/useAuth.ts
@@ -31,7 +31,7 @@ export const getDashboard = (user?: User): string => {
         return INIT_KRATOS_LOGIN_FLOW;
     } else {
         if (user.feature_access.includes(FeatureAccess.OpenContentAccess)) {
-            return '/open-content-dashboard';
+            return '/knowledge-center-dashboard';
         } else {
             return isAdministrator(user)
                 ? '/admin-dashboard'


### PR DESCRIPTION
## Description of the change

Renamed the Open Content page to Knowledge Center, updating the following areas:

Side Navigation:
For Admins, display the link as "Knowledge Center Management".
For Residents, display the link as "Knowledge Center".
Breadcrumb Page Title:
Update the page title in the breadcrumb to reflect the new names:
Admins: "Knowledge Center Management"
Residents: "Knowledge Center"
If possible consider refactoring any file names or types to reflect this change to knowledge center. * We may have an issue with the backend models and database tables and need to discuss if it's worth refactoring that at this point.

- **Related issues**: 
- Closes: #521 

## Screenshot(s)

https://github.com/user-attachments/assets/322da206-61b7-4cb0-b4bd-605f509a3a09

