### PR TITLE
simplify the cron scheduling, remove blocking for first run to get courses

### DIFF
--- a/backend/src/models/jobs.go
+++ b/backend/src/models/jobs.go
@@ -83,6 +83,22 @@ const (
 var AllDefaultProviderJobs = []JobType{GetCoursesJob, GetMilestonesJob, GetActivityJob}
 var AllContentProviderJobs = []JobType{ScrapeKiwixJob, RetryVideoDownloadsJob, SyncVideoMetadataJob, PutVideoMetadataJob}
 
+func (jt JobType) IsVideoJob() bool {
+	switch jt {
+	case RetryVideoDownloadsJob, SyncVideoMetadataJob, PutVideoMetadataJob:
+		return true
+	}
+	return false
+}
+
+func (jt JobType) IsLibraryJob() bool {
+	switch jt {
+	case ScrapeKiwixJob:
+		return true
+	}
+	return false
+}
+
 func (jt JobType) PubName() string {
 	return fmt.Sprintf("tasks.%s", string(jt))
 }

--- a/provider-middleware/middleware.go
+++ b/provider-middleware/middleware.go
@@ -91,7 +91,7 @@ func (sh *ServiceHandler) cleanupJob(ctx context.Context, provId int, jobId stri
 	log.Infof("job %s succeeded?: %v \n cleaning up task", jobId, success)
 	var task models.RunnableTask
 	if err := sh.db.WithContext(ctx).Model(models.RunnableTask{}).
-		Find(&task, "(provider_platform_id = ? AND job_id = ?) OR (open_content_provider_id = ? AND job_id = ?)", provId, jobId, provId, jobId).
+		First(&task, "(provider_platform_id = ? AND job_id = ?) OR (open_content_provider_id = ? AND job_id = ?)", provId, jobId, provId, jobId).
 		Error; err != nil {
 		log.Errorf("failed to fetch task: %v", err)
 		return


### PR DESCRIPTION
This improves the flow of the scheduled jobs, prevents blocking all other tasks if a provider is found with no courses, allowing the OCP tasks to run on first go. Simplifies the general flow.