### PR TITLE
fix: Default to Kiwix thumbnail for small image libraries

### DIFF
--- a/provider-middleware/kiwix_data.go
+++ b/provider-middleware/kiwix_data.go
@@ -211,6 +211,8 @@ func (ks *KiwixService) ParseUrls(externId string, links []Link) (string, string
 			if !ks.thumbnailExists(externId) {
 				if thumbnail, err := ks.downloadAndHostThumbnailImg(externId, link.Href); err == nil {
 					thumbnailURL = thumbnail
+				} else {
+					thumbnailURL = "/kiwix.jpg"
 				}
 			} else {
 				thumbnailURL = "/api/photos/" + externId + ".png"

--- a/provider-middleware/kiwix_data.go
+++ b/provider-middleware/kiwix_data.go
@@ -51,7 +51,7 @@ type Link struct {
 }
 
 const (
-	MinImgSize = 2048
+	MinImgSize = 150
 )
 
 func (ks *KiwixService) IntoLibrary(entry Entry, providerId uint) *models.Library {
@@ -113,8 +113,8 @@ func (ks *KiwixService) downloadAndHostThumbnailImg(lib, thumbnail string) (stri
 
 	var filename string
 	if len(imgData) < MinImgSize {
-		logger().Errorf("thumbnail image is too small: %d bytes", len(imgData))
-		return "kiwix.jpg", nil
+		logger().Errorf("thumbnail image %s is too small: %d bytes", lib, len(imgData))
+		return "/kiwix.jpg", nil
 	} else {
 		filename = lib + ".png"
 	}

--- a/provider-middleware/kiwix_data.go
+++ b/provider-middleware/kiwix_data.go
@@ -50,6 +50,10 @@ type Link struct {
 	Type string `xml:"type,attr"`
 }
 
+const (
+	MinImgSize = 2048
+)
+
 func (ks *KiwixService) IntoLibrary(entry Entry, providerId uint) *models.Library {
 	url, thumbnailURL := ks.ParseUrls(entry.Title, entry.Links)
 	return &models.Library{
@@ -107,9 +111,16 @@ func (ks *KiwixService) downloadAndHostThumbnailImg(lib, thumbnail string) (stri
 		return "", err
 	}
 
+	var filename string
+	if len(imgData) < MinImgSize {
+		logger().Errorf("thumbnail image is too small: %d bytes", len(imgData))
+		return "kiwix.jpg", nil
+	} else {
+		filename = lib + ".png"
+	}
+
 	body := &bytes.Buffer{}
 	writer := multipart.NewWriter(body)
-	filename := lib + ".png"
 
 	part, err := writer.CreateFormFile("file", filename)
 	if err != nil {


### PR DESCRIPTION
## Description of the change
This checks the byte size of the image being downloaded for the library thumbnail, if it is below the constant of 2048 bytes, it sets the filename and therefor the default thumbnail URL for the library to the kiwix thumbnail helping to avoid blank images when displaying libraries in the Dashboard or the Knowledge center. 

- **Related issues**: Closes #567 

## Additional context

Also adds a check in ParseUrls in which if there is an error in downloading the thumbnail it will default to the Kiwix thumbnail. 