### PR TITLE
feat: add in progress to user my progress page and remove activity chart per #528

### DIFF
--- a/backend/src/database/user_catalogue.go
+++ b/backend/src/database/user_catalogue.go
@@ -1,7 +1,6 @@
 package database
 
 import (
-	"UnlockEdv2/src/models"
 	"fmt"
 	"slices"
 	"strings"

--- a/backend/src/database/user_catalogue.go
+++ b/backend/src/database/user_catalogue.go
@@ -47,6 +47,13 @@ func (db *DB) GetUserCatalogue(userId int, tags []string, search, order string) 
 	return catalogue, nil
 }
 
+type UserCoursesInfo struct {
+	Courses    []UserCourses `json:"courses"`
+	Completed  uint          `json:"num_completed"`
+	InProgress uint          `json:"num_in_progress"`
+	TotalTime  uint          `json:"total_time"`
+}
+
 type UserCourses struct {
 	ID             uint       `json:"id"`
 	ThumbnailURL   string     `json:"thumbnail_url"`
@@ -66,13 +73,14 @@ func validOrder(str string) string {
 	return "desc"
 }
 
-func (db *DB) GetUserCourses(userId uint, order string, orderBy string, search string, tags []string) ([]UserCourses, uint, uint, error) {
+func (db *DB) GetUserCourses(userId uint, order string, orderBy string, search string, tags []string) (UserCoursesInfo, error) {
+	var courseInfo UserCoursesInfo
 	courses := []UserCourses{}
 	fieldMap := map[string]string{
 		"course_name":     "c.name",
 		"provider_name":   "pp.name",
 		"course_progress": "course_progress",
-		"total_time":      "a.total_time",
+		"total_time":      "total_time",
 		"start_dt":        "c.start_dt",
 		"end_dt":          "c.end_dt",
 	}
@@ -81,27 +89,33 @@ func (db *DB) GetUserCourses(userId uint, order string, orderBy string, search s
 		dbField = "c.name"
 	}
 	orderStr := dbField + " " + validOrder(order)
-
 	tx := db.Table("courses c").
 		Select(`c.id, c.thumbnail_url,
-    c.name as course_name, pp.name as provider_name, c.external_url, c.start_dt, c.end_dt,
-    CASE
-        WHEN EXISTS (SELECT 1 FROM outcomes o WHERE o.course_id = c.id AND o.user_id = ?) THEN 100
-        WHEN c.total_progress_milestones = 0 THEN 0
-        ELSE
-           CASE WHEN (SELECT COUNT(m.id) * 100.0 / c.total_progress_milestones
-              FROM milestones m
-              WHERE m.course_id = c.id AND m.user_id = ?) = 100 THEN 99.999
-          ELSE (SELECT COUNT(m.id) * 100.0 / c.total_progress_milestones) END
-    END as course_progress,
-    a.total_time`, userId, userId).
+		c.name as course_name, pp.name as provider_name, c.external_url, c.start_dt, c.end_dt,
+		progress.course_progress,
+			sum(a.total_time) as total_time`).
 		Joins("JOIN provider_platforms pp ON c.provider_platform_id = pp.id").
 		Joins("JOIN milestones as m ON m.course_id = c.id and m.user_id = ?", userId).
+		Joins(`JOIN (Select cc.id,
+				CASE WHEN EXISTS (SELECT 1 FROM outcomes o WHERE o.course_id = cc.id AND o.user_id = ?) THEN 100
+					WHEN cc.total_progress_milestones = 0 THEN 0
+				ELSE
+				CASE WHEN (SELECT COUNT(m.id) * 100.0 / cc.total_progress_milestones
+						FROM milestones m
+						WHERE m.course_id = cc.id AND m.user_id = ?) = 100 THEN 99.999
+				ELSE (SELECT COUNT(m.id) * 100.0 / cc.total_progress_milestones
+					FROM milestones m
+					WHERE m.course_id = cc.id AND m.user_id = ?
+				) END
+				END as course_progress
+				from courses cc 
+				where cc.deleted_at IS NULL
+				) progress on progress.id = c.id`, userId, userId, userId).
 		Joins(`JOIN (select id, course_id, user_id, total_time, row_number() over (PARTITION BY course_id, user_id ORDER BY created_at DESC) AS RN 
-               			from activities
+			from activities
 			) a on a.course_id = c.id
-        			and a.user_id = m.user_id
-        			and a.RN = 1`).
+			and a.user_id = m.user_id
+			and a.RN = 1`).
 		Joins("LEFT JOIN outcomes o ON o.course_id = c.id AND o.user_id = m.user_id").
 		Where("c.deleted_at IS NULL").
 		Where("pp.deleted_at IS NULL")
@@ -125,21 +139,27 @@ func (db *DB) GetUserCourses(userId uint, order string, orderBy string, search s
 			tx.Or(query)
 		}
 	}
-
-	tx.Group("c.id, c.name, c.thumbnail_url, pp.name, c.external_url, a.total_time")
+	tx.Group("c.id, c.name, c.thumbnail_url, pp.name, c.external_url, progress.course_progress")
 	err := tx.Scan(&courses).Error
 	if err != nil {
-		return nil, 0, 0, NewDBError(err, "error getting user programs")
+		return courseInfo, NewDBError(err, "error getting user programs")
 	}
-
-	var numCompleted int64
-	if err := db.Model(&models.Outcome{}).Where("user_id = ?", userId).Count(&numCompleted).Error; err != nil {
-		return nil, 0, 0, NewDBError(err, "error getting user programs")
-	}
-	var totalTime uint
+	var (
+		totalTime     uint
+		numCompleted  int64
+		numInProgress int64
+	)
 	for _, course := range courses {
 		totalTime += course.TotalTime
+		if int(course.CourseProgress) == 100 {
+			numCompleted++
+		} else {
+			numInProgress++
+		}
 	}
-
-	return courses, uint(numCompleted), totalTime, nil
+	courseInfo.Completed = uint(numCompleted)
+	courseInfo.InProgress = uint(numInProgress)
+	courseInfo.TotalTime = totalTime
+	courseInfo.Courses = courses
+	return courseInfo, nil
 }

--- a/backend/src/handlers/dashboard.go
+++ b/backend/src/handlers/dashboard.go
@@ -197,15 +197,10 @@ func (srv *Server) handleUserCourses(w http.ResponseWriter, r *http.Request, log
 	if len(tags) > 0 {
 		tagsSplit = strings.Split(tags[0], ",")
 	}
-	userCourses, numCompleted, totalTime, err := srv.Db.GetUserCourses(uint(userId), order, orderBy, search, tagsSplit)
+	userCourses, err := srv.Db.GetUserCourses(uint(userId), order, orderBy, search, tagsSplit)
 	if err != nil {
 		log.add("search", search)
 		return newDatabaseServiceError(err)
 	}
-	response := map[string]interface{}{
-		"courses":       userCourses,
-		"num_completed": numCompleted,
-		"total_time":    totalTime,
-	}
-	return writeJsonResponse(w, http.StatusOK, response)
+	return writeJsonResponse(w, http.StatusOK, userCourses)
 }

--- a/frontend/src/Pages/MyProgress.tsx
+++ b/frontend/src/Pages/MyProgress.tsx
@@ -2,7 +2,6 @@ import { useAuth } from '@/useAuth';
 import { useState } from 'react';
 import { AxiosError } from 'axios';
 import StatsCard from '@/Components/StatsCard';
-import UserActivityMap from '@/Components/UserActivityMap';
 import DarkGreenPill from '@/Components/pill-labels/DarkGreenPill';
 import TealPill from '@/Components/pill-labels/TealPill';
 import useSWR from 'swr';
@@ -54,24 +53,24 @@ export default function MyProgress() {
             <h1>My Progress</h1>
             {!error && courseData && (
                 <>
-                    <div className="mt-7 flex flex-row gap-12">
-                        <div className="flex flex-col justify-between w-full">
-                            <StatsCard
-                                title="TOTAL TIME"
-                                number={Math.floor(
-                                    courseData.total_time / 3600
-                                ).toString()}
-                                label="hours"
-                            />
-                            <StatsCard
-                                title="COMPLETED"
-                                number={courseData.num_completed.toString()}
-                                label="courses"
-                            />
-                        </div>
-                        <div className="w-full">
-                            <UserActivityMap />
-                        </div>
+                    <div className="grid grid-cols-3 gap-4 mt-6 mb-6">
+                        <StatsCard
+                            title="TOTAL TIME"
+                            number={Math.floor(
+                                courseData.total_time / 3600
+                            ).toString()}
+                            label="hours"
+                        />
+                        <StatsCard
+                            title="COMPLETED"
+                            number={courseData.num_completed.toString()}
+                            label="courses"
+                        />
+                        <StatsCard
+                            title="IN PROGRESS"
+                            number={courseData.num_in_progress.toString()}
+                            label="courses"
+                        />
                     </div>
                     <div className="flex flex-row gap-12 mt-12">
                         <div className="card bg-base-teal h-[531px] w-full p-4 overflow-y-auto">

--- a/frontend/src/common.ts
+++ b/frontend/src/common.ts
@@ -424,6 +424,7 @@ export interface Outcome {
 }
 export interface UserCoursesInfo {
     num_completed: number;
+    num_in_progress: number;
     total_time: number;
     courses: UserCourses[];
 }


### PR DESCRIPTION
## Description of the change

Validated that all of the following are displayed on the 'My Progress' page:

- Number of courses completed
- Number of courses in progress
- Time spent working on course material
- Course listing (completed and in progress)
- Activity view (removed from My Progress page)

Also, I have documented how each of the numbers is calculated here: https://github.com/UnlockedLabs/UnlockEdv2/wiki/Course-Progress-Calculations

I modified the SQL query to correctly group the database records along with summing the total time spent working on course material. I also added logic for retrieving the number of 'in progress' courses. 


- **Related issues**: Closes #528.

## Screenshot(s)

![Page528](https://github.com/user-attachments/assets/120aa429-f09a-40a6-bdfe-3fb07543e21c)
