### PR TITLE
fix: prevent scheduler from updating relation on task, frontend lints

### DIFF
--- a/backend/tasks/database.go
+++ b/backend/tasks/database.go
@@ -32,12 +32,12 @@ func initDB() *gorm.DB {
 }
 
 func (jr *JobRunner) intoProviderPlatformTask(cj *models.CronJob, provId uint, task *models.RunnableTask) error {
-	if err := jr.db.Model(&models.RunnableTask{}).Preload("Job").Preload("Provider").
+	if err := jr.db.Model(&models.RunnableTask{}).
 		Where(models.RunnableTask{ProviderPlatformID: &provId, JobID: cj.ID}).FirstOrCreate(&task).Error; err != nil {
 		log.Errorf("failed to create task for job: %v. error: %v", cj.Name, err)
 		return err
 	}
-	if err := jr.db.Model(&task).Preload("Job").Preload("Provider").First(&task).Error; err != nil {
+	if err := jr.db.Model(&models.RunnableTask{}).Preload("Job").Preload("Provider").First(&task, task.ID).Error; err != nil {
 		log.Errorf("failed to reload task for job: %v. error: %v", cj.Name, err)
 		return err
 	}

--- a/frontend/src/Components/inputs/DropdownInput.tsx
+++ b/frontend/src/Components/inputs/DropdownInput.tsx
@@ -38,7 +38,7 @@ export function DropdownInput({
                 ))}
             </select>
             <div className="text-error text-sm">
-                {errors[interfaceRef]?.message?.toString()}
+                {errors[interfaceRef]?.message as string}
             </div>
         </label>
     );

--- a/frontend/src/Components/inputs/TextAreaInput.tsx
+++ b/frontend/src/Components/inputs/TextAreaInput.tsx
@@ -39,7 +39,7 @@ export function TextAreaInput({
                 {...register(interfaceRef, options)}
             />
             <div className="text-error text-sm">
-                {errors[interfaceRef]?.message?.toString()}
+                {errors[interfaceRef]?.message as string}
             </div>
         </label>
     );

--- a/frontend/src/Components/inputs/TextInput.tsx
+++ b/frontend/src/Components/inputs/TextInput.tsx
@@ -53,7 +53,7 @@ export function TextInput({
                 autoFocus={isFocused}
             />
             <div className="text-error text-sm">
-                {errors[interfaceRef]?.message?.toString()}
+                {errors[interfaceRef]?.message as string}
             </div>
         </label>
     );


### PR DESCRIPTION
for whatever reason, `as string` shuts the lints up.

Also prevent the scheduler from creating/updating the tables that are embedded relationships in the struct.