### PR TITLE
Fixes for updating min values for hours spent and fixing moving page when favoriting libraries with wrapping text

### DIFF
--- a/frontend/src/Components/ConvertSeconds.tsx
+++ b/frontend/src/Components/ConvertSeconds.tsx
@@ -1,13 +1,10 @@
 const convertSeconds = (secs: number) => {
     const hours = Math.floor(secs / 3600);
     const minutes = Math.floor((secs % 3600) / 60);
-    const seconds = Math.floor(secs % 60);
-
+    //removed seconds per #601 along with not using abbreviations
     return hours
-        ? { number: hours, label: `hr${hours === 1 ? '' : 's'}` }
-        : (minutes
-          ? { number: minutes, label: `min${minutes === 1 ? '' : 's'}` }
-          : { number: seconds, label: `sec${seconds === 1 ? '' : 's'}` });
+        ? { number: hours, label: `hour${hours === 1 ? '' : 's'}` }
+        : { number: minutes, label: `minute${minutes === 1 ? '' : 's'}` };
 };
 
 export default convertSeconds;

--- a/frontend/src/Components/OpenContentItemAccordion.tsx
+++ b/frontend/src/Components/OpenContentItemAccordion.tsx
@@ -78,12 +78,14 @@ export default function OpenContentItemAccordion({
                             activeKey === title ? 'max-h-[800px]' : 'max-h-0'
                         }`}
                     >
-                        {contentItems.map((item) => (
-                            <OpenContentCard
-                                key={item.content_id}
-                                content={item}
-                            />
-                        ))}
+                        <div className="flex flex-col gap-4">
+                            {contentItems.map((item) => (
+                                <OpenContentCard
+                                    key={item.content_id}
+                                    content={item}
+                                />
+                            ))}
+                        </div>
                     </div>
                 </div>
             ))}

--- a/frontend/src/Components/dashboard/ResidentWeeklyActivityTable.tsx
+++ b/frontend/src/Components/dashboard/ResidentWeeklyActivityTable.tsx
@@ -14,7 +14,7 @@ export default function ResidentWeeklyActivityTable({
                     <thead>
                         <tr className="flex flex-row justify-between border border-x-0 border-t-0 mt-2">
                             <th className="body text-grey-4">Course Name</th>
-                            <th className="body text-grey-4">Hours Spent</th>
+                            <th className="body text-grey-4">Time Spent</th>
                         </tr>
                     </thead>
                     <tbody className="flex flex-col gap-4 mt-4 overflow-auto h-36 scrollbar">

--- a/frontend/src/Pages/MyProgress.tsx
+++ b/frontend/src/Pages/MyProgress.tsx
@@ -94,7 +94,7 @@ export default function MyProgress() {
                                     <tr className="flex flex-row justify-between border border-x-0 border-t-0 body text-grey-4 text-left">
                                         <th className="w-1/2">Course Name</th>
                                         <th className="w-1/5">Status</th>
-                                        <th className="w-1/5">Hours Spent</th>
+                                        <th className="w-1/5">Time Spent</th>
                                     </tr>
                                 </thead>
                                 <tbody className="flex flex-col gap-4 mt-4">

--- a/frontend/src/Pages/StudentLayer1.tsx
+++ b/frontend/src/Pages/StudentLayer1.tsx
@@ -86,7 +86,7 @@ export default function StudentLayer1() {
                 </div>
             </div>
             {/* right sidebar */}
-            <div className="min-w-[300px] border-l border-grey-1 flex flex-col gap-6 px-6 py-4">
+            <div className="min-w-[390px] border-l border-grey-1 flex flex-col gap-6 px-6 py-4">
                 <h2>Favorites</h2>
                 <div className="space-y-3 w-full">
                     {favorites?.data && favorites.data.length > 0 ? (


### PR DESCRIPTION
## Description of the change

- #601 
    - Consisted of modifying the column name Hours Spent to be Time Spent located on the following screens:  Learning Path and My Progress screens.  Made the change to only allow the table to support minutes/hours. No changes needed for sorting by Time spent--this already exists.
- #605 
    - Consisted of modifying CSS to stop page from jumping from the left side. This was happening when favoriting a library that had wrapping text.
    - Modified OpenContentCard to have a gap between each card.

- **Related issues**: Closes #601 and #605.

## Screenshot(s)
Screen Shots for #601 
![timespent601](https://github.com/user-attachments/assets/d331f9a9-aefe-4fbf-abe4-95d316949850)

![timespent6012](https://github.com/user-attachments/assets/264884d2-307f-4105-8eb0-0a1af73fcd8b)

Screenshot/Video for #605 
[TrendingContentFavs.webm](https://github.com/user-attachments/assets/17753ee0-a69a-4c56-85cc-6bec732694a0)

![605](https://github.com/user-attachments/assets/012f5076-8fbc-47f5-a294-13fa98b19050)
