### PR TITLE
fix: change Knowledge Center to Knowledge Base

### DIFF
--- a/frontend/src/Components/FeatureLevelCheckboxes.tsx
+++ b/frontend/src/Components/FeatureLevelCheckboxes.tsx
@@ -68,7 +68,7 @@ export default function FeatureLevelCheckboxes({
         <>
             <CheckboxGeneric
                 name="open_content"
-                label="Knowledge Center"
+                label="Knowledge Base"
                 checked={getCheckboxChecked(FeatureAccess.OpenContentAccess)}
                 onChange={handleFeatureToggle}
             />


### PR DESCRIPTION
## Description of the change
Changes Knowledge Center in the Super Admin feature check boxes to "Knowledge Base"

- **Related issues**: Closes #597 

## Screenshot(s)

![image](https://github.com/user-attachments/assets/177adf90-5d3a-42eb-8fa6-06c3a2dcf747)

