### PR TITLE
feat: add limit param for resources

### DIFF
--- a/backend/src/database/leftmenulinks.go
+++ b/backend/src/database/leftmenulinks.go
@@ -6,9 +6,9 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
-func (db *DB) GetLeftMenuLinks() ([]models.LeftMenuLink, error) {
+func (db *DB) GetLeftMenuLinks(limit int) ([]models.LeftMenuLink, error) {
 	var links []models.LeftMenuLink
-	if err := db.Find(&links).Error; err != nil {
+	if err := db.Model(&models.LeftMenuLink{}).Limit(limit).Find(&links).Error; err != nil {
 		return nil, newGetRecordsDBError(err, "left_menu_links")
 	}
 	return links, nil

--- a/backend/src/handlers/left_menu_handler.go
+++ b/backend/src/handlers/left_menu_handler.go
@@ -4,6 +4,7 @@ import (
 	"UnlockEdv2/src/models"
 	"encoding/json"
 	"net/http"
+	"strconv"
 )
 
 func (srv *Server) registerLeftMenuRoutes() []routeDef {
@@ -16,7 +17,12 @@ func (srv *Server) registerLeftMenuRoutes() []routeDef {
 
 func (srv *Server) handleGetLeftMenu(w http.ResponseWriter, r *http.Request, log sLog) error {
 	log.info("GET: /api/left-menu")
-	links, err := srv.Db.GetLeftMenuLinks()
+	var limit int
+	limit, err := strconv.Atoi(r.URL.Query().Get("limit"))
+	if err != nil {
+		limit = -1
+	}
+	links, err := srv.Db.GetLeftMenuLinks(limit)
 	if err != nil {
 		return newDatabaseServiceError(err)
 	}


### PR DESCRIPTION
## Description of the change

Adds limit to the backend so that resources (aka now helpful links) can be filtered to just the top 5 helpful links.

- **Related issues**: works towards #527 but this will be completed in my other PR (#532)

## Screenshot(s)

No relevant screenshots.

## Additional context

Depending on the order that the PRs are merged in, I'll have to modify one of them to update the frontend dashboard to add the limit to the api call in the frontend. This one is probably easier to merge in first and then i can push that new change into #532 and it can be merged in with that.