### PR TITLE
fix: add tooltip to make users aware of disabled favorited content

### DIFF
--- a/backend/tasks/scheduler.go
+++ b/backend/tasks/scheduler.go
@@ -151,7 +151,7 @@ func (jr *JobRunner) runTask(task *models.RunnableTask) {
 		return
 	}
 	task.Status = models.StatusRunning
-	if err := jr.db.Save(task).Error; err != nil {
+	if err := jr.db.Model(&models.RunnableTask{}).Where("id = ?", task.ID).Update("status", models.StatusRunning).Error; err != nil {
 		log.Errorf("failed to update task status: %v", err)
 		return
 	}

--- a/frontend/src/Components/FavoriteCard.tsx
+++ b/frontend/src/Components/FavoriteCard.tsx
@@ -52,7 +52,8 @@ const FavoriteCard: React.FC<FavoriteCardProps> = ({
                 favorite.visibility_status
                     ? 'bg-grey-2 cursor-not-allowed'
                     : 'bg-inner-background cursor-pointer'
-            }`}
+            } tooltip `}
+            data-tip={favorite.visibility_status ? 'Unavailable Content' : ''}
             onClick={favorite.visibility_status ? undefined : handleCardClick}
         >
             {!isAdminInStudentView && (

--- a/frontend/src/Components/LibraryCard.tsx
+++ b/frontend/src/Components/LibraryCard.tsx
@@ -74,32 +74,31 @@ export default function LibraryCard({
                 </figure>
                 <h3 className="w-3/4 body my-auto mr-7">{library.title}</h3>
             </div>
-            {role != UserRole.Student && (
-                <div
-                    className="absolute right-2 top-2 z-100"
-                    onClick={(e) => void toggleLibraryFavorite(e)}
-                >
-                    {/* don't display the favorite toggle when admin is viewing in student view*/}
-                    <ULIComponent
-                        tooltipClassName="absolute right-2 top-2 z-100"
-                        iconClassName={`w-6 h-6 ${library.favorites.length > 0 && 'text-primary-yellow'}`}
-                        icon={
-                            AdminRoles.includes(role)
-                                ? library.favorites.length > 0
-                                    ? FlagIcon
-                                    : FlagIconOutline
-                                : library.favorites.length > 0
-                                  ? StarIcon
-                                  : StarIconOutline
-                        }
-                        dataTip={
-                            AdminRoles.includes(role)
-                                ? 'Feature Library'
-                                : 'Favorite Library'
-                        }
-                    />
-                </div>
-            )}
+
+            <div
+                className="absolute right-2 top-2 z-100"
+                onClick={(e) => void toggleLibraryFavorite(e)}
+            >
+                {/* don't display the favorite toggle when admin is viewing in student view*/}
+                <ULIComponent
+                    tooltipClassName="absolute right-2 top-2 z-100"
+                    iconClassName={`w-6 h-6 ${library.favorites.length > 0 && 'text-primary-yellow'}`}
+                    icon={
+                        AdminRoles.includes(role)
+                            ? library.favorites.length > 0
+                                ? FlagIcon
+                                : FlagIconOutline
+                            : library.favorites.length > 0
+                              ? StarIcon
+                              : StarIconOutline
+                    }
+                    dataTip={
+                        AdminRoles.includes(role)
+                            ? 'Feature Library'
+                            : 'Favorite Library'
+                    }
+                />
+            </div>
 
             <div className="p-4 space-y-2">
                 <p className="body-small">{'Kiwix'}</p>

--- a/frontend/src/Components/OperationalInsightsCharts.tsx
+++ b/frontend/src/Components/OperationalInsightsCharts.tsx
@@ -48,7 +48,7 @@ const OperationalInsights = () => {
                         >
                             Refresh Data
                         </button>
-                        <div className="flex flex-row gap-4">
+                        <div className="flex flex-row gap-4 pb-4">
                             <div>
                                 <label htmlFor="days" className="label">
                                     <span className="label-text">Days</span>

--- a/frontend/src/Components/OperationalInsightsCharts.tsx
+++ b/frontend/src/Components/OperationalInsightsCharts.tsx
@@ -36,12 +36,12 @@ const OperationalInsights = () => {
     const metrics = data?.data;
 
     return (
-        <div className="p-8">
+        <div className="p-6">
             {error && <div>Error loading data</div>}
             {!data || (isLoading && <div>Loading...</div>)}
             {data && metrics && (
                 <>
-                    <div className="p-4">
+                    <div className="">
                         <button
                             className="button"
                             onClick={() => setResetCache(!resetCache)}

--- a/frontend/src/Pages/OperationalInsights.tsx
+++ b/frontend/src/Pages/OperationalInsights.tsx
@@ -3,8 +3,10 @@ import OperationalInsights from '@/Components/OperationalInsightsCharts';
 export default function OperationalInsightsPage() {
     return (
         <div>
-            <h1>Operational Insights</h1>
-            <OperationalInsights />
+            <div className="px-8 pb-4 mt-4">
+                <h1>Operational Insights</h1>
+                <OperationalInsights />
+            </div>
         </div>
     );
 }

--- a/frontend/src/Pages/OperationalInsights.tsx
+++ b/frontend/src/Pages/OperationalInsights.tsx
@@ -3,7 +3,7 @@ import OperationalInsights from '@/Components/OperationalInsightsCharts';
 export default function OperationalInsightsPage() {
     return (
         <div>
-            <div className="px-8 pb-4 mt-4">
+            <div className="px-8 pb-4 mt-8">
                 <h1>Operational Insights</h1>
                 <OperationalInsights />
             </div>


### PR DESCRIPTION
## Description of the change
This adds a tooltip "Unavailable Content" to any favorited content that has been disabled by an Admin since being favorited. Also fixes an admin check on the Library Card that was causing the favoriting star not to be rendered for students. Also adds appropriate spacing in Operational Insights 

- **Related issues**: Closes #566 Closes #576 

## Screenshot(s)
![image](https://github.com/user-attachments/assets/f8ffb014-2554-4863-9331-881ab46ae7a3)

![image](https://github.com/user-attachments/assets/1ca78d2a-fb0d-4a08-8d32-dd22fabe8d1a)

