### PR TITLE
fix: add button class on  Admin and  Student page, and pencil icon fix

### DIFF
--- a/frontend/src/Pages/AdminManagement.tsx
+++ b/frontend/src/Pages/AdminManagement.tsx
@@ -4,7 +4,7 @@ import {
     ArrowPathRoundedSquareIcon,
     LockClosedIcon,
     TrashIcon,
-    PencilIcon,
+    PencilSquareIcon,
     PlusCircleIcon
 } from '@heroicons/react/24/outline';
 import {
@@ -177,7 +177,7 @@ export default function AdminManagement() {
 
                     <div className="tooltip tooltip-left" data-tip="Add Admin">
                         <button
-                            className="btn btn-primary btn-sm text-base-teal"
+                            className="button"
                             onClick={() => addUserModal.current?.showModal()}
                         >
                             <PlusCircleIcon className="w-4 my-auto" />
@@ -240,7 +240,7 @@ export default function AdminManagement() {
                                                             setTargetUser(user);
                                                             editUserModal.current?.showModal();
                                                         }}
-                                                        icon={PencilIcon}
+                                                        icon={PencilSquareIcon}
                                                     />
                                                     <ULIComponent
                                                         dataTip={

--- a/frontend/src/Pages/StudentManagement.tsx
+++ b/frontend/src/Pages/StudentManagement.tsx
@@ -158,7 +158,7 @@ export default function StudentManagement() {
                         data-tip="Add Student"
                     >
                         <button
-                            className="btn btn-primary btn-sm text-base-teal"
+                            className="button "
                             onClick={() => addUserModal.current?.showModal()}
                         >
                             <PlusCircleIcon className="w-4 my-auto" />


### PR DESCRIPTION
## Description of the change
Add correct pencil icon in admin management page.
Removed old button classes for add admin and add student, and replaced with the button class.

- **Related issues**: Closes #619 
## Screenshot(s)
![image](https://github.com/user-attachments/assets/d4479e68-26f5-409c-8916-6950391145a9)
![image](https://github.com/user-attachments/assets/e8ef4015-31a6-49b8-b9f9-9adae084719a)
