### PR TITLE
Update Navigation Items for Level 2 Residents & Admins

### DIFF
--- a/frontend/src/Components/FeatureLevelCheckboxes.tsx
+++ b/frontend/src/Components/FeatureLevelCheckboxes.tsx
@@ -70,7 +70,7 @@ export default function FeatureLevelCheckboxes({
         <>
             <CheckboxGeneric
                 name="open_content"
-                label="Open Content"
+                label="Knowledge Center Management"
                 checked={getCheckboxChecked(FeatureAccess.OpenContentAccess)}
                 onChange={handleChange}
             />

--- a/frontend/src/Components/FeatureLevelCheckboxes.tsx
+++ b/frontend/src/Components/FeatureLevelCheckboxes.tsx
@@ -63,7 +63,7 @@ export default function FeatureLevelCheckboxes({
         toaster(resp.message, ToastState.success);
         const user = await fetchUser();
         setUser(user);
-        navigate('/admin-dashboard');
+        navigate('/student-activity');
     };
 
     return (

--- a/frontend/src/Components/Navbar.tsx
+++ b/frontend/src/Components/Navbar.tsx
@@ -73,19 +73,19 @@ export default function Navbar({
                             <>
                                 {/* admin view */}
                                 <li className="mt-16">
-                                    <Link to="/admin-dashboard">
+                                    <Link to="/student-activity">
                                         <ULIComponent icon={HomeIcon} />
-                                        Dashboard
+                                        Student Activity
                                     </Link>
                                 </li>
                                 <li>
-                                    <Link to="/student-management">
+                                    <Link to="/students">
                                         <ULIComponent icon={AcademicCapIcon} />
                                         Students
                                     </Link>
                                 </li>
                                 <li>
-                                    <Link to="/admin-management">
+                                    <Link to="/admins">
                                         <ULIComponent icon={UsersIcon} />
                                         Admins
                                     </Link>
@@ -117,11 +117,11 @@ export default function Navbar({
                                 ) && (
                                     <>
                                         <li>
-                                            <Link to="/provider-platform-management">
+                                            <Link to="/learning-platforms">
                                                 <ULIComponent
                                                     icon={CloudIcon}
                                                 />
-                                                Platforms
+                                                Learning Platforms
                                             </Link>
                                         </li>
                                         <li className="">
@@ -160,9 +160,9 @@ export default function Navbar({
                             <>
                                 {/* student view */}
                                 <li className="mt-16">
-                                    <Link to="/student-dashboard">
+                                    <Link to="/my-learning">
                                         <ULIComponent icon={HomeIcon} />
-                                        Dashboard
+                                        My Learning
                                     </Link>
                                 </li>
                                 {hasFeature(

--- a/frontend/src/Components/Navbar.tsx
+++ b/frontend/src/Components/Navbar.tsx
@@ -96,11 +96,11 @@ export default function Navbar({
                                 ) && (
                                     <>
                                         <li>
-                                            <Link to="/open-content-management/libraries">
+                                            <Link to="/knowledge-center-management/libraries">
                                                 <ULIComponent
                                                     icon={BookOpenIcon}
                                                 />
-                                                Open Content
+                                                Knowledge Center Management
                                             </Link>
                                         </li>
                                     </>
@@ -201,9 +201,9 @@ export default function Navbar({
                                     FeatureAccess.OpenContentAccess
                                 ) && (
                                     <li>
-                                        <Link to="/open-content/libraries">
+                                        <Link to="/knowledge-center/libraries">
                                             <ULIComponent icon={BookOpenIcon} />
-                                            Open Content
+                                            Knowledge Center
                                         </Link>
                                     </li>
                                 )}

--- a/frontend/src/Components/ResourcesSideBar.tsx
+++ b/frontend/src/Components/ResourcesSideBar.tsx
@@ -24,16 +24,16 @@ export default function ResourcesSideBar({ providers }: ResourcesSideBarProps) {
     const getUrl = (prov: OpenContentProvider): string => {
         switch (prov.name.toLowerCase()) {
             case 'kiwix':
-                return '/open-content/libraries';
+                return '/knowledge-center/libraries';
             case 'youtube':
-                return '/open-content/videos';
+                return '/knowledge-center/videos';
         }
-        return '/open-content/libraries';
+        return '/knowledge-center/libraries';
     };
     return (
         <div className="w-[409px] min-[1400px]:min-w-[409px] bg-background py-4 px-9">
             <div className="p-4 space-y-4">
-                <h2>Open Content</h2>
+                <h2>Knowledge Center</h2>
                 {providers?.map((provider: OpenContentProvider) => {
                     return (
                         <StaticContentCard

--- a/frontend/src/Pages/AdminManagement.tsx
+++ b/frontend/src/Pages/AdminManagement.tsx
@@ -156,7 +156,7 @@ export default function AdminManagement() {
     return (
         <div>
             <div className="flex flex-col space-y-6 overflow-x-auto rounded-lg p-4 px-8">
-                <h1>Admin Management</h1>
+                <h1>Admins</h1>
                 <div className="flex justify-between">
                     <div className="flex flex-row gap-x-2">
                         <SearchBar

--- a/frontend/src/Pages/OpenContent.tsx
+++ b/frontend/src/Pages/OpenContent.tsx
@@ -42,23 +42,23 @@ export default function OpenContent() {
 
     const handlePageChange = (tab: Tab) => {
         setActiveTab(tab);
-        navigate(`/open-content/${String(tab.value).toLowerCase()}`);
+        navigate(`/knowledge-center/${String(tab.value).toLowerCase()}`);
     };
     const handleReturnToAdminView = () => {
         if (currentTabValue === 'favorites') {
-            navigate('/open-content-management/libraries');
+            navigate('/knowledge-center-management/libraries');
         } else if (
             currentTabValue === 'libraries' ||
             currentTabValue === 'videos'
         ) {
-            navigate('/open-content-management/' + currentTabValue);
+            navigate('/knowledge-center-management/' + currentTabValue);
         }
     };
 
     return (
         <div className="px-8 pb-4">
             <div className="flex flex-row justify-between">
-                <h1>Open Content</h1>
+                <h1>Knowledge Center</h1>
                 {user && isAdministrator(user) && (
                     <button
                         className="button border border-primary bg-transparent text-body-text"

--- a/frontend/src/Pages/OpenContentManagement.tsx
+++ b/frontend/src/Pages/OpenContentManagement.tsx
@@ -27,16 +27,18 @@ export default function OpenContentManagement() {
 
     const handlePageChange = (tab: Tab) => {
         setActiveTab(tab);
-        navigate(`/open-content-management/${tab.value}`);
+        navigate(`/knowledge-center-management/${tab.value}`);
     };
 
     return (
         <div className="px-8 pb-4">
             <div className="flex flex-row justify-between">
-                <h1>Open Content Management</h1>
+                <h1>Knowledge Center Management</h1>
                 <button
                     className="button border border-primary bg-transparent text-body-text"
-                    onClick={() => navigate(`/open-content/${activeTab.value}`)}
+                    onClick={() =>
+                        navigate(`/knowledge-center/${activeTab.value}`)
+                    }
                 >
                     Preview Student View
                 </button>

--- a/frontend/src/Pages/StudentDashboard.tsx
+++ b/frontend/src/Pages/StudentDashboard.tsx
@@ -28,7 +28,7 @@ export default function StudentDashboard() {
     if (!user) {
         return;
     } else if (isAdministrator(user)) {
-        navigate('/admin-dashboard');
+        navigate('/student-activity');
         return;
     }
     const { data, error, isLoading } = useSWR<

--- a/frontend/src/Pages/StudentManagement.tsx
+++ b/frontend/src/Pages/StudentManagement.tsx
@@ -134,7 +134,7 @@ export default function StudentManagement() {
     return (
         <div>
             <div className="flex flex-col space-y-6 overflow-x-auto rounded-lg p-4 px-8">
-                <h1>Student Management</h1>
+                <h1>Students</h1>
                 <div className="flex justify-between">
                     <div className="flex flex-row gap-x-2">
                         <SearchBar

--- a/frontend/src/Pages/VideoManagement.tsx
+++ b/frontend/src/Pages/VideoManagement.tsx
@@ -50,7 +50,7 @@ export default function VideoManagement() {
         return null;
     }
     if (user.role === UserRole.Student) {
-        navigate('/open-content/videos', { replace: true });
+        navigate('/knowledge-center/videos', { replace: true });
     }
 
     const pollVideos = (delay: number) => {

--- a/frontend/src/app.tsx
+++ b/frontend/src/app.tsx
@@ -128,10 +128,10 @@ const router = createBrowserRouter([
                         loader: checkRole
                     },
                     {
-                        path: 'student-dashboard',
+                        path: 'my-learning',
                         element: <StudentDashboard />,
                         loader: getOpenContentProviders,
-                        handle: { title: 'Dashboard', path: ['dashboard'] }
+                        handle: { title: 'My Learning', path: ['my-learning'] }
                     },
                     {
                         path: 'consent',
@@ -289,30 +289,30 @@ const router = createBrowserRouter([
                 loader: getFacilities,
                 children: [
                     {
-                        path: 'admin-dashboard',
+                        path: 'student-activity',
                         element: <AdminDashboard />,
                         errorElement: <Error />,
                         handle: {
-                            title: 'Admin Dashboard',
-                            path: ['admin-dashboard']
+                            title: 'Student Activity',
+                            path: ['student-activity']
                         }
                     },
                     {
-                        path: 'student-management',
+                        path: 'students',
                         element: <StudentManagement />,
                         errorElement: <Error />,
                         handle: {
-                            title: 'Student Management',
-                            path: ['student-management']
+                            title: 'Students',
+                            path: ['students']
                         }
                     },
                     {
-                        path: 'admin-management',
+                        path: 'admins',
                         element: <AdminManagement />,
                         errorElement: <Error />,
                         handle: {
-                            title: 'Admin Management',
-                            path: ['admin-management']
+                            title: 'Admins',
+                            path: ['admins']
                         }
                     },
                     {
@@ -334,11 +334,11 @@ const router = createBrowserRouter([
                         errorElement: <Error />,
                         children: [
                             {
-                                path: 'provider-platform-management',
+                                path: 'learning-platforms',
                                 element: <ProviderPlatformManagement />,
                                 handle: {
-                                    title: 'Provider Platform Management',
-                                    path: ['provider-platform-management']
+                                    title: 'Learning Platforms',
+                                    path: ['learning-platforms']
                                 }
                             },
                             {

--- a/frontend/src/app.tsx
+++ b/frontend/src/app.tsx
@@ -152,11 +152,11 @@ const router = createBrowserRouter([
                         ),
                         children: [
                             {
-                                path: 'open-content',
+                                path: 'knowledge-center',
                                 element: <OpenContent />,
                                 handle: {
-                                    title: 'Open Content',
-                                    path: ['open-content', ':kind']
+                                    title: 'Knowledge Center',
+                                    path: ['knowledge-center', ':kind']
                                 },
                                 children: [
                                     {
@@ -165,7 +165,10 @@ const router = createBrowserRouter([
                                         errorElement: <Error />,
                                         handle: {
                                             title: 'Libraries',
-                                            path: ['open-content', 'libraries']
+                                            path: [
+                                                'knowledge-center',
+                                                'libraries'
+                                            ]
                                         }
                                     },
                                     {
@@ -174,7 +177,7 @@ const router = createBrowserRouter([
                                         errorElement: <Error />,
                                         handle: {
                                             title: 'Videos',
-                                            path: ['open-content', 'videos']
+                                            path: ['knowledge-center', 'videos']
                                         }
                                     },
                                     {
@@ -379,11 +382,14 @@ const router = createBrowserRouter([
                         errorElement: <Error />,
                         children: [
                             {
-                                path: 'open-content-management',
+                                path: 'knowledge-center-management',
                                 element: <OpenContentManagement />,
                                 handle: {
-                                    title: 'Open Content Management',
-                                    path: ['open-content-management', ':kind']
+                                    title: 'Knowledge Center Management',
+                                    path: [
+                                        'knowledge-center-management',
+                                        ':kind'
+                                    ]
                                 },
                                 children: [
                                     {
@@ -392,7 +398,10 @@ const router = createBrowserRouter([
                                         errorElement: <Error />,
                                         handle: {
                                             title: 'Libraries',
-                                            path: ['open-content', 'libraries']
+                                            path: [
+                                                'knowledge-center-management',
+                                                'libraries'
+                                            ]
                                         }
                                     },
                                     {
@@ -401,7 +410,7 @@ const router = createBrowserRouter([
                                         handle: {
                                             title: 'Videos',
                                             path: [
-                                                'open-content-management',
+                                                'knowledge-center-management',
                                                 'videos'
                                             ]
                                         }

--- a/frontend/src/common.ts
+++ b/frontend/src/common.ts
@@ -34,8 +34,8 @@ export const providerRoutes = [
 ];
 
 export const openContentRoutes = [
-    'open-content',
-    'open-content-management',
+    'knowledge-center',
+    'knowledge-center-management',
     'viewer'
 ];
 

--- a/frontend/src/common.ts
+++ b/frontend/src/common.ts
@@ -27,7 +27,7 @@ export interface User {
 }
 export const providerRoutes = [
     'provider-user-management',
-    'provider-platform-management',
+    'learning-platforms',
     'my-courses',
     'course-catalogue',
     'course-catalog-admin'

--- a/frontend/src/useAuth.ts
+++ b/frontend/src/useAuth.ts
@@ -30,9 +30,7 @@ export const getDashboard = (user?: User): string => {
     if (!user) {
         return INIT_KRATOS_LOGIN_FLOW;
     } else {
-        return isAdministrator(user)
-            ? '/admin-dashboard'
-            : '/student-dashboard';
+        return isAdministrator(user) ? '/student-activity' : '/my-learning';
     }
 };
 


### PR DESCRIPTION
## Description of the change
Admins should see the following navigation menu:


Student Activity → This is the old “Dashboard”

Students → Links to the current Students page

Admins → Links to the current Admins page

Facilities → Links to the current Facilities page

Learning Platforms → This is the Provider Platform page.
Residents should see the following navigation menu:


My Courses → Links to the current My Courses page

My Learning → This is the old dashboard.
- **Related issues**:
Closes: #509

## Screenshot(s)
