### PR TITLE
Blocked tooltip

### DIFF
--- a/backend/tasks/main.go
+++ b/backend/tasks/main.go
@@ -1,6 +1,8 @@
 package main
 
 import (
+	"UnlockEdv2/src/models"
+	"fmt"
 	"os"
 	"os/signal"
 	"syscall"
@@ -27,15 +29,20 @@ func main() {
 		log.Fatalf("failed to generate tasks: %v", err)
 		return
 	}
+	hour := 1
 	for _, task := range tasks {
 		if task.Job == nil {
 			log.Errorf("Task %v has no job", task.ID)
 			continue
 		}
-		_, err := scheduler.NewJob(gocron.CronJob(task.Job.Schedule, false), gocron.NewTask(runner.runTask, &task))
+		_, err := scheduler.NewJob(gocron.CronJob(getCronSchedule(&task, hour), false), gocron.NewTask(runner.runTask, &task))
 		if err != nil {
 			log.Errorf("Failed to create job: %v", err)
 			continue
+		}
+		hour++
+		if hour > 23 {
+			hour = 1
 		}
 	}
 	runner.execute()
@@ -67,4 +74,12 @@ func initLogging() {
 		level = log.DebugLevel
 	}
 	log.SetLevel(level)
+}
+
+func getCronSchedule(task *models.RunnableTask, hour int) string {
+	if task.Provider != nil && task.Provider.Type == models.Brightspace {
+		return fmt.Sprintf("0 0 %d * * 4", hour)
+	} else {
+		return task.Job.Schedule
+	}
 }

--- a/backend/tasks/scheduler.go
+++ b/backend/tasks/scheduler.go
@@ -172,6 +172,9 @@ func (jr *JobRunner) execute() {
 	}
 	log.Infof("Generated %v tasks", tasks)
 	for _, task := range tasks {
+		if task.Provider != nil && task.Provider.Type == models.Brightspace {
+			continue
+		}
 		log.Infof("Running task: %v", task.Job.Name)
 		jr.runTask(&task)
 	}

--- a/frontend/src/Components/FavoriteCard.tsx
+++ b/frontend/src/Components/FavoriteCard.tsx
@@ -52,7 +52,8 @@ const FavoriteCard: React.FC<FavoriteCardProps> = ({
                 favorite.visibility_status
                     ? 'bg-grey-2 cursor-not-allowed'
                     : 'bg-inner-background cursor-pointer'
-            }`}
+            } tooltip `}
+            data-tip={favorite.visibility_status ? 'Unavailable Content' : ''}
             onClick={favorite.visibility_status ? undefined : handleCardClick}
         >
             {!isAdminInStudentView && (

--- a/frontend/src/Components/LibraryCard.tsx
+++ b/frontend/src/Components/LibraryCard.tsx
@@ -74,32 +74,31 @@ export default function LibraryCard({
                 </figure>
                 <h3 className="w-3/4 body my-auto mr-7">{library.title}</h3>
             </div>
-            {role != UserRole.Student && (
-                <div
-                    className="absolute right-2 top-2 z-100"
-                    onClick={(e) => void toggleLibraryFavorite(e)}
-                >
-                    {/* don't display the favorite toggle when admin is viewing in student view*/}
-                    <ULIComponent
-                        tooltipClassName="absolute right-2 top-2 z-100"
-                        iconClassName={`w-6 h-6 ${library.favorites.length > 0 && 'text-primary-yellow'}`}
-                        icon={
-                            AdminRoles.includes(role)
-                                ? library.favorites.length > 0
-                                    ? FlagIcon
-                                    : FlagIconOutline
-                                : library.favorites.length > 0
-                                  ? StarIcon
-                                  : StarIconOutline
-                        }
-                        dataTip={
-                            AdminRoles.includes(role)
-                                ? 'Feature Library'
-                                : 'Favorite Library'
-                        }
-                    />
-                </div>
-            )}
+
+            <div
+                className="absolute right-2 top-2 z-100"
+                onClick={(e) => void toggleLibraryFavorite(e)}
+            >
+                {/* don't display the favorite toggle when admin is viewing in student view*/}
+                <ULIComponent
+                    tooltipClassName="absolute right-2 top-2 z-100"
+                    iconClassName={`w-6 h-6 ${library.favorites.length > 0 && 'text-primary-yellow'}`}
+                    icon={
+                        AdminRoles.includes(role)
+                            ? library.favorites.length > 0
+                                ? FlagIcon
+                                : FlagIconOutline
+                            : library.favorites.length > 0
+                              ? StarIcon
+                              : StarIconOutline
+                    }
+                    dataTip={
+                        AdminRoles.includes(role)
+                            ? 'Feature Library'
+                            : 'Favorite Library'
+                    }
+                />
+            </div>
 
             <div className="p-4 space-y-2">
                 <p className="body-small">{'Kiwix'}</p>


### PR DESCRIPTION
## Description of the change
This adds a tooltip "Unavailable Content" to any favorited content that has been disabled by an Admin since being favorited. Also fixes an admin check on the Library Card that was causing the favoriting star not to be rendered for students. 

- **Related issues**: Closes #566 

## Screenshot(s)

![image](https://github.com/user-attachments/assets/3160e852-d18a-4ab5-9a96-7fb1997a4ceb)

