### PR TITLE
feat: add helpful links limit and styling to opc dashboard

### DIFF
--- a/frontend/src/Components/cards/HelpfulLinkCard.tsx
+++ b/frontend/src/Components/cards/HelpfulLinkCard.tsx
@@ -1,4 +1,11 @@
-import { HelpfulLink, ModalType, ToastState, UserRole } from '@/common';
+import {
+    HelpfulLink,
+    HelpfulLinkAndSort,
+    ModalType,
+    ServerResponseOne,
+    ToastState,
+    UserRole
+} from '@/common';
 import API from '@/api/api';
 import VisibleHiddenToggle from '../VisibleHiddenToggle';
 import { useState } from 'react';
@@ -6,14 +13,17 @@ import ULIComponent from '../ULIComponent';
 import { PencilSquareIcon, TrashIcon } from '@heroicons/react/24/outline';
 import { AdminRoles, useAuth } from '@/useAuth';
 import { useToast } from '@/Context/ToastCtx';
+import { KeyedMutator } from 'swr';
 
 export default function HelpfulLinkCard({
     link,
     showModal,
+    mutate,
     role
 }: {
     link: HelpfulLink;
     showModal?: (link: HelpfulLink, type: ModalType) => void;
+    mutate?: KeyedMutator<ServerResponseOne<HelpfulLinkAndSort>>;
     role?: UserRole;
 }) {
     const [visible, setVisible] = useState<boolean>(link.visibility_status);
@@ -35,6 +45,7 @@ export default function HelpfulLinkCard({
             response.message,
             response.success ? ToastState.success : ToastState.error
         );
+        if (mutate) void mutate();
     };
 
     if (!user) {

--- a/frontend/src/Pages/HelpfulLinksManagement.tsx
+++ b/frontend/src/Pages/HelpfulLinksManagement.tsx
@@ -140,6 +140,7 @@ export default function HelpfulLinksManagement() {
                         <HelpfulLinkCard
                             key={index}
                             link={link}
+                            mutate={mutate}
                             showModal={showModifyLink}
                         />
                     );

--- a/frontend/src/Pages/OpenContentLevelDashboard.tsx
+++ b/frontend/src/Pages/OpenContentLevelDashboard.tsx
@@ -106,11 +106,11 @@ export default function OpenContentLevelDashboard() {
                     </div>
                 </div>
                 <h2>Resources</h2>
-                <div className="card card-row-padding overflow-x-scroll no-scrollbar">
+                <div className="card card-row-padding grid grid-cols-5 gap-3">
                     {helpfulLinks.map((link: HelpfulLink) => (
                         <div
                             key={link.id}
-                            className="w-[252px] cursor-pointer"
+                            className="cursor-pointer"
                             onClick={(e) => {
                                 e.preventDefault();
                                 void handleHelpfulLinkClick(link.id);

--- a/frontend/src/routeLoaders.ts
+++ b/frontend/src/routeLoaders.ts
@@ -22,7 +22,7 @@ export const getOpenContentDashboardData: LoaderFunction = async () => {
         favoritesResp,
         featuredResp
     ] = await Promise.all([
-        API.get(`helpful-links?visibility=true`),
+        API.get(`helpful-links?visibility=true&per_page=5`),
         API.get(`open-content/activity/${user.id}`),
         API.get(`open-content/activity`),
         API.get(`open-content/favorites`),


### PR DESCRIPTION
## Description of the change

Adds limit to helpful links query to only show top 5 links, fixes ui for helpful links on dashboard. also fixes a small bug where the visibility was not updating on the helpful links after switching to a new page.

- **Related issues**: Closes #527 

## Screenshot(s)
<img width="1049" alt="Screenshot 2024-12-10 at 9 33 49 AM" src="https://github.com/user-attachments/assets/3811de06-7a46-4896-9c33-c150f7e8d862">
