### PR TITLE
feat: add layer 0 operational insights page w/ charts for user data

### DIFF
--- a/backend/go.mod
+++ b/backend/go.mod
@@ -20,6 +20,7 @@ require (
 	github.com/stretchr/testify v1.9.0
 	github.com/teambition/rrule-go v1.8.2
 	golang.org/x/exp v0.0.0-20240613232115-7f521ea00fb8
+	golang.org/x/oauth2 v0.24.0
 	gorm.io/datatypes v1.2.0
 	gorm.io/driver/postgres v1.5.9
 	gorm.io/gorm v1.25.11
@@ -74,7 +75,6 @@ require (
 	go.uber.org/multierr v1.11.0 // indirect
 	golang.org/x/crypto v0.26.0 // indirect
 	golang.org/x/net v0.27.0 // indirect
-	golang.org/x/oauth2 v0.24.0 // indirect
 	golang.org/x/sync v0.8.0 // indirect
 	golang.org/x/sys v0.25.0 // indirect
 	golang.org/x/text v0.18.0 // indirect

--- a/backend/migrations/00025_add_login_count_table.sql
+++ b/backend/migrations/00025_add_login_count_table.sql
@@ -1,0 +1,28 @@
+-- +goose Up
+-- +goose StatementBegin
+CREATE TABLE public.login_metrics (
+     user_id INTEGER NOT NULL PRIMARY KEY,
+	 total BIGINT NOT NULL DEFAULT 1,
+	 last_login timestamp with time zone DEFAULT now(),
+	 FOREIGN KEY (user_id) REFERENCES public.users(id) ON DELETE CASCADE ON UPDATE CASCADE
+);
+CREATE INDEX user_login_metrics_user_id_idx ON public.login_metrics(user_id);
+CREATE INDEX user_login_metrics_login_count_idx ON public.login_metrics(total);
+CREATE INDEX user_login_metrics_last_login_idx ON public.login_metrics(last_login);
+
+CREATE TABLE public.login_activity (
+    time_interval TIMESTAMP NOT NULL,
+    facility_id INT,
+    total_logins BIGINT DEFAULT 1,
+	FOREIGN KEY (facility_id) REFERENCES public.facilities(id) ON DELETE CASCADE ON UPDATE CASCADE,
+    PRIMARY KEY (time_interval, facility_id)
+);
+CREATE INDEX login_activity_time_interval_idx ON public.login_activity(time_interval);
+CREATE INDEX login_activity_facility_id_idx ON public.login_activity(facility_id);
+-- +goose StatementEnd
+
+-- +goose Down
+-- +goose StatementBegin
+DROP TABLE public.login_metrics CASCADE;
+DROP TABLE public.login_activity CASCADE;
+-- +goose StatementEnd

--- a/backend/src/handlers/left_menu_handler.go
+++ b/backend/src/handlers/left_menu_handler.go
@@ -16,7 +16,6 @@ func (srv *Server) registerLeftMenuRoutes() []routeDef {
 }
 
 func (srv *Server) handleGetLeftMenu(w http.ResponseWriter, r *http.Request, log sLog) error {
-	log.info("GET: /api/left-menu")
 	var limit int
 	limit, err := strconv.Atoi(r.URL.Query().Get("limit"))
 	if err != nil {

--- a/backend/src/handlers/login_flow.go
+++ b/backend/src/handlers/login_flow.go
@@ -77,6 +77,11 @@ func (s *Server) handleLogin(w http.ResponseWriter, r *http.Request, log sLog) e
 	if err != nil {
 		return NewServiceError(err, resp.StatusCode, "Invalid login")
 	}
+	err = s.Db.IncrementUserLogin(form.Username)
+	if err != nil {
+		log.error("Error incrementing user login count", err)
+		return newDatabaseServiceError(err)
+	}
 	return writeJsonResponse(w, http.StatusOK, redirect)
 }
 

--- a/backend/src/models/facilities.go
+++ b/backend/src/models/facilities.go
@@ -5,8 +5,9 @@ type Facility struct {
 	Name     string `gorm:"size:255;not null" json:"name"`
 	Timezone string `gorm:"size:255;not null" json:"timezone" validate:"timezone"`
 
-	Users    []User    `gorm:"foreignKey:FacilityID;references:ID;constraint:OnUpdate:CASCADE,OnDelete:SET NULL;" json:"-"`
-	Programs []Program `json:"programs" gorm:"many2many:facilities_programs;"`
+	Users         []User          `gorm:"foreignKey:FacilityID;references:ID;constraint:OnUpdate:CASCADE,OnDelete:SET NULL;" json:"-"`
+	Programs      []Program       `json:"programs" gorm:"many2many:facilities_programs;"`
+	LoginActivity []LoginActivity `json:"login_activity" gorm:"foreignKey:FacilityID;constraint:OnDelete CASCADE"`
 }
 
 func (Facility) TableName() string {

--- a/backend/src/models/logins.go
+++ b/backend/src/models/logins.go
@@ -1,0 +1,23 @@
+package models
+
+import "time"
+
+type LoginMetrics struct {
+	UserID    uint      `json:"user_id" gorm:"primaryKey"`
+	Total     int64     `json:"total" gorm:"default:1"`
+	LastLogin time.Time `json:"last_login" gorm:"default:CURRENT_TIMESTAMP"`
+
+	User *User `json:"user,omitempty" gorm:"foreignKey:UserID;constraint:OnDelete CASCADE"`
+}
+
+func (LoginMetrics) TableName() string { return "login_metrics" }
+
+type LoginActivity struct {
+	TimeInterval time.Time `json:"time_interval" gorm:"primaryKey"`
+	FacilityID   uint      `json:"facility_id" gorm:"primaryKey"`
+	TotalLogins  int64     `json:"total_logins" gorm:"default:1"`
+
+	Facility *Facility `json:"facility,omitempty" gorm:"foreignKey:FacilityID;constraint:OnDelete CASCADE"`
+}
+
+func (LoginActivity) TableName() string { return "login_activity" }

--- a/backend/src/models/users.go
+++ b/backend/src/models/users.go
@@ -45,6 +45,7 @@ type User struct {
 	FavoritePrograms []ProgramFavorite     `json:"favorite_programs,omitempty" gorm:"foreignKey:UserID;constraint:OnDelete CASCADE"`
 	Facility         *Facility             `json:"facility,omitempty" gorm:"foreignKey:FacilityID;constraint:OnDelete SET NULL"`
 	UserRole         *Role                 `json:"-" gorm:"foreignKey:Role;constraint:OnDelete SET NULL"`
+	LoginCount       *LoginMetrics         `json:"login_count,omitempty" gorm:"foreignKey:UserID;constraint:OnDelete CASCADE"`
 }
 
 type ImportUser struct {

--- a/config/kratos/kratos.yml
+++ b/config/kratos/kratos.yml
@@ -127,6 +127,6 @@ courier:
     from_address: no-reply@ory.kratos.sh
     local_name: localhost
 
-dev: true
+dev: false
 feature_flags:
   use_continue_with_transitions: true

--- a/frontend/src/Components/EngagementRateGraph.tsx
+++ b/frontend/src/Components/EngagementRateGraph.tsx
@@ -1,0 +1,39 @@
+import { Cell, Legend, Pie, PieChart, Tooltip } from 'recharts';
+
+const EngagementRateGraph = ({
+    active,
+    inactive
+}: {
+    active: number;
+    inactive: number;
+}) => {
+    const data = [
+        { name: 'Active', value: active },
+        { name: 'Inactive', value: inactive }
+    ];
+    const COLORS = ['#0088FE', '#00C49F', '#FFBB28', '#FF8042'];
+    return (
+        <>
+            <PieChart width={400} height={350}>
+                <Pie
+                    data={data}
+                    dataKey="value"
+                    nameKey="name"
+                    cx="50%"
+                    cy="50%"
+                    outerRadius={100}
+                    fill="#8884d8"
+                    label
+                >
+                    {data.map((_, index) => (
+                        <Cell key={`cell-${index}`} fill={COLORS[index]} />
+                    ))}
+                </Pie>
+                <Tooltip />
+                <Legend />
+            </PieChart>
+        </>
+    );
+};
+
+export default EngagementRateGraph;

--- a/frontend/src/Components/Navbar.tsx
+++ b/frontend/src/Components/Navbar.tsx
@@ -16,8 +16,9 @@ import {
     DocumentTextIcon,
     FolderOpenIcon,
     CloudIcon,
+    RssIcon,
     RectangleStackIcon,
-    RssIcon
+    CogIcon
 } from '@heroicons/react/24/solid';
 import { handleLogout, hasFeature, isAdministrator, useAuth } from '@/useAuth';
 import Modal from '@/Components/Modal';
@@ -133,6 +134,12 @@ export default function Navbar({
                                         </li>
                                     </>
                                 )}
+                                <li>
+                                    <Link to="/operational-insights">
+                                        <ULIComponent icon={CogIcon} />
+                                        Operational Insights
+                                    </Link>
+                                </li>
                                 {hasFeature(
                                     user,
                                     FeatureAccess.ProviderAccess

--- a/frontend/src/Components/OperationalInsightsCharts.tsx
+++ b/frontend/src/Components/OperationalInsightsCharts.tsx
@@ -1,0 +1,162 @@
+import { useEffect, useState } from 'react';
+import useSWR from 'swr';
+import { AxiosError } from 'axios';
+import API from '@/api/api';
+import { Facility, LoginMetrics, ServerResponseOne } from '@/common';
+import StatsCard from './StatsCard';
+import PeakLoginTimesChart from './PeakLoginTimesChart';
+import { ResponsiveContainer } from 'recharts';
+import EngagementRateGraph from './EngagementRateGraph';
+
+const OperationalInsights = () => {
+    const [facilities, setFacilities] = useState<Facility[]>();
+    const [facility, setFacility] = useState('all');
+    const [days, setDays] = useState(7);
+    const [resetCache, setResetCache] = useState(false);
+
+    const { data, error, isLoading, mutate } = useSWR<
+        ServerResponseOne<LoginMetrics>,
+        AxiosError
+    >(
+        `/api/login-metrics?facility=${facility}&days=${days}&reset=${resetCache}`
+    );
+
+    useEffect(() => {
+        void mutate();
+    }, [facility, days, resetCache]);
+
+    useEffect(() => {
+        const fetchFacilities = async () => {
+            const response = await API.get<Facility>('facilities');
+            setFacilities(response.data as Facility[]);
+        };
+        void fetchFacilities();
+    }, []);
+
+    const metrics = data?.data;
+
+    return (
+        <div className="p-8">
+            {error && <div>Error loading data</div>}
+            {!data || (isLoading && <div>Loading...</div>)}
+            {data && metrics && (
+                <>
+                    <div className="p-4">
+                        <button
+                            className="button"
+                            onClick={() => setResetCache(!resetCache)}
+                        >
+                            Refresh Data
+                        </button>
+                        <div className="flex flex-row gap-4">
+                            <div>
+                                <label htmlFor="days" className="label">
+                                    <span className="label-text">Days</span>
+                                </label>
+                                <select
+                                    id="days"
+                                    className="select select-bordered w-full max-w-xs"
+                                    value={days}
+                                    onChange={(e) =>
+                                        setDays(parseInt(e.target.value))
+                                    }
+                                >
+                                    <option value={7}>Last 7 days</option>
+                                    <option value={30}>Last 30 days</option>
+                                </select>
+                            </div>
+                            <div>
+                                <label htmlFor="facility" className="label">
+                                    <span className="label-text">Facility</span>
+                                </label>
+                                <select
+                                    id="facility"
+                                    className="select select-bordered w-full max-w-xs"
+                                    value={facility}
+                                    onChange={(e) =>
+                                        setFacility(e.target.value)
+                                    }
+                                >
+                                    <option key={'all'} value={'all'}>
+                                        All
+                                    </option>
+                                    {facilities?.map((facility) => (
+                                        <option
+                                            key={facility.id}
+                                            value={facility.id}
+                                        >
+                                            {facility.name}
+                                        </option>
+                                    ))}
+                                </select>
+                            </div>
+                        </div>
+                    </div>
+                    <div className="grid grid-cols-3 gap-4 mb-6">
+                        <StatsCard
+                            title="Total Users"
+                            number={metrics.total_users.toString()}
+                            label="users"
+                        />
+                        <StatsCard
+                            title="Active Users"
+                            number={metrics.active_users.toString()}
+                            label={`${(
+                                (metrics.active_users / metrics.total_users) *
+                                100
+                            ).toFixed(2)}% of total`}
+                        />
+                        <StatsCard
+                            title="Inactive Users"
+                            number={(
+                                metrics.total_users - metrics.active_users
+                            ).toString()}
+                            label="users"
+                        />
+                        <StatsCard
+                            title="Total Logins"
+                            number={metrics.total_logins.toString()}
+                            label="logins"
+                        />
+                        <StatsCard
+                            title="Logins per Day"
+                            number={metrics.logins_per_day.toString()}
+                            label="logins/day"
+                        />
+                        <StatsCard
+                            title="New Residents Added"
+                            number={metrics.new_residents_added.toString()}
+                            label="residents"
+                        />
+                    </div>
+                    <div className="card card-row-padding mb-30">
+                        <div className="flex flex-row gap-6">
+                            <div className="flex-1">
+                                <ResponsiveContainer width="100%" height={300}>
+                                    <PeakLoginTimesChart
+                                        peak_login_times={
+                                            metrics?.peak_login_times
+                                        }
+                                    />
+                                </ResponsiveContainer>
+                            </div>
+                            <div className="flex-1">
+                                <ResponsiveContainer width="100%" height={350}>
+                                    <EngagementRateGraph
+                                        active={metrics?.active_users}
+                                        inactive={
+                                            metrics.total_users -
+                                            metrics.active_users
+                                        }
+                                    />
+                                </ResponsiveContainer>
+                            </div>
+                        </div>
+                    </div>
+                </>
+            )}
+        </div>
+    );
+};
+
+export default OperationalInsights;

--- a/frontend/src/Components/PeakLoginTimesChart.tsx
+++ b/frontend/src/Components/PeakLoginTimesChart.tsx
@@ -1,0 +1,41 @@
+import {
+    Bar,
+    BarChart,
+    CartesianGrid,
+    Legend,
+    Tooltip,
+    XAxis,
+    YAxis
+} from 'recharts';
+import { LoginActivity } from '@/common';
+
+const PeakLoginTimesChart = ({
+    peak_login_times
+}: {
+    peak_login_times: LoginActivity[];
+}) => {
+    return (
+        <div className="mb-6">
+            <h3 className="text-xl font-semibold mb-2">Peak Login Times</h3>
+            <div className="flex flex-row gap-6">
+                <BarChart width={600} height={300} data={peak_login_times}>
+                    <CartesianGrid strokeDasharray="3 3" />
+                    <XAxis
+                        dataKey="time_interval"
+                        tickFormatter={(tick: string) =>
+                            new Date(tick).toLocaleTimeString([], {
+                                hour: '2-digit',
+                                minute: '2-digit'
+                            })
+                        }
+                    />
+                    <YAxis allowDecimals={false} />
+                    <Tooltip />
+                    <Legend />
+                    <Bar dataKey="total_logins" fill="#96D5CE" />
+                </BarChart>
+            </div>
+        </div>
+    );
+};
+export default PeakLoginTimesChart;

--- a/frontend/src/Pages/OperationalInsights.tsx
+++ b/frontend/src/Pages/OperationalInsights.tsx
@@ -1,0 +1,10 @@
+import OperationalInsights from '@/Components/OperationalInsightsCharts';
+
+export default function OperationalInsightsPage() {
+    return (
+        <div>
+            <h1>Operational Insights</h1>
+            <OperationalInsights />
+        </div>
+    );
+}

--- a/frontend/src/app.tsx
+++ b/frontend/src/app.tsx
@@ -55,6 +55,7 @@ import OpenContentManagement from './Pages/OpenContentManagement.tsx';
 import { FeatureAccess, INIT_KRATOS_LOGIN_FLOW } from './common.ts';
 import FavoritesPage from './Pages/Favorites.tsx';
 import OpenContentLevelDashboard from './Pages/OpenContentLevelDashboard.tsx';
+import OperationalInsightsPage from './Pages/OperationalInsights.tsx';
 
 const WithAuth: React.FC = () => {
     return (
@@ -314,9 +315,19 @@ const router = createBrowserRouter([
         element: <WithAdmin />,
         children: [
             {
+                id: 'admin',
                 element: <AuthenticatedLayout />,
                 loader: getFacilities,
                 children: [
+                    {
+                        path: 'operational-insights',
+                        element: <OperationalInsightsPage />,
+                        errorElement: <Error />,
+                        handle: {
+                            title: 'Operational Insights',
+                            path: ['operational-insights']
+                        }
+                    },
                     {
                         path: 'student-management',
                         element: <StudentManagement />,

--- a/frontend/src/common.ts
+++ b/frontend/src/common.ts
@@ -349,6 +349,24 @@ export interface ResourceCategory {
     rank: number;
 }
 
+export interface LoginMetrics {
+    active_users: number;
+    total_logins: number;
+    logins_per_day: number;
+    percent_active: number;
+    percent_inactive: number;
+    total_users: number;
+    facility: string;
+    new_residents_added: number;
+    peak_login_times: LoginActivity[];
+}
+
+export interface LoginActivity {
+    time_interval: string;
+    total_logins: number;
+    facility_id: number;
+}
+
 export type ResourceLink = Record<string, string>;
 
 export type EditableResourceCollection = ResourceCategory & {

--- a/provider-middleware/Dockerfile
+++ b/provider-middleware/Dockerfile
@@ -5,7 +5,7 @@ ARG YTDLP_VERSION=2024.12.06
 FROM mwader/static-ffmpeg:$FFMPEG_VERSION AS ffmpeg
 
 FROM golang:$GOLANG_VERSION AS yt-dlp
-RUN curl -L https://github.com/yt-dlp/yt-dlp/releases/download/$YTDLP_VERSION/yt-dlp_linux -o /yt-dlp && chmod a+x /yt-dlp
+RUN curl -L https://github.com/yt-dlp/yt-dlp/releases/download/$YTDLP_VERSION/yt-dlp -o /yt-dlp && chmod a+x /yt-dlp
 
 FROM golang:$GOLANG_VERSION-alpine as builder
 WORKDIR /app

--- a/provider-middleware/dev.Dockerfile
+++ b/provider-middleware/dev.Dockerfile
@@ -5,7 +5,7 @@ ARG YTDLP_VERSION=2024.12.06
 FROM mwader/static-ffmpeg:$FFMPEG_VERSION AS ffmpeg
 
 FROM golang:$GOLANG_VERSION AS yt-dlp
-RUN curl -L https://github.com/yt-dlp/yt-dlp/releases/download/$YTDLP_VERSION/yt-dlp_linux -o /yt-dlp && chmod a+x /yt-dlp
+RUN curl -L https://github.com/yt-dlp/yt-dlp/releases/download/$YTDLP_VERSION/yt-dlp -o /yt-dlp && chmod a+x /yt-dlp
 
 FROM golang:$GOLANG_VERSION-alpine as builder
 WORKDIR /app

--- a/provider-middleware/handlers.go
+++ b/provider-middleware/handlers.go
@@ -38,7 +38,7 @@ func (sh *ServiceHandler) initSubscription() error {
 		{models.SyncVideoMetadataJob.PubName(), sh.handleSyncVideoMetadata},
 	}
 	for _, sub := range subscriptions {
-		_, err := sh.nats.Subscribe(sub.topic, func(msg *nats.Msg) {
+		_, err := sh.nats.QueueSubscribe(sub.topic, "middleware", func(msg *nats.Msg) {
 			go sub.fn(sh.ctx, msg)
 		})
 		if err != nil {

--- a/provider-middleware/main.go
+++ b/provider-middleware/main.go
@@ -26,7 +26,6 @@ type ProviderServiceInterface interface {
 
 	ImportActivityForCourse(coursePair map[string]interface{}, db *gorm.DB) error
 
-	// TODO: GetOutcomes()
 	GetJobParams() *map[string]interface{}
 }
 

--- a/provider-middleware/video_dl.go
+++ b/provider-middleware/video_dl.go
@@ -165,7 +165,6 @@ func (yt *VideoService) downloadAndHostThumbnail(yt_id, url string) (string, err
 	}
 	req.Header.Set("User-Agent", "Mozilla/5.0")
 	req.Header.Set("Accept", "image/*")
-
 	resp, err := yt.Client.Do(req)
 	if err != nil {
 		logger().Errorf("error fetching thumbnail image from URL: %v", err)
@@ -176,17 +175,15 @@ func (yt *VideoService) downloadAndHostThumbnail(yt_id, url string) (string, err
 		logger().Errorf("failed to fetch thumbnail image: received %v response", resp.Status)
 		return "", fmt.Errorf("failed to fetch thumbnail image: %v", resp.Status)
 	}
-
 	imgData, err := io.ReadAll(resp.Body)
 	if err != nil {
 		logger().Errorf("error reading thumbnail image: %v", err)
 		return "", err
 	}
-
 	body := &bytes.Buffer{}
 	writer := multipart.NewWriter(body)
-	filename := yt_id + ".jpg"
 
+	filename := yt_id + ".jpg"
 	part, err := writer.CreateFormFile("file", filename)
 	if err != nil {
 		return "", err
@@ -195,8 +192,7 @@ func (yt *VideoService) downloadAndHostThumbnail(yt_id, url string) (string, err
 	if err != nil {
 		return "", err
 	}
-	fields := map[string]string{"filename": filename, "size": fmt.Sprintf("%d", len(imgData)), "type": "image/jpg"}
-	for key, value := range fields {
+	for key, value := range map[string]string{"filename": filename, "size": fmt.Sprintf("%d", len(imgData)), "type": "image/jpg"} {
 		err = writer.WriteField(key, value)
 		if err != nil {
 			return "", err
@@ -207,15 +203,12 @@ func (yt *VideoService) downloadAndHostThumbnail(yt_id, url string) (string, err
 		logger().Errorf("error closing writer: %v", err)
 		return "", err
 	}
-
-	uploadURL := os.Getenv("APP_URL") + "/upload"
-	req, err = http.NewRequest(http.MethodPost, uploadURL, body)
+	req, err = http.NewRequest(http.MethodPost, os.Getenv("APP_URL")+"/upload", body)
 	if err != nil {
 		logger().Errorf("error creating upload request: %v", err)
 		return "", err
 	}
 	req.Header.Set("Content-Type", writer.FormDataContentType())
-
 	uploadResp, err := yt.Client.Do(req)
 	if err != nil {
 		logger().Errorf("error sending upload request: %v", err)


### PR DESCRIPTION
This adds an `Operational Insights` page visible by administrators. This also creates the necessary table to track logins/counts/and times across facilities and displays the data to admins.

![image](https://github.com/user-attachments/assets/02242601-a315-46b6-be43-2aa04ce06bb1)
