### PR TITLE
fix: add titles for pages

### DIFF
--- a/frontend/src/Components/TitleManager.tsx
+++ b/frontend/src/Components/TitleManager.tsx
@@ -1,0 +1,48 @@
+import { useMatches, useLocation } from 'react-router-dom';
+import { useEffect } from 'react';
+import { TitleHandler } from '@/common';
+
+export function TitleManager() {
+    const matches = useMatches();
+    const location = useLocation();
+
+    useEffect(() => {
+        const updateTitle = () => {
+            const isLibraryViewer =
+                location.pathname.includes('/viewer/libraries/');
+
+            if (isLibraryViewer) {
+                setTimeout(() => {
+                    const titleInterval = setInterval(() => {
+                        const libraryViewer = document.getElementById(
+                            'library-viewer-iframe'
+                        ) as HTMLIFrameElement;
+                        if (libraryViewer?.contentWindow?.document) {
+                            const iframeTitle =
+                                libraryViewer.contentWindow.document.title;
+                            if (iframeTitle) {
+                                document.title = iframeTitle + ' - UnlockEd';
+                            }
+                        }
+                    }, 1000);
+
+                    return () => clearInterval(titleInterval);
+                }, 5000);
+                return;
+            }
+
+            const activeHandle = matches
+                .filter((match) =>
+                    Boolean((match.handle as TitleHandler)?.title)
+                )
+                .pop();
+            const title =
+                (activeHandle?.handle as TitleHandler)?.title ?? 'UnlockEd';
+            document.title = title + ' - UnlockEd';
+        };
+
+        updateTitle();
+    }, [matches, location.pathname]);
+
+    return null;
+}

--- a/frontend/src/Pages/LibraryViewer.tsx
+++ b/frontend/src/Pages/LibraryViewer.tsx
@@ -58,9 +58,9 @@ export default function LibraryViewer() {
                         </div>
                     ) : src != '' ? (
                         <iframe
-                            sandbox="allow-scripts allow-same-origin"
+                            sandbox="allow-scripts allow-same-origin allow-modals allow-popups"
                             className="w-full h-screen pt-4"
-                            id="library-viewer"
+                            id="library-viewer-iframe"
                             src={src}
                         />
                     ) : (

--- a/frontend/src/app.tsx
+++ b/frontend/src/app.tsx
@@ -59,12 +59,14 @@ import StudentLayer0 from './Pages/StudentLayer0.tsx';
 import StudentLayer2 from './Pages/StudentDashboard.tsx';
 import AdminLayer1 from './Pages/AdminLayer1.tsx';
 import HelpfulLinks from './Pages/HelpfulLinks.tsx';
+import { TitleManager } from './Components/TitleManager.tsx';
 
 const WithAuth: React.FC = () => {
     return (
         <AuthProvider>
             <ToastProvider>
                 <PathValueProvider>
+                    <TitleManager />
                     <Outlet />
                 </PathValueProvider>
             </ToastProvider>
@@ -104,6 +106,7 @@ function WithAdmin() {
             <ToastProvider>
                 <PathValueProvider>
                     <AdminOnly>
+                        <TitleManager />
                         <Outlet />
                     </AdminOnly>
                 </PathValueProvider>

--- a/frontend/src/common.ts
+++ b/frontend/src/common.ts
@@ -854,3 +854,7 @@ export interface OpenContentItem {
     provider_name?: string;
     channel_title?: string;
 }
+export interface TitleHandler {
+    title: string;
+    path?: string[];
+}


### PR DESCRIPTION
## Description of the change
This PR adds dynamic title changes for pages. In the library viewer the TitleManager checks to see if we are in the library viewer, if we are it gives an explicit 5 second timeout to wait for the iFrame to load the content, after that pulls the title tag from inside of the document and then renders it as the Title for the parent DOM. 

- **Related issues**: Closes #610 

## Screenshot(s)
1'st layer 
![image](https://github.com/user-attachments/assets/ac4974dc-9d55-46c3-96b6-97cd9ac3763c)

2'nd nested layer inside of the library viewer 
![image](https://github.com/user-attachments/assets/8b552fc4-759f-4d23-83d8-00da4340893c)

5 layers deep
![image](https://github.com/user-attachments/assets/4591263a-980c-4b79-aa64-3069871d1b09)


![image](https://github.com/user-attachments/assets/bbc492b5-26f6-40b3-946e-5ec4fccb29fe)


## Additional context
There is an issue in which if the user clicks on a link inside of the iFrame that is cross-site, the title will not change, and there will be errors in the console, but, this does not effect any of the functionality outside of that. 