### PR TITLE
refactor: modified logging statement to include library name

### DIFF
--- a/provider-middleware/kiwix.go
+++ b/provider-middleware/kiwix.go
@@ -90,7 +90,7 @@ func (ks *KiwixService) ImportLibraries(ctx context.Context, db *gorm.DB) error 
 }
 
 func (ks *KiwixService) UpdateOrInsertLibrary(ctx context.Context, db *gorm.DB, entry Entry, providerId uint) error {
-	logger().Infoln("Attempting to update existing Kiwix Libraries.")
+	logger().Infof("Attempting to insert or update library from Kiwix: %v", entry.Title)
 	library := ks.IntoLibrary(entry, providerId)
 	if err := db.WithContext(ctx).
 		Where(&models.Library{ExternalID: models.StringPtr(entry.ID)}).


### PR DESCRIPTION
## Description of the change

This change just updates one of the logging statements to include the Kiwix library name. 

Before

>Attempting to update existing Kiwix Libraries.","time":"2024-12-11T17:14:34Z

After

>Attempting to insert or update library from Kiwix: Termux Wiki","time":"2024-12-11T19:51:36Z