### PR TITLE
Layer 1 Resident Dashboard > Organize Favorites by Content Type #550

### DIFF
--- a/backend/migrations/00029_alter_open_content_favorites_table.sql
+++ b/backend/migrations/00029_alter_open_content_favorites_table.sql
@@ -1,0 +1,11 @@
+-- +goose Up
+-- +goose StatementBegin
+ALTER TABLE public.open_content_favorites DROP COLUMN updated_at;
+ALTER TABLE public.open_content_favorites DROP COLUMN deleted_at;
+-- +goose StatementEnd
+
+-- +goose Down
+-- +goose StatementBegin
+ALTER TABLE public.open_content_favorites ADD COLUMN updated_at timestamp with time zone;
+ALTER TABLE public.open_content_favorites ADD COLUMN deleted_at timestamp with time zone;
+-- +goose StatementEnd

--- a/backend/src/database/helpful_links.go
+++ b/backend/src/database/helpful_links.go
@@ -15,7 +15,7 @@ func (db *DB) GetHelpfulLinks(page, perPage int, search, orderBy string, onlyVis
 
 	subQuery := db.Table("open_content_favorites f").
 		Select("1").
-		Where("f.content_id = helpful_links.id AND f.user_id = ? AND f.deleted_at IS NULL", userID)
+		Where("f.content_id = helpful_links.id AND f.user_id = ?", userID)
 	tx := db.Model(&models.HelpfulLink{}).Select("helpful_links.*, EXISTS(?) as is_favorited", subQuery)
 	var total int64
 

--- a/backend/src/database/libraries.go
+++ b/backend/src/database/libraries.go
@@ -24,7 +24,6 @@ func (db *DB) GetAllLibraries(page, perPage int, userId, facilityId uint, visibi
             WHERE f.content_id = libraries.id
               AND f.open_content_provider_id = libraries.open_content_provider_id
               AND f.user_id = ?
-              AND f.deleted_at IS NULL
         ) AS is_favorited`, userId)
 
 	visibility = strings.ToLower(visibility)
@@ -65,7 +64,6 @@ func (db *DB) GetAllLibraries(page, perPage int, userId, facilityId uint, visibi
                 WHERE f.content_id = libraries.id
                   AND f.open_content_provider_id = libraries.open_content_provider_id
                   AND f.user_id = ?
-                  AND f.deleted_at IS NULL
             ) AS is_favorited`, userId)
 		if !isFeatured {
 			tx = tx.Joins(`LEFT JOIN open_content_favorites f 
@@ -84,7 +82,6 @@ func (db *DB) GetAllLibraries(page, perPage int, userId, facilityId uint, visibi
                 WHERE f.content_id = libraries.id
                   AND f.open_content_provider_id = libraries.open_content_provider_id
                   AND f.user_id = ?
-                  AND f.deleted_at IS NULL
             ) AS is_favorited`, userId)
 		if !isFeatured {
 			tx = tx.Joins(`LEFT JOIN open_content_favorites f 

--- a/backend/src/database/open_content.go
+++ b/backend/src/database/open_content.go
@@ -66,7 +66,7 @@ func (db *DB) GetUserFavoriteGroupings(userID uint) ([]models.OpenContentItem, e
 			AND ocp.deleted_at IS NULL
 		JOIN libraries lib ON lib.open_content_provider_id = ocp.id 
 			AND lib.id = f.content_id
-		WHERE f.user_id = ? AND f.deleted_at IS NULL
+		WHERE f.user_id = ?
 			AND f.content_id IN (SELECT id FROM libraries where visibility_status = true)
 	),
 	ordered_videos AS (
@@ -89,7 +89,7 @@ func (db *DB) GetUserFavoriteGroupings(userID uint) ([]models.OpenContentItem, e
 			AND ocp.deleted_at IS NULL
 		JOIN videos ON videos.open_content_provider_id = ocp.id
 			AND videos.id = f.content_id
-		WHERE f.user_id = ? AND f.deleted_at IS NULL
+		WHERE f.user_id = ?
 			AND f.content_id IN (SELECT id FROM videos where visibility_status = true AND availability = 'available')
 	),
 	ordered_helpful_links AS (
@@ -112,7 +112,7 @@ func (db *DB) GetUserFavoriteGroupings(userID uint) ([]models.OpenContentItem, e
 				AND ocp.deleted_at IS NULL
 		JOIN helpful_links hl ON hl.open_content_provider_id = ocp.id
 				AND hl.id = f.content_id
-		WHERE f.user_id = ? AND f.deleted_at IS NULL
+		WHERE f.user_id = ?
 		AND f.content_id IN (SELECT id from helpful_links WHERE visibility_status = true)
 	)
 	SELECT 
@@ -149,7 +149,7 @@ func (db *DB) GetUserFavorites(userID uint, page, perPage int) (int64, []models.
             JOIN open_content_providers ocp ON ocp.id = lib.open_content_provider_id
                 AND ocp.currently_enabled = true
                 AND ocp.deleted_at IS NULL
-            WHERE fav.user_id = ? AND fav.deleted_at IS NULL
+            WHERE fav.user_id = ?
         ) AS total_favorites
     `
 	if err := db.Raw(countQuery, userID).Scan(&total).Error; err != nil {
@@ -187,7 +187,7 @@ func (db *DB) GetUserFavorites(userID uint, page, perPage int) (int64, []models.
             AND ocp.deleted_at IS NULL
         JOIN libraries lib ON lib.open_content_provider_id = ocp.id 
             AND lib.id = f.content_id
-        WHERE f.user_id = ? AND f.deleted_at IS NULL
+        WHERE f.user_id = ?
             AND f.content_id IN (SELECT id FROM libraries where visibility_status = true)
         UNION ALL
 
@@ -209,7 +209,7 @@ func (db *DB) GetUserFavorites(userID uint, page, perPage int) (int64, []models.
             AND ocp.deleted_at IS NULL
         JOIN videos ON videos.open_content_provider_id = ocp.id
             AND videos.id = f.content_id
-        WHERE f.user_id = ? AND f.deleted_at IS NULL
+        WHERE f.user_id = ?
             AND f.content_id IN (SELECT id FROM videos where visibility_status = true AND availability = 'available')
        UNION ALL
 
@@ -231,7 +231,7 @@ func (db *DB) GetUserFavorites(userID uint, page, perPage int) (int64, []models.
             AND ocp.deleted_at IS NULL
         JOIN helpful_links hl ON hl.open_content_provider_id = ocp.id
             AND hl.id = f.content_id
-        WHERE f.user_id = ? AND f.deleted_at IS NULL
+        WHERE f.user_id = ?
           AND f.content_id IN (SELECT id from helpful_links WHERE visibility_status = true)
     ) AS all_favorites
     ORDER BY created_at DESC

--- a/backend/src/database/open_content.go
+++ b/backend/src/database/open_content.go
@@ -43,6 +43,103 @@ func (db *DB) CreateContentActivity(urlString string, activity *models.OpenConte
 	}
 }
 
+// This method will at most ever return the most recent 30 favorites (10 Libraries, 10 Videos, 10 Helpful Links)
+func (db *DB) GetUserFavoriteGroupings(userID uint) ([]models.OpenContentItem, error) {
+	favorites := make([]models.OpenContentItem, 0, 30)
+	favoritesQuery := `WITH ordered_libraries AS (
+		SELECT
+			'library' AS content_type,
+			f.content_id,
+			lib.title,
+			lib.url,
+			lib.thumbnail_url,
+			ocp.description,
+			lib.visibility_status,
+			lib.open_content_provider_id,
+			ocp.title AS provider_name,
+			NULL AS channel_title,
+			f.created_at,
+			ROW_NUMBER() OVER (ORDER BY f.created_at DESC) AS row_num
+		FROM open_content_favorites f
+		JOIN open_content_providers ocp ON ocp.id = f.open_content_provider_id
+			AND ocp.currently_enabled = TRUE
+			AND ocp.deleted_at IS NULL
+		JOIN libraries lib ON lib.open_content_provider_id = ocp.id 
+			AND lib.id = f.content_id
+		WHERE f.user_id = ? AND f.deleted_at IS NULL
+			AND f.content_id IN (SELECT id FROM libraries where visibility_status = true)
+	),
+	ordered_videos AS (
+		SELECT
+			'video' AS content_type,
+			f.content_id,
+			videos.title,
+			videos.url,
+			videos.thumbnail_url,
+			videos.description,
+			videos.visibility_status,
+			videos.open_content_provider_id,
+			NULL AS provider_name,
+			videos.channel_title,
+			f.created_at,
+			ROW_NUMBER() OVER (ORDER BY f.created_at DESC) AS row_num
+		FROM open_content_favorites f
+		JOIN open_content_providers ocp ON ocp.id = f.open_content_provider_id
+			AND ocp.currently_enabled = TRUE
+			AND ocp.deleted_at IS NULL
+		JOIN videos ON videos.open_content_provider_id = ocp.id
+			AND videos.id = f.content_id
+		WHERE f.user_id = ? AND f.deleted_at IS NULL
+			AND f.content_id IN (SELECT id FROM videos where visibility_status = true AND availability = 'available')
+	),
+	ordered_helpful_links AS (
+		SELECT
+			'helpful_link' AS content_type,
+			f.content_id AS content_id,
+			hl.title,
+			hl.url,
+			hl.thumbnail_url,
+			hl.description,
+			hl.visibility_status,
+			hl.open_content_provider_id AS open_content_provider_id,
+			NULL AS provider_name,
+			NULL AS channel_title,
+			f.created_at,
+			ROW_NUMBER() OVER (ORDER BY f.created_at DESC) AS row_num
+		FROM open_content_favorites f
+		JOIN open_content_providers ocp ON ocp.id = f.open_content_provider_id
+				AND ocp.currently_enabled = TRUE
+				AND ocp.deleted_at IS NULL
+		JOIN helpful_links hl ON hl.open_content_provider_id = ocp.id
+				AND hl.id = f.content_id
+		WHERE f.user_id = ? AND f.deleted_at IS NULL
+		AND f.content_id IN (SELECT id from helpful_links WHERE visibility_status = true)
+	)
+	SELECT 
+			content_type,
+			content_id,
+			title,
+			url,
+			thumbnail_url,
+			description,
+			visibility_status,
+			open_content_provider_id,
+			provider_name,
+			channel_title,
+			created_at
+	FROM (
+		SELECT * FROM ordered_libraries WHERE row_num <= 10
+		UNION ALL
+		SELECT * FROM ordered_videos WHERE row_num <= 10
+		UNION ALL
+		SELECT * FROM ordered_helpful_links WHERE row_num <= 10
+	)`
+	if err := db.Raw(favoritesQuery, userID, userID, userID).Scan(&favorites).Error; err != nil {
+		return nil, err
+	}
+	return favorites, nil
+}
+
 func (db *DB) GetUserFavorites(userID uint, page, perPage int) (int64, []models.OpenContentItem, error) {
 	var total int64
 	countQuery := `SELECT COUNT(*) FROM (
@@ -50,7 +147,7 @@ func (db *DB) GetUserFavorites(userID uint, page, perPage int) (int64, []models.
             FROM open_content_favorites fav
             JOIN libraries lib ON lib.id = fav.content_id
             JOIN open_content_providers ocp ON ocp.id = lib.open_content_provider_id
-                AND ocp.currently_enabled = true 
+                AND ocp.currently_enabled = true
                 AND ocp.deleted_at IS NULL
             WHERE fav.user_id = ? AND fav.deleted_at IS NULL
         ) AS total_favorites
@@ -58,9 +155,8 @@ func (db *DB) GetUserFavorites(userID uint, page, perPage int) (int64, []models.
 	if err := db.Raw(countQuery, userID).Scan(&total).Error; err != nil {
 		return 0, nil, err
 	}
-
 	favorites := make([]models.OpenContentItem, 0, perPage)
-	favoritesQuery := `SELECT 
+	favoritesQuery := `SELECT
         content_type,
         content_id,
         title,
@@ -86,10 +182,11 @@ func (db *DB) GetUserFavorites(userID uint, page, perPage int) (int64, []models.
             NULL AS channel_title,
             f.created_at
         FROM open_content_favorites f
-        JOIN libraries lib ON lib.id = f.content_id
-        JOIN open_content_providers ocp ON ocp.id = lib.open_content_provider_id
+        JOIN open_content_providers ocp ON ocp.id = f.open_content_provider_id
             AND ocp.currently_enabled = TRUE
             AND ocp.deleted_at IS NULL
+        JOIN libraries lib ON lib.open_content_provider_id = ocp.id 
+            AND lib.id = f.content_id
         WHERE f.user_id = ? AND f.deleted_at IS NULL
             AND f.content_id IN (SELECT id FROM libraries where visibility_status = true)
         UNION ALL
@@ -107,13 +204,14 @@ func (db *DB) GetUserFavorites(userID uint, page, perPage int) (int64, []models.
             videos.channel_title,
             f.created_at
         FROM open_content_favorites f
-        JOIN videos ON videos.id = f.content_id
-        JOIN open_content_providers ocp ON ocp.id = videos.open_content_provider_id
+        JOIN open_content_providers ocp ON ocp.id = f.open_content_provider_id
             AND ocp.currently_enabled = TRUE
             AND ocp.deleted_at IS NULL
+        JOIN videos ON videos.open_content_provider_id = ocp.id
+            AND videos.id = f.content_id
         WHERE f.user_id = ? AND f.deleted_at IS NULL
             AND f.content_id IN (SELECT id FROM videos where visibility_status = true AND availability = 'available')
-       UNION ALL 
+       UNION ALL
 
         SELECT
             'helpful_link' AS content_type,
@@ -128,16 +226,19 @@ func (db *DB) GetUserFavorites(userID uint, page, perPage int) (int64, []models.
             NULL AS channel_title,
             f.created_at
         FROM open_content_favorites f
-        JOIN helpful_links hl ON hl.id = f.content_id
+        JOIN open_content_providers ocp ON ocp.id = f.open_content_provider_id
+            AND ocp.currently_enabled = TRUE
+            AND ocp.deleted_at IS NULL
+        JOIN helpful_links hl ON hl.open_content_provider_id = ocp.id
+            AND hl.id = f.content_id
         WHERE f.user_id = ? AND f.deleted_at IS NULL
-	      AND f.content_id IN (SELECT id from helpful_links WHERE visibility_status = true)
+          AND f.content_id IN (SELECT id from helpful_links WHERE visibility_status = true)
     ) AS all_favorites
     ORDER BY created_at DESC
     LIMIT ? OFFSET ?`
 	if err := db.Raw(favoritesQuery, userID, userID, userID, perPage, calcOffset(page, perPage)).Scan(&favorites).Error; err != nil {
 		return 0, nil, err
 	}
-
 	return total, favorites, nil
 }
 

--- a/backend/src/database/videos.go
+++ b/backend/src/database/videos.go
@@ -28,7 +28,7 @@ func (db *DB) FavoriteOpenContent(contentID int, ocpID uint, userID uint, facili
 		FacilityID:            facilityID,
 	}
 	//use Unscoped method to ignore soft deletions
-	tx := db.Where("content_id = ? AND open_content_provider_id = ?", contentID, ocpID)
+	tx := db.Unscoped().Where("content_id = ? AND open_content_provider_id = ?", contentID, ocpID)
 	if facilityID != nil {
 		tx = tx.Where("facility_id = ?", facilityID)
 	}
@@ -37,7 +37,7 @@ func (db *DB) FavoriteOpenContent(contentID int, ocpID uint, userID uint, facili
 		if facilityID != nil {
 			delTx = delTx.Where("facility_id = ?", facilityID)
 		}
-		if err := delTx.Delete(&fav).Error; err != nil {
+		if err := delTx.Unscoped().Delete(&fav).Error; err != nil {
 			return false, newDeleteDBError(err, "video_favorites")
 		}
 		return false, nil

--- a/backend/src/database/videos.go
+++ b/backend/src/database/videos.go
@@ -64,7 +64,6 @@ func (db *DB) GetAllVideos(onlyVisible bool, page, perPage int, search, orderBy 
 		WHERE f.content_id = videos.id
 		  AND f.open_content_provider_id = videos.open_content_provider_id
 		  AND f.user_id = ?
-		  AND f.deleted_at IS NULL
 	) AS is_favorited`, userID)
 	var total int64
 	validOrder := map[string]bool{

--- a/backend/src/database/videos.go
+++ b/backend/src/database/videos.go
@@ -28,7 +28,7 @@ func (db *DB) FavoriteOpenContent(contentID int, ocpID uint, userID uint, facili
 		FacilityID:            facilityID,
 	}
 	//use Unscoped method to ignore soft deletions
-	tx := db.Unscoped().Where("content_id = ? AND open_content_provider_id = ?", contentID, ocpID)
+	tx := db.Where("content_id = ? AND open_content_provider_id = ?", contentID, ocpID)
 	if facilityID != nil {
 		tx = tx.Where("facility_id = ?", facilityID)
 	}
@@ -37,7 +37,7 @@ func (db *DB) FavoriteOpenContent(contentID int, ocpID uint, userID uint, facili
 		if facilityID != nil {
 			delTx = delTx.Where("facility_id = ?", facilityID)
 		}
-		if err := delTx.Unscoped().Delete(&fav).Error; err != nil {
+		if err := delTx.Delete(&fav).Error; err != nil {
 			return false, newDeleteDBError(err, "video_favorites")
 		}
 		return false, nil

--- a/backend/src/handlers/open_content_handler.go
+++ b/backend/src/handlers/open_content_handler.go
@@ -9,8 +9,9 @@ import (
 func (srv *Server) registerOpenContentRoutes() []routeDef {
 	axx := models.Feature(models.OpenContentAccess)
 	return []routeDef{
-		{"GET /api/open-content/favorites", srv.handleGetUserFavoriteOpenContent, false, axx},
 		{"GET /api/open-content", srv.handleIndexOpenContent, false, axx},
+		{"GET /api/open-content/favorites", srv.handleGetUserFavoriteOpenContent, false, axx},
+		{"GET /api/open-content/favorite-groupings", srv.handleGetUserFavoriteOpenContentGroupings, false, axx},
 	}
 }
 
@@ -35,4 +36,12 @@ func (srv *Server) handleGetUserFavoriteOpenContent(w http.ResponseWriter, r *ht
 	}
 	meta := models.NewPaginationInfo(page, perPage, total)
 	return writePaginatedResponse(w, http.StatusOK, favorites, meta)
+}
+
+func (srv *Server) handleGetUserFavoriteOpenContentGroupings(w http.ResponseWriter, r *http.Request, log sLog) error {
+	favorites, err := srv.Db.GetUserFavoriteGroupings(srv.getUserID(r))
+	if err != nil {
+		return newDatabaseServiceError(err)
+	}
+	return writeJsonResponse(w, http.StatusOK, favorites)
 }

--- a/backend/src/handlers/open_content_handler_test.go
+++ b/backend/src/handlers/open_content_handler_test.go
@@ -1,0 +1,110 @@
+package handlers
+
+import (
+	"UnlockEdv2/src/models"
+	"encoding/json"
+	"net/http"
+	"slices"
+	"testing"
+)
+
+func TestHandleIndexOpenContent(t *testing.T) {
+	httpTests := []httpTest{
+		{"TestIndexOpenContentAsAdmin", "admin", nil, http.StatusOK, ""},
+		{"TestIndexOpenContentAsUser", "student", nil, http.StatusOK, ""},
+	}
+	for _, test := range httpTests {
+		t.Run(test.testName, func(t *testing.T) {
+			req, err := http.NewRequest(http.MethodGet, "/api/open-content", nil)
+			if err != nil {
+				t.Fatalf("unable to create new request, error is %v", err)
+			}
+			handler := getHandlerByRole(server.handleIndexOpenContent, test.role)
+			rr := executeRequest(t, req, handler, test)
+			var all bool
+			if test.role == "admin" {
+				all = true
+			}
+			openContentProviders, err := server.Db.GetOpenContent(all)
+			if err != nil {
+				t.Fatalf("unable to get open content from db, error is %v", err)
+			}
+			data := models.Resource[[]models.OpenContentProvider]{}
+			received := rr.Body.String()
+			if err = json.Unmarshal([]byte(received), &data); err != nil {
+				t.Errorf("failed to unmarshal resource, error is %v", err)
+			}
+			for _, provider := range openContentProviders {
+				if !slices.ContainsFunc(data.Data, func(ocProvider models.OpenContentProvider) bool {
+					return ocProvider.ID == provider.ID
+				}) {
+					t.Error("providers not found, out of sync")
+				}
+			}
+		})
+	}
+}
+
+func TestHandleGetUserFavoriteOpenContentGroupings(t *testing.T) {
+	httpTests := []httpTest{
+		{"TestGetUserFavoriteOpenContentGroupingsAsUser", "student", map[string]any{"user_id": uint(4)}, http.StatusOK, ""},
+	}
+	for _, test := range httpTests {
+		t.Run(test.testName, func(t *testing.T) {
+			req, err := http.NewRequest(http.MethodGet, "/api/open-content/favorite-groupings", nil)
+			if err != nil {
+				t.Fatalf("unable to create new request, error is %v", err)
+			}
+			handler := getHandlerByRole(server.handleGetUserFavoriteOpenContentGroupings, test.role)
+			rr := executeRequest(t, req, handler, test)
+			contentItems, err := server.Db.GetUserFavoriteGroupings(test.mapKeyValues["user_id"].(uint))
+			if err != nil {
+				t.Fatalf("unable to get open content items from db, error is %v", err)
+			}
+			data := models.Resource[[]models.OpenContentItem]{}
+			received := rr.Body.String()
+			if err = json.Unmarshal([]byte(received), &data); err != nil {
+				t.Errorf("failed to unmarshal resource, error is %v", err)
+			}
+			for _, contentItem := range contentItems {
+				if !slices.ContainsFunc(data.Data, func(item models.OpenContentItem) bool {
+					return item.ContentId == contentItem.ContentId
+				}) {
+					t.Error("open content favorites not found, out of sync")
+				}
+			}
+		})
+	}
+}
+
+func TestHandleGetUserFavoriteOpenContent(t *testing.T) {
+	httpTests := []httpTest{
+		{"TestGetUserFavoriteOpenContentUser", "student", map[string]any{"user_id": uint(4), "page": 1, "per_page": 10}, http.StatusOK, ""},
+	}
+	for _, test := range httpTests {
+		t.Run(test.testName, func(t *testing.T) {
+			req, err := http.NewRequest(http.MethodGet, "/api/open-content/favorites", nil)
+			if err != nil {
+				t.Fatalf("unable to create new request, error is %v", err)
+			}
+			handler := getHandlerByRole(server.handleGetUserFavoriteOpenContent, test.role)
+			rr := executeRequest(t, req, handler, test)
+			_, favorites, err := server.Db.GetUserFavorites(test.mapKeyValues["user_id"].(uint), test.mapKeyValues["page"].(int), test.mapKeyValues["per_page"].(int))
+			if err != nil {
+				t.Fatalf("unable to get user favorites from db, error is %v", err)
+			}
+			data := models.PaginatedResource[models.OpenContentItem]{}
+			received := rr.Body.String()
+			if err = json.Unmarshal([]byte(received), &data); err != nil {
+				t.Errorf("failed to unmarshal resource, error is %v", err)
+			}
+			for _, favorite := range favorites {
+				if !slices.ContainsFunc(data.Data, func(item models.OpenContentItem) bool {
+					return favorite.ContentId == item.ContentId
+				}) {
+					t.Error("favorites not found, out of sync")
+				}
+			}
+		})
+	}
+}

--- a/backend/src/handlers/video_handler.go
+++ b/backend/src/handlers/video_handler.go
@@ -166,7 +166,7 @@ func (srv *Server) handleFavoriteVideo(w http.ResponseWriter, r *http.Request, l
 	if err != nil {
 		return newInvalidIdServiceError(err, "video_id")
 	}
-	isFavorited, err := srv.Db.FavoriteOpenContent(vidId, userID, video.OpenContentProviderID, nil)
+	isFavorited, err := srv.Db.FavoriteOpenContent(vidId, video.OpenContentProviderID, userID, nil)
 	if err != nil {
 		return newInternalServerServiceError(err, "error favoriting video")
 	}

--- a/backend/src/models/open_content.go
+++ b/backend/src/models/open_content.go
@@ -34,6 +34,7 @@ type OpenContentActivity struct {
 }
 
 type OpenContentFavorite struct {
+	DatabaseFields
 	UserID                uint  `gorm:"not null" json:"user_id"`
 	ContentID             uint  `gorm:"not null" json:"content_id"`
 	OpenContentProviderID uint  `gorm:"not null" json:"open_content_provider_id"`

--- a/backend/src/models/open_content.go
+++ b/backend/src/models/open_content.go
@@ -34,11 +34,12 @@ type OpenContentActivity struct {
 }
 
 type OpenContentFavorite struct {
-	UserID                uint      `gorm:"not null" json:"user_id"`
-	ContentID             uint      `gorm:"not null" json:"content_id"`
-	OpenContentProviderID uint      `gorm:"not null" json:"open_content_provider_id"`
-	FacilityID            *uint     `json:"facility_id"`
-	CreatedAt             time.Time `json:"created_at"`
+	UserID                uint           `gorm:"not null" json:"user_id"`
+	ContentID             uint           `gorm:"not null" json:"content_id"`
+	OpenContentProviderID uint           `gorm:"not null" json:"open_content_provider_id"`
+	FacilityID            *uint          `json:"facility_id"`
+	CreatedAt             time.Time      `json:"created_at"`
+	DeletedAt             gorm.DeletedAt `gorm:"index" json:"-"`
 }
 
 func (OpenContentActivity) TableName() string { return "open_content_activities" }

--- a/backend/src/models/open_content.go
+++ b/backend/src/models/open_content.go
@@ -34,11 +34,11 @@ type OpenContentActivity struct {
 }
 
 type OpenContentFavorite struct {
-	DatabaseFields
-	UserID                uint  `gorm:"not null" json:"user_id"`
-	ContentID             uint  `gorm:"not null" json:"content_id"`
-	OpenContentProviderID uint  `gorm:"not null" json:"open_content_provider_id"`
-	FacilityID            *uint `json:"facility_id"`
+	UserID                uint      `gorm:"not null" json:"user_id"`
+	ContentID             uint      `gorm:"not null" json:"content_id"`
+	OpenContentProviderID uint      `gorm:"not null" json:"open_content_provider_id"`
+	FacilityID            *uint     `json:"facility_id"`
+	CreatedAt             time.Time `json:"created_at"`
 }
 
 func (OpenContentActivity) TableName() string { return "open_content_activities" }

--- a/backend/src/models/open_content.go
+++ b/backend/src/models/open_content.go
@@ -34,12 +34,11 @@ type OpenContentActivity struct {
 }
 
 type OpenContentFavorite struct {
-	UserID                uint           `gorm:"not null" json:"user_id"`
-	ContentID             uint           `gorm:"not null" json:"content_id"`
-	OpenContentProviderID uint           `gorm:"not null" json:"open_content_provider_id"`
-	FacilityID            *uint          `json:"facility_id"`
-	CreatedAt             time.Time      `json:"created_at"`
-	DeletedAt             gorm.DeletedAt `gorm:"index" json:"-"`
+	UserID                uint      `gorm:"not null" json:"user_id"`
+	ContentID             uint      `gorm:"not null" json:"content_id"`
+	OpenContentProviderID uint      `gorm:"not null" json:"open_content_provider_id"`
+	FacilityID            *uint     `json:"facility_id"`
+	CreatedAt             time.Time `json:"created_at"`
 }
 
 func (OpenContentActivity) TableName() string { return "open_content_activities" }

--- a/backend/src/models/video.go
+++ b/backend/src/models/video.go
@@ -17,7 +17,6 @@ type Video struct {
 	VisibilityStatus      bool              `json:"visibility_status" gorm:"not null;default:false"`
 	ThumbnailUrl          string            `json:"thumbnail_url" gorm:"size:255"`
 	OpenContentProviderID uint              `json:"open_content_provider_id" gorm:"not null"`
-	IsFavorited           bool              `json:"is_favorited"`
 
 	Provider  *OpenContentProvider   `json:"open_content_provider" gorm:"foreignKey:OpenContentProviderID"`
 	Attempts  []VideoDownloadAttempt `json:"video_download_attempts" gorm:"foreignKey:VideoID"`

--- a/backend/src/models/video.go
+++ b/backend/src/models/video.go
@@ -17,6 +17,7 @@ type Video struct {
 	VisibilityStatus      bool              `json:"visibility_status" gorm:"not null;default:false"`
 	ThumbnailUrl          string            `json:"thumbnail_url" gorm:"size:255"`
 	OpenContentProviderID uint              `json:"open_content_provider_id" gorm:"not null"`
+	IsFavorited           bool              `json:"is_favorited"`
 
 	Provider  *OpenContentProvider   `json:"open_content_provider" gorm:"foreignKey:OpenContentProviderID"`
 	Attempts  []VideoDownloadAttempt `json:"video_download_attempts" gorm:"foreignKey:VideoID"`

--- a/frontend/src/Components/OpenContentItemAccordion.tsx
+++ b/frontend/src/Components/OpenContentItemAccordion.tsx
@@ -15,27 +15,24 @@ export default function OpenContentItemAccordion({
 }: {
     items: OpenContentItem[];
 }) {
-    const contentMap: OpenContentItemMap = {};
-    items.forEach((item) => {
-        let sectionKey;
-        switch (item.content_type) {
-            case 'video':
-                sectionKey = 'Videos';
-                break;
-            case 'library':
-                sectionKey = 'Libraries';
-                break;
-            case 'helpful_link':
-                sectionKey = 'Helpful Links';
-                break;
-            default:
-                sectionKey = 'All Others';
-                break;
+    const contentMap: OpenContentItemMap = {
+        Libraries: items.filter((item) => item.content_type === 'library'),
+        Videos: items.filter((item) => item.content_type === 'video'),
+        'Helpful Links': items.filter(
+            (item) => item.content_type === 'helpful_link'
+        ),
+        'All Others': items.filter(
+            (item) =>
+                !['library', 'video', 'helpful_link'].includes(
+                    item.content_type
+                )
+        )
+    };
+    //getting rid of the empty lists
+    Object.keys(contentMap).forEach((title) => {
+        if (contentMap[title].length < 1) {
+            delete contentMap[title];
         }
-        if (!contentMap[sectionKey]) {
-            contentMap[sectionKey] = [];
-        }
-        contentMap[sectionKey].push(item);
     });
     const [activeKey, setActiveKey] = useState<string | null>(null);
     const toggleAccordion = (key: string) => {

--- a/frontend/src/Components/OpenContentItemAccordion.tsx
+++ b/frontend/src/Components/OpenContentItemAccordion.tsx
@@ -1,0 +1,95 @@
+import { OpenContentItem } from '@/common';
+import {
+    ChevronRightIcon,
+    VideoCameraIcon,
+    BookOpenIcon,
+    InformationCircleIcon
+} from '@heroicons/react/24/solid';
+import React, { useState } from 'react';
+import OpenContentCard from './cards/OpenContentCard';
+
+type OpenContentItemMap = Record<string, OpenContentItem[]>;
+
+export default function OpenContentItemAccordion({
+    items
+}: {
+    items: OpenContentItem[];
+}) {
+    const contentMap: OpenContentItemMap = {};
+    items.forEach((item) => {
+        let sectionKey;
+        switch (item.content_type) {
+            case 'video':
+                sectionKey = 'Videos';
+                break;
+            case 'library':
+                sectionKey = 'Libraries';
+                break;
+            case 'helpful_link':
+                sectionKey = 'Helpful Links';
+                break;
+            default:
+                sectionKey = 'All Others';
+                break;
+        }
+        if (!contentMap[sectionKey]) {
+            contentMap[sectionKey] = [];
+        }
+        contentMap[sectionKey].push(item);
+    });
+    const [activeKey, setActiveKey] = useState<string | null>(null);
+    const toggleAccordion = (key: string) => {
+        setActiveKey(activeKey === key ? null : key);
+    };
+    const displayIconByTitle = (title: string) => {
+        let icon = null;
+        switch (title) {
+            case 'Videos':
+                icon = <VideoCameraIcon className="w-4" />;
+                break;
+            case 'Libraries':
+                icon = <BookOpenIcon className="w-4" />;
+                break;
+            case 'Helpful Links':
+                icon = <InformationCircleIcon className="w-4" />;
+                break;
+            default:
+                break;
+        }
+        return icon;
+    };
+    return (
+        <div className="w-full max-w-md mx-auto">
+            {Object.entries(contentMap).map(([title, contentItems]) => (
+                <div key={title} className="border-b">
+                    <button
+                        className="flex items-center w-full px-4 py-3 text-left"
+                        onClick={() => toggleAccordion(title)}
+                    >
+                        <ChevronRightIcon
+                            className={`w-4 mr-3 transform transition-transform ${
+                                activeKey === title ? 'rotate-90' : ''
+                            }`}
+                        />
+                        {displayIconByTitle(title)}
+                        <span className="flex-1 text-lg font-medium ml-2">
+                            {title}
+                        </span>
+                    </button>
+                    <div
+                        className={`overflow-hidden transition-[max-height] duration-700 ${
+                            activeKey === title ? 'max-h-[800px]' : 'max-h-0'
+                        }`}
+                    >
+                        {contentItems.map((item) => (
+                            <OpenContentCard
+                                key={item.content_id}
+                                content={item}
+                            />
+                        ))}
+                    </div>
+                </div>
+            ))}
+        </div>
+    );
+}

--- a/frontend/src/Components/VideoCard.tsx
+++ b/frontend/src/Components/VideoCard.tsx
@@ -57,7 +57,7 @@ export default function VideoCard({
     };
 
     let bookmark: JSX.Element;
-    if (video.video_favorites && video.video_favorites.length > 0) {
+    if (video.is_favorited) {
         bookmark = <StarIcon className="h-5 text-primary-yellow" />;
     } else bookmark = <StarIconOutline className={`h-5 `} />;
     return (

--- a/frontend/src/Pages/StudentLayer1.tsx
+++ b/frontend/src/Pages/StudentLayer1.tsx
@@ -7,7 +7,6 @@ import {
     HelpfulLinkAndSort,
     ServerResponseMany
 } from '@/common';
-import OpenContentCard from '@/Components/cards/OpenContentCard';
 import HelpfulLinkCard from '@/Components/cards/HelpfulLinkCard';
 import { useAuth } from '@/useAuth';
 import { useLoaderData, useNavigate } from 'react-router-dom';
@@ -16,6 +15,7 @@ import { FeaturedContent } from '@/Components/dashboard';
 import TopContentList from '@/Components/dashboard/TopContentList';
 import useSWR from 'swr';
 import { AxiosError } from 'axios';
+import OpenContentItemAccordion from '@/Components/OpenContentItemAccordion';
 
 export default function StudentLayer1() {
     const { user } = useAuth();
@@ -31,7 +31,7 @@ export default function StudentLayer1() {
     const { data: favorites, mutate: mutateFavLibs } = useSWR<
         ServerResponseMany<OpenContentItem>,
         AxiosError
-    >('api/open-content/favorites');
+    >('api/open-content/favorite-groupings');
     const { data: helpfulLinks, mutate: mutateHelpfulFavs } = useSWR<
         ServerResponseOne<HelpfulLinkAndSort>,
         AxiosError
@@ -109,15 +109,8 @@ export default function StudentLayer1() {
             <div className="min-w-[300px] border-l border-grey-1 flex flex-col gap-6 px-6 py-4">
                 <h2>Favorites</h2>
                 <div className="space-y-3 w-full">
-                    {favorites ? (
-                        favorites.data.map((favorite: OpenContentItem) => {
-                            return (
-                                <OpenContentCard
-                                    key={favorite.content_id}
-                                    content={favorite}
-                                />
-                            );
-                        })
+                    {favorites?.data && favorites.data.length > 0 ? (
+                        <OpenContentItemAccordion items={favorites.data} />
                     ) : (
                         <div>No Favorites</div>
                     )}

--- a/frontend/src/common.ts
+++ b/frontend/src/common.ts
@@ -63,6 +63,7 @@ export interface Video {
     duration: number;
     created_at: string;
     updated_at: string;
+    is_favorited: boolean;
     open_content_provider?: OpenContentProvider;
     video_download_attempts: VideoDownloadAttempt[];
     video_favorites: VideoFavorites[];


### PR DESCRIPTION
## Description of the change

Updated the Resident's Trending Content page to display Libraries, Videos, and Helpful Links into collapsible sections with an icon. 

I implemented each category to contain at most 10 content items (always most recent) to avoid overloading the screen with too much content.

There were also bugs associated with video favorites that were located during this implementation and were corrected. 

Would like to demo for Chris to see if there are any additional adjustments that are required.

- **Related issues**: Closes #550".

## Screenshot(s)
![image](https://github.com/user-attachments/assets/38e7538c-378b-4698-89e6-df92c9f791a5)

![image](https://github.com/user-attachments/assets/d5dcb284-a9dd-47f9-8b14-3bb3c1aa77b4)
