### PR TITLE
Fixes for hover-state icons, display of course titles, featuring functionality, and favoriting per issues #592, #617, #612, #627, #629 

### DIFF
--- a/backend/src/database/videos.go
+++ b/backend/src/database/videos.go
@@ -27,18 +27,22 @@ func (db *DB) FavoriteOpenContent(contentID int, ocpID uint, userID uint, facili
 		UserID:                userID,
 		FacilityID:            facilityID,
 	}
-	//use Unscoped method to ignore soft deletions
+	//added user id to query below to isolate favorite by user when facility id is passed in
 	tx := db.Where("content_id = ? AND open_content_provider_id = ?", contentID, ocpID)
 	if facilityID != nil {
 		tx = tx.Where("facility_id = ?", facilityID)
+	} else {
+		tx = tx.Where("user_id = ?", userID)
 	}
 	if tx.First(&models.OpenContentFavorite{}).RowsAffected > 0 {
-		delTx := db.Where("content_id = ? AND user_id = ? AND open_content_provider_id = ?", contentID, userID, ocpID)
+		delTx := db.Where("content_id = ? AND open_content_provider_id = ?", contentID, ocpID)
 		if facilityID != nil {
 			delTx = delTx.Where("facility_id = ?", facilityID)
+		} else {
+			delTx = delTx.Where("user_id = ?", userID)
 		}
 		if err := delTx.Delete(&fav).Error; err != nil {
-			return false, newDeleteDBError(err, "video_favorites")
+			return false, newDeleteDBError(err, "open_content_favorites")
 		}
 		return false, nil
 	} else {

--- a/backend/src/handlers/libraries_handler.go
+++ b/backend/src/handlers/libraries_handler.go
@@ -28,12 +28,13 @@ func (srv *Server) handleIndexLibraries(w http.ResponseWriter, r *http.Request, 
 	showHidden := "visible"
 	if !userIsAdmin(r) && r.URL.Query().Get("visibility") == "hidden" {
 		return newUnauthorizedServiceError()
-	}
-	if userIsAdmin(r) {
+	} else if !userIsAdmin(r) && r.URL.Query().Get("visibility") == "featured" {
+		showHidden = "featured"
+	} else if userIsAdmin(r) {
 		showHidden = r.URL.Query().Get("visibility")
 	}
 	claims := r.Context().Value(ClaimsKey).(*Claims)
-	total, libraries, err := srv.Db.GetAllLibraries(page, perPage, claims.UserID, claims.FacilityID, showHidden, orderBy, search, days)
+	total, libraries, err := srv.Db.GetAllLibraries(page, perPage, days, claims.UserID, claims.FacilityID, showHidden, orderBy, search, claims.isAdmin())
 	if err != nil {
 		return newDatabaseServiceError(err)
 	}

--- a/frontend/src/Components/CatalogCourseCard.tsx
+++ b/frontend/src/Components/CatalogCourseCard.tsx
@@ -63,10 +63,9 @@ export default function CatalogCourseCard({
           })
         : '';
     const finalDateStr =
-        ' • ' +
-        courseStartDtStr +
-        (courseStartDt || courseEndDt ? ' - ' : '') +
-        courseEndDtStr;
+        courseStartDt || courseEndDt
+            ? ' • ' + courseStartDtStr + ' - ' + courseEndDtStr
+            : '';
     if (view == ViewType.List) {
         return (
             <a
@@ -113,13 +112,13 @@ export default function CatalogCourseCard({
                     </figure>
                     <div className="card-body gap-0.5">
                         {/* this should be the school or course that offers the course */}
-                        <p className="text-xs">
-                            {course.provider_name}
-                            {finalDateStr}
-                        </p>
                         <h3 className="card-title text-sm">
                             {course.course_name}
                         </h3>
+                        <p className="text-xs h-6">
+                            {course.provider_name}
+                            {finalDateStr}
+                        </p>
                         <p className="body-small line-clamp-2">
                             {course.description}
                         </p>

--- a/frontend/src/Components/EnrolledCourseCard.tsx
+++ b/frontend/src/Components/EnrolledCourseCard.tsx
@@ -20,23 +20,28 @@ export default function EnrolledCourseCard({
     const url = course.external_url;
     let status: CourseStatus | null = null;
     if (course.course_progress == 100) status = CourseStatus.Completed;
-    const courseStartDt = course.start_dt ? new Date(course.start_dt) : course.start_dt;
+    const courseStartDt = course.start_dt
+        ? new Date(course.start_dt)
+        : course.start_dt;
     const courseEndDt = course.end_dt ? new Date(course.end_dt) : course.end_dt;
-    const courseStartDtStr = courseStartDt ? courseStartDt.toLocaleDateString('en-US', 
-        {
-            year: 'numeric',
-            month: '2-digit',
-            day: 'numeric'
-        })
-     : ""
-     const courseEndDtStr = courseEndDt ? courseEndDt.toLocaleDateString('en-US', 
-        {
-            year: 'numeric',
-            month: '2-digit',
-            day: 'numeric'
-        })
-     : "";
-    const finalDateStr = " • " + courseStartDtStr + (courseStartDt || courseEndDt ? " - " : "") + courseEndDtStr
+    const courseStartDtStr = courseStartDt
+        ? courseStartDt.toLocaleDateString('en-US', {
+              year: 'numeric',
+              month: '2-digit',
+              day: 'numeric'
+          })
+        : '';
+    const courseEndDtStr = courseEndDt
+        ? courseEndDt.toLocaleDateString('en-US', {
+              year: 'numeric',
+              month: '2-digit',
+              day: 'numeric'
+          })
+        : '';
+    const finalDateStr =
+        courseStartDt || courseEndDt
+            ? ' • ' + courseStartDtStr + ' - ' + courseEndDtStr
+            : '';
     if (view == ViewType.List) {
         return (
             <a
@@ -48,7 +53,10 @@ export default function EnrolledCourseCard({
                 <div className="flex flex-row gap-3 items-center">
                     <h2>{course.course_name}</h2>
                     <p className="body">|</p>
-                    <p className="body">{course.provider_platform_name}{finalDateStr}</p>
+                    <p className="body">
+                        {course.provider_platform_name}
+                        {finalDateStr}
+                    </p>
                 </div>
                 {status === CourseStatus.Completed ? (
                     <div className="flex flex-row gap-2 body-small text-teal-3">
@@ -86,13 +94,14 @@ export default function EnrolledCourseCard({
                         )}
                     </figure>
                     <div className="card-body gap-0.5">
-                        <p className="text-xs line-clamp-2">
-                            {course.provider_platform_name}{finalDateStr}
-                        </p>
-                        <h3 className="card-title text-sm h-10 line-clamp-2">
+                        <h3 className="card-title text-sm line-clamp-2">
                             {course.alt_name && course.alt_name + ' - '}
                             {course.course_name}
                         </h3>
+                        <p className="text-xs h-10 line-clamp-2">
+                            {course.provider_platform_name}
+                            {finalDateStr}
+                        </p>
                         <div className="mt-3 justify-end">
                             {status == CourseStatus.Completed ? (
                                 <div className="flex flex-row gap-2 body-small text-teal-3">

--- a/frontend/src/Components/ProviderCard.tsx
+++ b/frontend/src/Components/ProviderCard.tsx
@@ -30,7 +30,7 @@ export default function ProviderCard({
     openEditProvider: (prov: ProviderPlatform) => void;
     oidcClient: (prov: ProviderPlatform) => void;
     showAuthorizationInfo: (prov: ProviderPlatform) => void;
-    refreshToken: (prov: ProviderPlatform) => void; 
+    refreshToken: (prov: ProviderPlatform) => void;
     archiveProvider: (prov: ProviderPlatform) => void;
 }) {
     const navigate = useNavigate();
@@ -38,7 +38,8 @@ export default function ProviderCard({
         <tr className="bg-base-teal card p-4 w-full grid-cols-4 justify-items-center">
             <td className="justify-self-start">{provider.name}</td>
             <td>
-                {provider.oidc_id !== 0 || provider.type === ProviderPlatformType.BRIGHTSPACE ? (
+                {provider.oidc_id !== 0 ||
+                provider.type === ProviderPlatformType.BRIGHTSPACE ? (
                     <CheckCircleIcon className="w-4" />
                 ) : (
                     <div className="w-4"></div>
@@ -59,27 +60,31 @@ export default function ProviderCard({
             <td className="flex flex-row gap-3 justify-self-end">
                 {provider.state !== ProviderPlatformState.ARCHIVED ? (
                     <>
-                        {provider.oidc_id !== 0 || provider.type === ProviderPlatformType.BRIGHTSPACE ? (
+                        {provider.oidc_id !== 0 ||
+                        provider.type === ProviderPlatformType.BRIGHTSPACE ? (
                             <>
-                                {provider.type === ProviderPlatformType.BRIGHTSPACE ? (
+                                {provider.type ===
+                                ProviderPlatformType.BRIGHTSPACE ? (
                                     <ULIComponent
-                                    dataTip={'Refresh Token'}
-                                    icon={ArrowPathIcon}
-                                    onClick={() =>
-                                        refreshToken(provider)
-                                    }
-                                />
-                                ) : ( <ULIComponent
-                                    dataTip={'Auth Info'}
-                                    icon={InformationCircleIcon}
-                                    onClick={() =>
-                                        showAuthorizationInfo(provider)
-                                    }
-                                />)
-                                }
+                                        tooltipClassName="cursor-pointer"
+                                        dataTip={'Refresh Token'}
+                                        icon={ArrowPathIcon}
+                                        onClick={() => refreshToken(provider)}
+                                    />
+                                ) : (
+                                    <ULIComponent
+                                        tooltipClassName="cursor-pointer"
+                                        dataTip={'Auth Info'}
+                                        icon={InformationCircleIcon}
+                                        onClick={() =>
+                                            showAuthorizationInfo(provider)
+                                        }
+                                    />
+                                )}
                                 {provider.type !==
                                     ProviderPlatformType.KOLIBRI && (
                                     <ULIComponent
+                                        tooltipClassName="cursor-pointer"
                                         dataTip={'Manage Users'}
                                         icon={UserGroupIcon}
                                         onClick={() =>
@@ -92,17 +97,20 @@ export default function ProviderCard({
                             </>
                         ) : (
                             <ULIComponent
+                                tooltipClassName="cursor-pointer"
                                 dataTip={'Register Provider'}
                                 icon={LinkIcon}
                                 onClick={() => oidcClient(provider)}
                             />
                         )}
                         <ULIComponent
+                            tooltipClassName="cursor-pointer"
                             dataTip={'Edit Provider'}
                             icon={PencilSquareIcon}
                             onClick={() => openEditProvider(provider)}
                         />
                         <ULIComponent
+                            tooltipClassName="w-4 h-4 self-start cursor-pointer"
                             dataTip={'Disable'}
                             icon={XMarkIcon}
                             onClick={() => archiveProvider(provider)}
@@ -110,6 +118,7 @@ export default function ProviderCard({
                     </>
                 ) : (
                     <ULIComponent
+                        tooltipClassName="cursor-pointer"
                         dataTip={'Enable Provider'}
                         icon={CheckCircleIcon}
                         onClick={() => archiveProvider(provider)}

--- a/frontend/src/Pages/AdminManagement.tsx
+++ b/frontend/src/Pages/AdminManagement.tsx
@@ -235,7 +235,7 @@ export default function AdminManagement() {
                                                 <div className="flex space-x-4">
                                                     <ULIComponent
                                                         dataTip={'Edit Admin'}
-                                                        tooltipClassName="tooltip-left"
+                                                        tooltipClassName="tooltip-left cursor-pointer"
                                                         onClick={() => {
                                                             setTargetUser(user);
                                                             editUserModal.current?.showModal();
@@ -246,7 +246,7 @@ export default function AdminManagement() {
                                                         dataTip={
                                                             'Reset Password'
                                                         }
-                                                        tooltipClassName="tooltip-left"
+                                                        tooltipClassName="tooltip-left cursor-pointer"
                                                         onClick={() => {
                                                             setTargetUser(user);
                                                             resetUserPasswordModal.current?.showModal();
@@ -259,7 +259,7 @@ export default function AdminManagement() {
                                                         dataTip={getUserIconData[
                                                             'data-tip'
                                                         ](user)}
-                                                        tooltipClassName="tooltip-left"
+                                                        tooltipClassName="tooltip-left cursor-pointer"
                                                         onClick={getUserIconData.onClick(
                                                             user
                                                         )}

--- a/frontend/src/Pages/StudentManagement.tsx
+++ b/frontend/src/Pages/StudentManagement.tsx
@@ -216,7 +216,7 @@ export default function StudentManagement() {
                                                 <div className="flex space-x-4">
                                                     <ULIComponent
                                                         dataTip={'Edit Student'}
-                                                        tooltipClassName="tooltip-left"
+                                                        tooltipClassName="tooltip-left cursor-pointer"
                                                         icon={PencilSquareIcon}
                                                         onClick={() => {
                                                             setTargetUser(user);
@@ -228,7 +228,7 @@ export default function StudentManagement() {
                                                         dataTip={
                                                             'Reset Password'
                                                         }
-                                                        tooltipClassName="tooltip-left"
+                                                        tooltipClassName="tooltip-left cursor-pointer"
                                                         icon={
                                                             ArrowPathRoundedSquareIcon
                                                         }
@@ -242,7 +242,7 @@ export default function StudentManagement() {
                                                         dataTip={
                                                             'Delete Student'
                                                         }
-                                                        tooltipClassName="tooltip-left"
+                                                        tooltipClassName="tooltip-left cursor-pointer"
                                                         icon={TrashIcon}
                                                         onClick={() => {
                                                             setTargetUser(user);


### PR DESCRIPTION
## Description of the change

- #592 
    - Consisted of adding logic to the library handler to use the parameter value 'featured' when resident navigates to Trending Content page.
- #617 
    - Consisted of adding CSS style 'cursor-pointer' to interactive icons.
- #612 
    - Consisted of swapping positions of the Course title and Platform provider. Also modified Javascript to not display bullet point when there is no start/stop date displayed.
- #627 
    - Consisted of modifying the query that is used for favoriting the library. The issue was due to the user id not being part of the criteria of the query.
- #629 
    - Consisted of modifying the query that is used for pulling libraries to display when navigating to the 'Knowledge Center Management'.  I also modified the query for favoriting to allow the feature toggle to work correctly.

- **Related issues**: Closes #592, #617, #612, #627, #629.

## Screenshot(s)
[592.webm](https://github.com/user-attachments/assets/9943be2c-1bf2-4fa2-90e5-36fa23e9b7f0)
[617.webm](https://github.com/user-attachments/assets/dac792d3-30b2-402f-9381-4f7d9a7d4fda)
[627.webm](https://github.com/user-attachments/assets/7d160619-8411-4055-9027-054641002ad8)
[629.webm](https://github.com/user-attachments/assets/cb21849c-c151-42d6-94df-185267708ce2)
