### PR TITLE
Update navigation for Level 2 access

### DIFF
--- a/backend/src/database/open_content.go
+++ b/backend/src/database/open_content.go
@@ -6,6 +6,18 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
+func (db *DB) GetOpenContent(all bool) ([]models.OpenContentProvider, error) {
+	tx := db.Model(&models.OpenContentProvider{})
+	if !all {
+		tx = tx.Where("currently_enabled = ?", true)
+	}
+	openContent := make([]models.OpenContentProvider, 0, 3)
+	if err := tx.Find(&openContent).Error; err != nil {
+		return nil, newNotFoundDBError(err, "open_content_providers")
+	}
+	return openContent, nil
+}
+
 func (db *DB) FindKolibriInstance() (*models.ProviderPlatform, error) {
 	kolibri := models.ProviderPlatform{}
 	if err := db.First(&kolibri, "type = ?", "kolibri").Error; err != nil {

--- a/backend/src/handlers/open_content_handler.go
+++ b/backend/src/handlers/open_content_handler.go
@@ -3,13 +3,28 @@ package handlers
 import (
 	"UnlockEdv2/src/models"
 	"net/http"
+	"strings"
 )
 
 func (srv *Server) registerOpenContentRoutes() []routeDef {
 	axx := models.Feature(models.OpenContentAccess)
 	return []routeDef{
 		{"GET /api/open-content/favorites", srv.handleGetUserFavoriteOpenContent, false, axx},
+		{"GET /api/open-content", srv.handleIndexOpenContent, false, axx},
 	}
+}
+
+func (srv *Server) handleIndexOpenContent(w http.ResponseWriter, r *http.Request, log sLog) error {
+	only := r.URL.Query().Get("all")
+	var all bool
+	if userIsAdmin(r) && strings.ToLower(strings.TrimSpace(only)) == "true" {
+		all = true
+	}
+	content, err := srv.Db.GetOpenContent(all)
+	if err != nil {
+		return newDatabaseServiceError(err)
+	}
+	return writeJsonResponse(w, http.StatusOK, content)
 }
 
 func (srv *Server) handleGetUserFavoriteOpenContent(w http.ResponseWriter, r *http.Request, log sLog) error {

--- a/backend/tasks/main.go
+++ b/backend/tasks/main.go
@@ -32,7 +32,7 @@ func main() {
 			log.Errorf("Task %v has no job", task.ID)
 			continue
 		}
-		_, err := scheduler.NewJob(gocron.CronJob(task.Job.Schedule, false), gocron.NewTask(runner.runTask, task))
+		_, err := scheduler.NewJob(gocron.CronJob(task.Job.Schedule, false), gocron.NewTask(runner.runTask, &task))
 		if err != nil {
 			log.Errorf("Failed to create job: %v", err)
 			continue

--- a/frontend/src/Components/FeatureLevelCheckboxes.tsx
+++ b/frontend/src/Components/FeatureLevelCheckboxes.tsx
@@ -61,7 +61,7 @@ export default function FeatureLevelCheckboxes({
         toaster(resp.message, ToastState.success);
         const user = await fetchUser();
         setUser(user);
-        navigate('/admin-dashboard');
+        navigate('/authcallback');
     };
 
     return (
@@ -74,13 +74,13 @@ export default function FeatureLevelCheckboxes({
             />
             <CheckboxGeneric
                 name="provider_platforms"
-                label="Provider Platform Integrations"
+                label="Connected Learning"
                 checked={getCheckboxChecked(FeatureAccess.ProviderAccess)}
                 onChange={handleFeatureToggle}
             />
             <CheckboxGeneric
                 name="program_management"
-                label="Program Management"
+                label="Program Hub"
                 checked={getCheckboxChecked(FeatureAccess.ProgramAccess)}
                 onChange={handleFeatureToggle}
             />

--- a/frontend/src/Components/Navbar.tsx
+++ b/frontend/src/Components/Navbar.tsx
@@ -50,7 +50,11 @@ export default function Navbar({
     const { toaster } = useToast();
     const confirmSeedModal = useRef<HTMLDialogElement | null>(null);
     const [seedInProgress, setSeedInProgress] = useState<boolean>(false);
-
+    const dashboardTitle = new Map([
+        ['/learning-insights', 'Learning'],
+        ['/knowledge-insights', 'Knowledge'],
+        ['/operational-insights', 'Operational']
+    ]);
     const handleSeedDemoData = async () => {
         setSeedInProgress(true);
         const resp = await API.post<null, object>(`auth/demo-seed`, {});
@@ -107,15 +111,21 @@ export default function Navbar({
                                 <li className="mt-16">
                                     <Link to={getDashboardLink(user)}>
                                         <ULIComponent icon={HomeIcon} />
-                                        Dashboard
+                                        {dashboardTitle.get(
+                                            getDashboardLink(user)
+                                        ) ?? 'Operational'}{' '}
+                                        Insights
                                     </Link>
                                 </li>
-                                <li>
-                                    <Link to="/operational-insights">
-                                        <ULIComponent icon={CogIcon} />
-                                        Operational Insights
-                                    </Link>
-                                </li>
+                                {/* this acts as the dashboard in the case there are no features enabled */}
+                                {user.feature_access.length > 0 && (
+                                    <li>
+                                        <Link to="/operational-insights">
+                                            <ULIComponent icon={CogIcon} />
+                                            Operational Insights
+                                        </Link>
+                                    </li>
+                                )}
                                 {hasFeature(
                                     user,
                                     FeatureAccess.ProviderAccess
@@ -147,7 +157,7 @@ export default function Navbar({
                                         <li>
                                             <Link to="/programs">
                                                 <ULIComponent
-                                                    icon={CloudIcon}
+                                                    icon={DocumentTextIcon}
                                                 />
                                                 Programs
                                             </Link>
@@ -159,6 +169,17 @@ export default function Navbar({
                                     FeatureAccess.OpenContentAccess
                                 ) && (
                                     <>
+                                        {/* in the case where this is the only feature, this would otherwise be the dashboard */}
+                                        {user.feature_access.length > 1 && (
+                                            <li>
+                                                <Link to="/knowledge-insights">
+                                                    <ULIComponent
+                                                        icon={BookOpenIcon}
+                                                    />
+                                                    Knowledge Insights
+                                                </Link>
+                                            </li>
+                                        )}
                                         <li>
                                             <Link to="/knowledge-center-management/libraries">
                                                 <ULIComponent
@@ -205,12 +226,17 @@ export default function Navbar({
                                     FeatureAccess.ProviderAccess
                                 ) && (
                                     <>
-                                        <li className="mt-16">
-                                            <Link to="/student-activity">
-                                                <ULIComponent icon={HomeIcon} />
-                                                My Learning
-                                            </Link>
-                                        </li>
+                                        {getDashboardLink(user) !==
+                                            '/learning-path' && (
+                                            <li>
+                                                <Link to="/learning-path">
+                                                    <ULIComponent
+                                                        icon={HomeIcon}
+                                                    />
+                                                    My Learning
+                                                </Link>
+                                            </li>
+                                        )}
                                         <li>
                                             <Link to="/my-courses">
                                                 <ULIComponent
@@ -219,31 +245,55 @@ export default function Navbar({
                                                 My Courses
                                             </Link>
                                         </li>
+                                        <li>
+                                            <Link to="/my-progress">
+                                                <ULIComponent
+                                                    icon={AcademicCapIcon}
+                                                />{' '}
+                                                My Progress
+                                            </Link>
+                                        </li>
                                     </>
                                 )}
                                 {hasFeature(
                                     user,
                                     FeatureAccess.OpenContentAccess
                                 ) && (
-                                    <li>
-                                        <Link to="/knowledge-center/libraries">
-                                            <ULIComponent icon={BookOpenIcon} />
-                                            Knowledge Center
-                                        </Link>
-                                    </li>
+                                    <>
+                                        {user.feature_access.length > 1 && (
+                                            <li>
+                                                <Link to="/trending-content">
+                                                    <ULIComponent
+                                                        icon={BookOpenIcon}
+                                                    />
+                                                    Trending Content
+                                                </Link>
+                                            </li>
+                                        )}
+                                        <li>
+                                            <Link to="/knowledge-center/libraries">
+                                                <ULIComponent
+                                                    icon={BookOpenIcon}
+                                                />
+                                                Knowledge Center
+                                            </Link>
+                                        </li>
+                                    </>
                                 )}
                                 {hasFeature(
                                     user,
                                     FeatureAccess.ProgramAccess
                                 ) && (
-                                    <li>
-                                        <Link to="/programs">
-                                            <ULIComponent
-                                                icon={DocumentTextIcon}
-                                            />
-                                            Programs
-                                        </Link>
-                                    </li>
+                                    <>
+                                        <li>
+                                            <Link to="/programs">
+                                                <ULIComponent
+                                                    icon={DocumentTextIcon}
+                                                />
+                                                Programs
+                                            </Link>
+                                        </li>
+                                    </>
                                 )}
                             </>
                         )}

--- a/frontend/src/Components/Navbar.tsx
+++ b/frontend/src/Components/Navbar.tsx
@@ -6,14 +6,12 @@ import {
     ChevronDoubleLeftIcon,
     ChevronDoubleRightIcon,
     HomeIcon,
-    TrophyIcon,
     UsersIcon,
     ArrowRightEndOnRectangleIcon,
     SunIcon,
     MoonIcon,
     UserCircleIcon,
     DocumentTextIcon,
-    FolderOpenIcon,
     CloudIcon,
     RssIcon,
     RectangleStackIcon,
@@ -103,26 +101,27 @@ export default function Navbar({
                                 {hasFeature(
                                     user,
                                     FeatureAccess.OpenContentAccess
-                                ) && user.feature_access.length === 1 ? (
-                                    <li className="mt-16">
-                                        <Link to="/knowledge-center-dashboard">
-                                            <ULIComponent icon={HomeIcon} />
-                                            Dashboard
-                                        </Link>
-                                    </li>
-                                ) : (
-                                    <li className="mt-16">
-                                        <Link to="/admin-dashboard">
-                                            <ULIComponent icon={HomeIcon} />
-                                            Dashboard
-                                        </Link>
-                                    </li>
-                                )}
-                                {hasFeature(
-                                    user,
-                                    FeatureAccess.OpenContentAccess
                                 ) && (
                                     <>
+                                        {user.feature_access.length === 1 ? (
+                                            <li className="mt-16">
+                                                <Link to="/knowledge-center-dashboard">
+                                                    <ULIComponent
+                                                        icon={HomeIcon}
+                                                    />
+                                                    Dashboard
+                                                </Link>
+                                            </li>
+                                        ) : (
+                                            <li className="mt-16">
+                                                <Link to="/admin-dashboard">
+                                                    <ULIComponent
+                                                        icon={HomeIcon}
+                                                    />
+                                                    Dashboard
+                                                </Link>
+                                            </li>
+                                        )}
                                         <li>
                                             <Link to="/knowledge-center-management/libraries">
                                                 <ULIComponent
@@ -133,31 +132,17 @@ export default function Navbar({
                                         </li>
                                     </>
                                 )}
-                                <li>
-                                    <Link to="/operational-insights">
-                                        <ULIComponent icon={CogIcon} />
-                                        Operational Insights
-                                    </Link>
-                                </li>
                                 {hasFeature(
                                     user,
                                     FeatureAccess.ProviderAccess
                                 ) && (
                                     <>
                                         <li>
-                                            <Link to="/provider-platform-management">
+                                            <Link to="/learning-platforms">
                                                 <ULIComponent
                                                     icon={CloudIcon}
                                                 />
-                                                Platforms
-                                            </Link>
-                                        </li>
-                                        <li className="">
-                                            <Link to="/course-catalog-admin">
-                                                <ULIComponent
-                                                    icon={FolderOpenIcon}
-                                                />
-                                                Course Catalog
+                                                Learning Platforms
                                             </Link>
                                         </li>
                                     </>
@@ -166,29 +151,58 @@ export default function Navbar({
                                     user,
                                     FeatureAccess.ProgramAccess
                                 ) && (
-                                    <li>
-                                        <Link to="/programs">
-                                            <ULIComponent
-                                                icon={DocumentTextIcon}
-                                            />
-                                            Programs
-                                        </Link>
-                                    </li>
+                                    <>
+                                        <li>
+                                            <Link to="/programs">
+                                                <ULIComponent
+                                                    icon={DocumentTextIcon}
+                                                />
+                                                Programs
+                                            </Link>
+                                        </li>
+                                    </>
                                 )}
                                 <li>
-                                    <Link to="/student-management">
+                                    <Link to="/operational-insights">
+                                        <ULIComponent icon={CogIcon} />
+                                        Operational Insights
+                                    </Link>
+                                </li>
+                                <li>
+                                    <Link to="/students">
                                         <ULIComponent icon={AcademicCapIcon} />
                                         Students
                                     </Link>
                                 </li>
                                 <li>
-                                    <Link to="/admin-management">
+                                    <Link to="/admins">
+                                        <ULIComponent icon={UsersIcon} />
+                                        Admins
+                                    </Link>
+                                </li>
+
+                                <li>
+                                    <Link to="/facilities">
+                                        <ULIComponent
+                                            icon={BuildingStorefrontIcon}
+                                        />
+                                        Facilities
+                                    </Link>
+                                </li>
+                                <li>
+                                    <Link to="/students">
+                                        <ULIComponent icon={AcademicCapIcon} />
+                                        Students
+                                    </Link>
+                                </li>
+                                <li>
+                                    <Link to="/admins">
                                         <ULIComponent icon={UsersIcon} />
                                         Admins
                                     </Link>
                                 </li>
                                 <li>
-                                    <Link to="/facilities-management">
+                                    <Link to="/facilities">
                                         <ULIComponent
                                             icon={BuildingStorefrontIcon}
                                         />
@@ -198,51 +212,58 @@ export default function Navbar({
                             </>
                         ) : (
                             <>
+                                {/* student view */}
                                 {hasFeature(
                                     user,
                                     FeatureAccess.OpenContentAccess
-                                ) && user.feature_access.length === 1 ? (
-                                    <li className="mt-16">
-                                        <Link to="/knowledge-center-dashboard">
-                                            <ULIComponent icon={HomeIcon} />
-                                            Dashboard
-                                        </Link>
-                                    </li>
-                                ) : (
-                                    <li className="mt-16">
-                                        <Link to="/student-dashboard">
-                                            <ULIComponent icon={HomeIcon} />
-                                            Dashboard
-                                        </Link>
-                                    </li>
+                                ) && (
+                                    <>
+                                        {user.feature_access.length === 1 ? (
+                                            <li className="mt-16">
+                                                <Link to="/knowledge-center-dashboard">
+                                                    <ULIComponent
+                                                        icon={HomeIcon}
+                                                    />
+                                                    Dashboard
+                                                </Link>
+                                            </li>
+                                        ) : (
+                                            <li className="mt-16">
+                                                <Link to="/student-dashboard">
+                                                    <ULIComponent
+                                                        icon={HomeIcon}
+                                                    />
+                                                    Dashboard
+                                                </Link>
+                                            </li>
+                                        )}
+                                        <li>
+                                            <Link to="/open-content/libraries">
+                                                <ULIComponent
+                                                    icon={BookOpenIcon}
+                                                />
+                                                Open Content
+                                            </Link>
+                                        </li>
+                                    </>
                                 )}
                                 {hasFeature(
                                     user,
                                     FeatureAccess.ProviderAccess
                                 ) && (
                                     <>
+                                        <li className="mt-16">
+                                            <Link to="/student-activity">
+                                                <ULIComponent icon={HomeIcon} />
+                                                My Learning
+                                            </Link>
+                                        </li>
                                         <li>
                                             <Link to="/my-courses">
                                                 <ULIComponent
                                                     icon={RectangleStackIcon}
                                                 />{' '}
                                                 My Courses
-                                            </Link>
-                                        </li>
-                                        <li>
-                                            <Link to="/course-catalog">
-                                                <ULIComponent
-                                                    icon={FolderOpenIcon}
-                                                />
-                                                Course Catalog
-                                            </Link>
-                                        </li>
-                                        <li>
-                                            <Link to="/my-progress">
-                                                <ULIComponent
-                                                    icon={TrophyIcon}
-                                                />{' '}
-                                                My Progress
                                             </Link>
                                         </li>
                                     </>

--- a/frontend/src/Components/Navbar.tsx
+++ b/frontend/src/Components/Navbar.tsx
@@ -17,7 +17,13 @@ import {
     RectangleStackIcon,
     CogIcon
 } from '@heroicons/react/24/solid';
-import { handleLogout, hasFeature, isAdministrator, useAuth } from '@/useAuth';
+import {
+    getDashboardLink,
+    handleLogout,
+    hasFeature,
+    isAdministrator,
+    useAuth
+} from '@/useAuth';
 import Modal from '@/Components/Modal';
 import ULIComponent from './ULIComponent';
 import { Link } from 'react-router-dom';
@@ -95,48 +101,34 @@ export default function Navbar({
             <div className="h-full">
                 <ul className="menu h-full flex flex-col justify-between">
                     <div>
+                        {/* admin view */}
                         {user && isAdministrator(user) ? (
                             <>
-                                {/* admin view */}
-                                {hasFeature(
-                                    user,
-                                    FeatureAccess.OpenContentAccess
-                                ) && (
-                                    <>
-                                        {user.feature_access.length === 1 ? (
-                                            <li className="mt-16">
-                                                <Link to="/knowledge-center-dashboard">
-                                                    <ULIComponent
-                                                        icon={HomeIcon}
-                                                    />
-                                                    Dashboard
-                                                </Link>
-                                            </li>
-                                        ) : (
-                                            <li className="mt-16">
-                                                <Link to="/admin-dashboard">
-                                                    <ULIComponent
-                                                        icon={HomeIcon}
-                                                    />
-                                                    Dashboard
-                                                </Link>
-                                            </li>
-                                        )}
-                                        <li>
-                                            <Link to="/knowledge-center-management/libraries">
-                                                <ULIComponent
-                                                    icon={BookOpenIcon}
-                                                />
-                                                Knowledge Center
-                                            </Link>
-                                        </li>
-                                    </>
-                                )}
+                                <li className="mt-16">
+                                    <Link to={getDashboardLink(user)}>
+                                        <ULIComponent icon={HomeIcon} />
+                                        Dashboard
+                                    </Link>
+                                </li>
+                                <li>
+                                    <Link to="/operational-insights">
+                                        <ULIComponent icon={CogIcon} />
+                                        Operational Insights
+                                    </Link>
+                                </li>
                                 {hasFeature(
                                     user,
                                     FeatureAccess.ProviderAccess
                                 ) && (
                                     <>
+                                        <li>
+                                            <Link to="/course-catalog-admin">
+                                                <ULIComponent
+                                                    icon={CloudIcon}
+                                                />
+                                                Course Catalog
+                                            </Link>
+                                        </li>
                                         <li>
                                             <Link to="/learning-platforms">
                                                 <ULIComponent
@@ -155,19 +147,28 @@ export default function Navbar({
                                         <li>
                                             <Link to="/programs">
                                                 <ULIComponent
-                                                    icon={DocumentTextIcon}
+                                                    icon={CloudIcon}
                                                 />
                                                 Programs
                                             </Link>
                                         </li>
                                     </>
                                 )}
-                                <li>
-                                    <Link to="/operational-insights">
-                                        <ULIComponent icon={CogIcon} />
-                                        Operational Insights
-                                    </Link>
-                                </li>
+                                {hasFeature(
+                                    user,
+                                    FeatureAccess.OpenContentAccess
+                                ) && (
+                                    <>
+                                        <li>
+                                            <Link to="/knowledge-center-management/libraries">
+                                                <ULIComponent
+                                                    icon={BookOpenIcon}
+                                                />
+                                                Knowledge Center
+                                            </Link>
+                                        </li>
+                                    </>
+                                )}
                                 <li>
                                     <Link to="/students">
                                         <ULIComponent icon={AcademicCapIcon} />
@@ -189,64 +190,16 @@ export default function Navbar({
                                         Facilities
                                     </Link>
                                 </li>
-                                <li>
-                                    <Link to="/students">
-                                        <ULIComponent icon={AcademicCapIcon} />
-                                        Students
-                                    </Link>
-                                </li>
-                                <li>
-                                    <Link to="/admins">
-                                        <ULIComponent icon={UsersIcon} />
-                                        Admins
-                                    </Link>
-                                </li>
-                                <li>
-                                    <Link to="/facilities">
-                                        <ULIComponent
-                                            icon={BuildingStorefrontIcon}
-                                        />
-                                        Facilities
-                                    </Link>
-                                </li>
                             </>
                         ) : (
                             <>
                                 {/* student view */}
-                                {hasFeature(
-                                    user,
-                                    FeatureAccess.OpenContentAccess
-                                ) && (
-                                    <>
-                                        {user.feature_access.length === 1 ? (
-                                            <li className="mt-16">
-                                                <Link to="/knowledge-center-dashboard">
-                                                    <ULIComponent
-                                                        icon={HomeIcon}
-                                                    />
-                                                    Dashboard
-                                                </Link>
-                                            </li>
-                                        ) : (
-                                            <li className="mt-16">
-                                                <Link to="/student-dashboard">
-                                                    <ULIComponent
-                                                        icon={HomeIcon}
-                                                    />
-                                                    Dashboard
-                                                </Link>
-                                            </li>
-                                        )}
-                                        <li>
-                                            <Link to="/open-content/libraries">
-                                                <ULIComponent
-                                                    icon={BookOpenIcon}
-                                                />
-                                                Open Content
-                                            </Link>
-                                        </li>
-                                    </>
-                                )}
+                                <li className="mt-16">
+                                    <Link to={getDashboardLink(user)}>
+                                        <ULIComponent icon={HomeIcon} />
+                                        Dashboard
+                                    </Link>
+                                </li>
                                 {hasFeature(
                                     user,
                                     FeatureAccess.ProviderAccess

--- a/frontend/src/Components/forms/EditUserForm.tsx
+++ b/frontend/src/Components/forms/EditUserForm.tsx
@@ -1,20 +1,13 @@
 import { ServerResponseOne, User, UserRole } from '@/common.ts';
 import { useState } from 'react';
 import { SubmitHandler, useForm } from 'react-hook-form';
-import {
-    TextInput,
-    DropdownInput,
-    SubmitButton,
-    CloseX
-} from '@/Components/inputs';
+import { TextInput, SubmitButton, CloseX } from '@/Components/inputs';
 import API from '@/api/api';
 
 interface Inputs {
     [key: string]: string | UserRole;
     name_first: string;
     name_last: string;
-    username: string;
-    role: UserRole;
     email: string;
 }
 
@@ -36,7 +29,6 @@ export default function EditUserForm({
         defaultValues: {
             name_first: user.name_first,
             name_last: user.name_last,
-            username: user.username,
             role: user.role,
             email: user.email
         }
@@ -64,18 +56,10 @@ export default function EditUserForm({
         )) as ServerResponseOne<User>;
         if (!resp.success) {
             switch (resp.message) {
-                case 'userexists': {
-                    setError('username', {
-                        type: 'custom',
-                        message: 'Username already exists'
-                    });
-                    break;
-                }
                 case 'alphanum': {
-                    setError('username', {
+                    setError('name', {
                         type: 'custom',
-                        message:
-                            'Name + Username must contain letters and numbers only'
+                        message: 'Name must contain letters and spaces only'
                     });
                     break;
                 }
@@ -113,28 +97,12 @@ export default function EditUserForm({
                     register={register}
                 />
                 <TextInput
-                    label={'Username'}
-                    interfaceRef={'username'}
-                    required
-                    length={50}
-                    errors={errors}
-                    register={register}
-                />
-                <TextInput
                     label={'Email'}
                     interfaceRef={'email'}
                     required={false}
                     length={50}
                     errors={errors}
                     register={register}
-                />
-                <DropdownInput
-                    label={'Role'}
-                    interfaceRef={'role'}
-                    required
-                    errors={errors}
-                    register={register}
-                    enumType={UserRole}
                 />
                 <SubmitButton errorMessage={errorMessage} />
             </form>

--- a/frontend/src/Pages/AdminDashboard.tsx
+++ b/frontend/src/Pages/AdminDashboard.tsx
@@ -11,7 +11,7 @@ import { ThemeContext } from '@/Context/ThemeContext';
 import { AxiosError } from 'axios';
 import UnauthorizedNotFound from './Unauthorized';
 
-export default function AdminDashboard() {
+export default function AdminLayer2() {
     const { user } = useAuth();
     const { data, error, isLoading } = useSWR<
         ServerResponse<AdminDashboardJoin>,

--- a/frontend/src/Pages/AdminManagement.tsx
+++ b/frontend/src/Pages/AdminManagement.tsx
@@ -156,7 +156,7 @@ export default function AdminManagement() {
     return (
         <div>
             <div className="flex flex-col space-y-6 overflow-x-auto rounded-lg p-4 px-8">
-                <h1>Admin Management</h1>
+                <h1>Admins</h1>
                 <div className="flex justify-between">
                     <div className="flex flex-row gap-x-2">
                         <SearchBar

--- a/frontend/src/Pages/MyProgress.tsx
+++ b/frontend/src/Pages/MyProgress.tsx
@@ -7,14 +7,8 @@ import DarkGreenPill from '@/Components/pill-labels/DarkGreenPill';
 import TealPill from '@/Components/pill-labels/TealPill';
 import useSWR from 'swr';
 import DropdownControl from '@/Components/inputs/DropdownControl';
-import {
-    ProgramAttendanceData,
-    ServerResponse,
-    UserCourses,
-    UserCoursesInfo
-} from '@/common';
+import { ServerResponse, UserCourses, UserCoursesInfo } from '@/common';
 import convertSeconds from '@/Components/ConvertSeconds';
-import Error from './Error';
 
 export default function MyProgress() {
     const [sortCourses, setSortCourses] = useState<string>(
@@ -29,16 +23,13 @@ export default function MyProgress() {
         ServerResponse<UserCoursesInfo>,
         AxiosError
     >(`/api/users/${user.id}/courses?${sortCourses}`);
+
     const courseData = data?.data
         ? (data?.data as UserCoursesInfo)
         : ({} as UserCoursesInfo);
-    const { isLoading: loadingProgramData, error: programDataError } = useSWR<
-        ServerResponse<ProgramAttendanceData>,
-        AxiosError
-    >(`/api/student-attendance`);
-
-    if (isLoading || loadingProgramData) return <div>Loading...</div>;
-    if (error || programDataError) return <Error />;
+    if (isLoading) {
+        return <div>Loading...</div>;
+    }
 
     function handleSortCourses(value: string) {
         const defaultSort = 'order=asc&order_by=course_name';
@@ -61,7 +52,7 @@ export default function MyProgress() {
     return (
         <div className="px-8 py-4">
             <h1>My Progress</h1>
-            {courseData && (
+            {!error && courseData && (
                 <>
                     <div className="mt-7 flex flex-row gap-12">
                         <div className="flex flex-col justify-between w-full">

--- a/frontend/src/Pages/OpenContentLevelDashboard.tsx
+++ b/frontend/src/Pages/OpenContentLevelDashboard.tsx
@@ -10,12 +10,12 @@ import OpenContentCard from '@/Components/cards/OpenContentCard';
 import HelpfulLinkCard from '@/Components/cards/HelpfulLinkCard';
 import LibraryCard from '@/Components/LibraryCard';
 import ULIComponent from '@/Components/ULIComponent';
-import { useAuth } from '@/useAuth';
+import { isAdministrator, useAuth } from '@/useAuth';
 import { ArrowTopRightOnSquareIcon } from '@heroicons/react/24/outline';
 import { useLoaderData, useNavigate } from 'react-router-dom';
 import API from '@/api/api';
 
-export default function OpenContentLevelDashboard() {
+export default function StudentLayer1() {
     const { user } = useAuth();
     const navigate = useNavigate();
     const {
@@ -31,13 +31,11 @@ export default function OpenContentLevelDashboard() {
         featured: Library[];
         helpfulLinks: HelpfulLink[];
     };
-
+    const nav = isAdministrator(user)
+        ? '/knowledge-center-management/libraries'
+        : '/knowledge-center/libraries';
     function navigateToOpenContent() {
-        if (user?.role == UserRole.Student) {
-            navigate(`/knowledge-center/libraries`);
-        } else {
-            navigate(`/knowledge-center-management/libraries`);
-        }
+        navigate(nav);
     }
 
     async function handleHelpfulLinkClick(id: number): Promise<void> {
@@ -47,7 +45,7 @@ export default function OpenContentLevelDashboard() {
         )) as ServerResponseOne<{ url: string }>;
         if (resp.success) {
             window.open(resp.data.url, '_blank');
-            navigate(`/knowledge-center-management/libraries`);
+            navigate(nav);
         }
     }
 

--- a/frontend/src/Pages/OpenContentLevelDashboard.tsx
+++ b/frontend/src/Pages/OpenContentLevelDashboard.tsx
@@ -39,6 +39,7 @@ export default function OpenContentLevelDashboard() {
             navigate(`/knowledge-center-management/libraries`);
         }
     }
+
     async function handleHelpfulLinkClick(id: number): Promise<void> {
         const resp = (await API.put<{ url: string }, object>(
             `helpful-links/activity/${id}`,
@@ -46,8 +47,10 @@ export default function OpenContentLevelDashboard() {
         )) as ServerResponseOne<{ url: string }>;
         if (resp.success) {
             window.open(resp.data.url, '_blank');
+            navigate(`/knowledge-center-management/libraries`);
         }
     }
+
     return (
         <div className="flex flex-row h-full">
             {/* main section */}

--- a/frontend/src/Pages/ProviderPlatformManagement.tsx
+++ b/frontend/src/Pages/ProviderPlatformManagement.tsx
@@ -178,7 +178,7 @@ export default function ProviderPlatformManagement() {
     return (
         <div>
             <div className="px-8 py-4">
-                <h1>Provider Platforms</h1>
+                <h1>Learning Platforms</h1>
                 <div className="flex flex-row justify-between">
                     <div>
                         {/* TO DO: this is where SEARCH and SORT will go */}
@@ -190,7 +190,7 @@ export default function ProviderPlatformManagement() {
                         }}
                     >
                         <PlusCircleIcon className="w-4 my-auto" />
-                        Add Provider
+                        Add Learning Platform
                     </button>
                 </div>
                 <table className="table-2">
@@ -227,7 +227,7 @@ export default function ProviderPlatformManagement() {
                             })
                         ) : (
                             <tr>
-                                <td>No provider platforms</td>
+                                <td>No learning platforms</td>
                             </tr>
                         )}
                     </tbody>

--- a/frontend/src/Pages/StudentDashboard.tsx
+++ b/frontend/src/Pages/StudentDashboard.tsx
@@ -12,13 +12,13 @@ import {
 } from '@/Components/dashboard';
 import ResourcesSideBar from '@/Components/ResourcesSideBar';
 
-export default function StudentDashboard() {
+export default function StudentLayer2() {
     const { user } = useAuth();
     const navigate = useNavigate();
     if (!user) {
         return;
     } else if (isAdministrator(user)) {
-        navigate('/admin-dashboard');
+        navigate('/learning-insights');
         return;
     }
     const { data, error, isLoading } = useSWR<

--- a/frontend/src/Pages/StudentLayer0.tsx
+++ b/frontend/src/Pages/StudentLayer0.tsx
@@ -1,0 +1,17 @@
+import { useAuth } from '@/useAuth';
+
+export default function StudentLayer0() {
+    const { user } = useAuth();
+    return (
+        <div className="card card-title">
+            <h1 className="text-2xl"> Hi, {user?.name_first ?? 'Student'}! </h1>
+            <h2 className="text-xl"> Welcome to UnlockEd</h2>
+            <img
+                src="/ul-logo.png"
+                alt="UnlockEd Logo"
+                className="w-125px h-125px"
+            />
+            <div className="card card-row-padding"></div>
+        </div>
+    );
+}

--- a/frontend/src/Pages/StudentManagement.tsx
+++ b/frontend/src/Pages/StudentManagement.tsx
@@ -134,7 +134,7 @@ export default function StudentManagement() {
     return (
         <div>
             <div className="flex flex-col space-y-6 overflow-x-auto rounded-lg p-4 px-8">
-                <h1>Student Management</h1>
+                <h1>Students</h1>
                 <div className="flex justify-between">
                     <div className="flex flex-row gap-x-2">
                         <SearchBar

--- a/frontend/src/app.tsx
+++ b/frontend/src/app.tsx
@@ -236,12 +236,12 @@ const router = createBrowserRouter([
                         errorElement: <Error />,
                         children: [
                             {
-                                path: 'student-dashboard',
+                                path: 'student-activity',
                                 element: <StudentDashboard />,
                                 loader: getRightSidebarData,
                                 handle: {
-                                    title: 'Dashboard',
-                                    path: ['dashboard']
+                                    title: 'Student Activity',
+                                    path: ['student-activity']
                                 }
                             },
                             {
@@ -259,14 +259,6 @@ const router = createBrowserRouter([
                                     title: 'My Progress',
                                     path: ['my-progress']
                                 }
-                            },
-                            {
-                                path: 'course-catalog',
-                                element: <CourseCatalog />,
-                                handle: {
-                                    title: 'Course Catalog',
-                                    path: ['course-catalog']
-                                }
                             }
                         ]
                     },
@@ -280,12 +272,12 @@ const router = createBrowserRouter([
                         errorElement: <Error />,
                         children: [
                             {
-                                path: 'student-dashboard',
+                                path: 'student-activity',
                                 element: <StudentDashboard />,
                                 loader: getRightSidebarData,
                                 handle: {
-                                    title: 'Dashboard',
-                                    path: ['dashboard']
+                                    title: 'Student Activity',
+                                    path: ['student-activity']
                                 }
                             },
                             {
@@ -328,21 +320,21 @@ const router = createBrowserRouter([
                         }
                     },
                     {
-                        path: 'student-management',
+                        path: 'students',
                         element: <StudentManagement />,
                         errorElement: <Error />,
                         handle: {
-                            title: 'Student Management',
-                            path: ['student-management']
+                            title: 'Students',
+                            path: ['students']
                         }
                     },
                     {
-                        path: 'admin-management',
+                        path: 'admins',
                         element: <AdminManagement />,
                         errorElement: <Error />,
                         handle: {
-                            title: 'Admin Management',
-                            path: ['admin-management']
+                            title: 'Admins',
+                            path: ['admins']
                         }
                     },
                     {
@@ -359,16 +351,16 @@ const router = createBrowserRouter([
                                 element: <AdminDashboard />,
                                 errorElement: <Error />,
                                 handle: {
-                                    title: 'Admin Dashboard',
+                                    title: 'Student Activity',
                                     path: ['admin-dashboard']
                                 }
                             },
                             {
-                                path: 'provider-platform-management',
+                                path: 'learning-platforms',
                                 element: <ProviderPlatformManagement />,
                                 handle: {
-                                    title: 'Provider Platform Management',
-                                    path: ['provider-platform-management']
+                                    title: 'Learning Platforms',
+                                    path: ['learning-platforms']
                                 }
                             },
                             {
@@ -389,15 +381,24 @@ const router = createBrowserRouter([
                                     title: 'Course Catalog',
                                     path: ['course-catalog']
                                 }
+                            },
+                            {
+                                path: 'student-activity',
+                                element: <StudentDashboard />,
+                                loader: getRightSidebarData,
+                                handle: {
+                                    title: 'Student Activity',
+                                    path: ['student-activity']
+                                }
                             }
                         ]
                     },
                     {
-                        path: 'facilities-management',
+                        path: 'facilities',
                         element: <FacilityManagement />,
                         handle: {
-                            title: 'Facilities Management',
-                            path: ['facilities-management']
+                            title: 'Facilities',
+                            path: ['facilities']
                         }
                     },
                     {
@@ -457,7 +458,7 @@ const router = createBrowserRouter([
                                         handle: {
                                             title: 'Helpful Links',
                                             path: [
-                                                'open-content-management',
+                                                'knowledge-center-management',
                                                 'helpful-links'
                                             ]
                                         }

--- a/frontend/src/app.tsx
+++ b/frontend/src/app.tsx
@@ -37,8 +37,7 @@ import {
 import Loading from './Components/Loading';
 import AuthenticatedLayout from './Layouts/AuthenticatedLayout.tsx';
 import { PathValueProvider } from '@/Context/PathValueCtx';
-import AdminDashboard from './Pages/AdminDashboard.tsx';
-import StudentDashboard from './Pages/StudentDashboard.tsx';
+import AdminLayer2 from './Pages/AdminDashboard.tsx';
 import {
     getFacilities,
     getOpenContentDashboardData,
@@ -52,9 +51,11 @@ import VideoContent from './Components/VideoContent.tsx';
 import OpenContentManagement from './Pages/OpenContentManagement.tsx';
 import { FeatureAccess, INIT_KRATOS_LOGIN_FLOW } from './common.ts';
 import FavoritesPage from './Pages/Favorites.tsx';
-import OpenContentLevelDashboard from './Pages/OpenContentLevelDashboard.tsx';
+import StudentLayer1 from './Pages/OpenContentLevelDashboard.tsx';
 import OperationalInsightsPage from './Pages/OperationalInsights.tsx';
 import HelpfulLinksManagement from './Pages/HelpfulLinksManagement.tsx';
+import StudentLayer0 from './Pages/StudentLayer0.tsx';
+import StudentLayer2 from './Pages/StudentDashboard.tsx';
 
 const WithAuth: React.FC = () => {
     return (
@@ -141,6 +142,14 @@ const router = createBrowserRouter([
                         }
                     },
                     {
+                        path: 'home',
+                        element: <StudentLayer0 />,
+                        handle: {
+                            title: 'UnlockEd',
+                            path: ['home']
+                        }
+                    },
+                    {
                         path: '',
                         element: (
                             <ProtectedRoute
@@ -151,12 +160,12 @@ const router = createBrowserRouter([
                         ),
                         children: [
                             {
-                                path: 'knowledge-center-dashboard',
-                                element: <OpenContentLevelDashboard />,
+                                path: 'trending-content',
+                                element: <StudentLayer1 />,
                                 loader: getOpenContentDashboardData,
                                 handle: {
-                                    title: 'Knowledge Center Dashboard',
-                                    path: ['knowledge-center-dashboard']
+                                    title: 'Trending Content',
+                                    path: ['trending-content']
                                 }
                             },
                             {
@@ -236,12 +245,12 @@ const router = createBrowserRouter([
                         errorElement: <Error />,
                         children: [
                             {
-                                path: 'student-activity',
-                                element: <StudentDashboard />,
+                                path: 'learning-path',
+                                element: <StudentLayer2 />,
                                 loader: getRightSidebarData,
                                 handle: {
-                                    title: 'Student Activity',
-                                    path: ['student-activity']
+                                    title: 'Learning Path',
+                                    path: ['learning-path']
                                 }
                             },
                             {
@@ -271,15 +280,6 @@ const router = createBrowserRouter([
                         ),
                         errorElement: <Error />,
                         children: [
-                            {
-                                path: 'student-activity',
-                                element: <StudentDashboard />,
-                                loader: getRightSidebarData,
-                                handle: {
-                                    title: 'Student Activity',
-                                    path: ['student-activity']
-                                }
-                            },
                             {
                                 path: 'programs',
                                 element: <Programs />,
@@ -338,6 +338,14 @@ const router = createBrowserRouter([
                         }
                     },
                     {
+                        path: 'facilities',
+                        element: <FacilityManagement />,
+                        handle: {
+                            title: 'Facilities',
+                            path: ['facilities']
+                        }
+                    },
+                    {
                         path: '',
                         element: (
                             <ProtectedRoute
@@ -347,12 +355,12 @@ const router = createBrowserRouter([
                         errorElement: <Error />,
                         children: [
                             {
-                                path: 'admin-dashboard',
-                                element: <AdminDashboard />,
+                                path: 'learning-insights',
+                                element: <AdminLayer2 />,
                                 errorElement: <Error />,
                                 handle: {
-                                    title: 'Student Activity',
-                                    path: ['admin-dashboard']
+                                    title: 'Learning Insights',
+                                    path: ['learning-insights']
                                 }
                             },
                             {
@@ -381,25 +389,8 @@ const router = createBrowserRouter([
                                     title: 'Course Catalog',
                                     path: ['course-catalog']
                                 }
-                            },
-                            {
-                                path: 'student-activity',
-                                element: <StudentDashboard />,
-                                loader: getRightSidebarData,
-                                handle: {
-                                    title: 'Student Activity',
-                                    path: ['student-activity']
-                                }
                             }
                         ]
-                    },
-                    {
-                        path: 'facilities',
-                        element: <FacilityManagement />,
-                        handle: {
-                            title: 'Facilities',
-                            path: ['facilities']
-                        }
                     },
                     {
                         path: '',
@@ -413,12 +404,12 @@ const router = createBrowserRouter([
                         errorElement: <Error />,
                         children: [
                             {
-                                path: 'knowledge-center-dashboard',
-                                element: <OpenContentLevelDashboard />,
+                                path: 'knowledge-insights',
+                                element: <StudentLayer1 />,
                                 loader: getOpenContentDashboardData,
                                 handle: {
-                                    title: 'Dashboard',
-                                    path: ['dashboard']
+                                    title: 'Knowledge Insights',
+                                    path: ['knowledge-insights']
                                 }
                             },
                             {

--- a/frontend/src/app.tsx
+++ b/frontend/src/app.tsx
@@ -155,8 +155,8 @@ const router = createBrowserRouter([
                                 element: <OpenContentLevelDashboard />,
                                 loader: getOpenContentDashboardData,
                                 handle: {
-                                    title: 'Dashboard',
-                                    path: ['dashboard']
+                                    title: 'Knowledge Center Dashboard',
+                                    path: ['knowledge-center-dashboard']
                                 }
                             },
                             {
@@ -436,7 +436,7 @@ const router = createBrowserRouter([
                                         handle: {
                                             title: 'Libraries',
                                             path: [
-                                                'knowledge-center-management',
+                                                'knowledge-center',
                                                 'libraries'
                                             ]
                                         }
@@ -446,10 +446,7 @@ const router = createBrowserRouter([
                                         element: <VideoManagement />,
                                         handle: {
                                             title: 'Videos',
-                                            path: [
-                                                'knowledge-center-management',
-                                                'videos'
-                                            ]
+                                            path: ['knowledge-center', 'videos']
                                         }
                                     },
                                     {
@@ -458,7 +455,7 @@ const router = createBrowserRouter([
                                         handle: {
                                             title: 'Helpful Links',
                                             path: [
-                                                'knowledge-center-management',
+                                                'knowledge-center',
                                                 'helpful-links'
                                             ]
                                         }

--- a/frontend/src/common.ts
+++ b/frontend/src/common.ts
@@ -27,7 +27,7 @@ export interface User {
 }
 export const providerRoutes = [
     'provider-user-management',
-    'provider-platform-management',
+    'learning-platforms',
     'my-courses',
     'course-catalogue',
     'course-catalog-admin'

--- a/frontend/src/routeLoaders.ts
+++ b/frontend/src/routeLoaders.ts
@@ -5,7 +5,6 @@ import {
     OpenContentItem,
     OpenContentProvider,
     ServerResponse,
-    HelpfulLink,
     HelpfulLinkAndSort,
     Library
 } from './common';
@@ -61,7 +60,7 @@ export const getRightSidebarData: LoaderFunction = async () => {
     ]);
 
     const resourcesData = resourcesResp.success
-        ? (resourcesResp.data as HelpfulLink[])
+        ? (resourcesResp.data as HelpfulLinkAndSort).helpful_links
         : [];
     const openContentData = openContentResp.success
         ? (openContentResp.data as OpenContentProvider[])

--- a/frontend/src/useAuth.ts
+++ b/frontend/src/useAuth.ts
@@ -35,7 +35,7 @@ export const getDashboard = (user?: User): string => {
         } else {
             return isAdministrator(user)
                 ? '/admin-dashboard'
-                : '/student-dashboard';
+                : '/student-activity';
         }
     }
 };


### PR DESCRIPTION
## Description of the change
Admins should see the following navigation menu:


Student Activity → This is the old “Dashboard”

Students → Links to the current Students page

Admins → Links to the current Admins page

Facilities → Links to the current Facilities page

Learning Platforms → This is the Provider Platform page.
Residents should see the following navigation menu:


My Courses → Links to the current My Courses page

My Learning → This is the old dashboard.
- **Related issues**:
Closes: #509

## Screenshot(s)

https://github.com/user-attachments/assets/9f9acbe7-42eb-45c6-8d00-b6745ce5f293

