### PR TITLE
feat: add cron scheduling for Brightspace

### DIFF
--- a/backend/tasks/main.go
+++ b/backend/tasks/main.go
@@ -1,6 +1,8 @@
 package main
 
 import (
+	"UnlockEdv2/src/models"
+	"fmt"
 	"os"
 	"os/signal"
 	"syscall"
@@ -27,15 +29,20 @@ func main() {
 		log.Fatalf("failed to generate tasks: %v", err)
 		return
 	}
+	hour := 1
 	for _, task := range tasks {
 		if task.Job == nil {
 			log.Errorf("Task %v has no job", task.ID)
 			continue
 		}
-		_, err := scheduler.NewJob(gocron.CronJob(task.Job.Schedule, false), gocron.NewTask(runner.runTask, task))
+		_, err := scheduler.NewJob(gocron.CronJob(getCronSchedule(&task, hour), false), gocron.NewTask(runner.runTask, &task))
 		if err != nil {
 			log.Errorf("Failed to create job: %v", err)
 			continue
+		}
+		hour++
+		if hour > 23 {
+			hour = 1
 		}
 	}
 	runner.execute()
@@ -67,4 +74,12 @@ func initLogging() {
 		level = log.DebugLevel
 	}
 	log.SetLevel(level)
+}
+
+func getCronSchedule(task *models.RunnableTask, hour int) string {
+	if task.Provider != nil && task.Provider.Type == models.Brightspace {
+		return fmt.Sprintf("0 0 %d * * 4", hour)
+	} else {
+		return task.Job.Schedule
+	}
 }

--- a/backend/tasks/scheduler.go
+++ b/backend/tasks/scheduler.go
@@ -172,6 +172,9 @@ func (jr *JobRunner) execute() {
 	}
 	log.Infof("Generated %v tasks", tasks)
 	for _, task := range tasks {
+		if task.Provider != nil && task.Provider.Type == models.Brightspace {
+			continue
+		}
 		log.Infof("Running task: %v", task.Job.Name)
 		jr.runTask(&task)
 	}


### PR DESCRIPTION
## Description of the change

This adds the necessary logic for cron job scheduling of Brightspace tasks. 

- **Related issues**: Closes #545 


## Additional context
This checks the provider type against Brightspace, if the tasks provider type is of type models.Brightspace then at 1am getCourses will run, at 2am getMilestones will run, and at 3am getActivity will run. Given the https nature of Brightspace this implementation had to be tested on an instance of the development product configured for https, and then ported over to the regular non-https instance of the product. This branch brightspace_cron is a non-https ported branch, that which is running https tested code, just for reference. 