### PR TITLE
fix: path for csv volume was invalid

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -103,7 +103,7 @@ services:
       - logs:/logs
       - ./frontend/public/videos:/videos
       - ./:/app
-      - csvs:/csvs
+      - ./provider-middleware/csvs:/csvs
     ports:
       - 8081:8081
     restart: unless-stopped


### PR DESCRIPTION
The path for the CSV volume in the Dockerfile wasn't recognized as a valid path. Updated it to include the `provider-middleware` folder.