### PR TITLE
fix: add dotted box to indicate no featured content on knowledge insights

### DIFF
--- a/frontend/src/Components/dashboard/FeaturedContent.tsx
+++ b/frontend/src/Components/dashboard/FeaturedContent.tsx
@@ -2,7 +2,7 @@ import { Library, UserRole } from '@/common';
 import LibraryCard from '../LibraryCard';
 import { useAuth } from '@/useAuth';
 import { useState } from 'react';
-
+import { useNavigate } from 'react-router-dom';
 export default function FeaturedContent({
     featured,
     mutate
@@ -14,28 +14,59 @@ export default function FeaturedContent({
     const [expanded, setExpanded] = useState<boolean>(false);
     const cols = user?.role == UserRole.Student ? 3 : 4;
     const slice = expanded ? featured.length : cols;
+
+    const navigate = useNavigate();
+
+    const handleEmptyStateClick = () => {
+        if (
+            user?.role === UserRole.Admin ||
+            user?.role === UserRole.SystemAdmin
+        ) {
+            navigate('/knowledge-center-management/libraries', {
+                replace: true
+            });
+        }
+    };
+
     return (
         <>
             <h2>Featured Content</h2>
             <div className="card card-row-padding flex flex-col gap-3">
-                <div className={`grid grid-cols-${cols} gap-3`}>
-                    {featured.slice(0, slice).map((item: Library) => {
-                        return (
-                            <LibraryCard
-                                key={item.id}
-                                library={item}
-                                role={UserRole.Student}
-                                mutate={mutate}
-                            />
-                        );
-                    })}
-                </div>
-                <button
-                    className="flex justify-end text-teal-3 hover:text-teal-4 body"
-                    onClick={() => setExpanded(!expanded)}
-                >
-                    {expanded ? 'See less' : 'See more featured content'}
-                </button>
+                {featured.length > 0 ? (
+                    <>
+                        <div className={`grid grid-cols-${cols} gap-3`}>
+                            {featured.slice(0, slice).map((item: Library) => (
+                                <LibraryCard
+                                    key={item.id}
+                                    library={item}
+                                    role={UserRole.Student}
+                                    mutate={mutate}
+                                />
+                            ))}
+                        </div>
+                        {featured.length > cols && (
+                            <button
+                                className="flex justify-end text-teal-3 hover:text-teal-4 body"
+                                onClick={() => setExpanded(!expanded)}
+                            >
+                                {expanded
+                                    ? 'See less'
+                                    : 'See more featured content'}
+                            </button>
+                        )}
+                    </>
+                ) : (
+                    <div className={`grid grid-cols-${cols} gap-3`}>
+                        <div
+                            onClick={handleEmptyStateClick}
+                            className="card border-2 border-dashed border-teal-3 cursor-pointer hover:bg-teal-1 transition-colors h-[168px] flex items-center justify-center"
+                        >
+                            <p className="text-teal-4 text-lg text-center px-4">
+                                Feature content to showcase
+                            </p>
+                        </div>
+                    </div>
+                )}
             </div>
         </>
     );


### PR DESCRIPTION
## Description of the change

Adds a dotted outline library shaped line around where a Library card would be in the Knowledge insights that is optionally clickable, when an admin clicks on the box it will redirect them to libraries so that they can feature content. 

- **Related issues**: Closes #634 

## Screenshot(s)

![image](https://github.com/user-attachments/assets/0d6cbbfe-0469-4145-a7fb-bd8a79c73974)
![image](https://github.com/user-attachments/assets/fb08aa62-e480-45d5-981c-499293c69f52)

![image](https://github.com/user-attachments/assets/9f8a8eff-6311-4317-b639-0202669ed144)
![image](https://github.com/user-attachments/assets/c5236bd0-e332-4504-b5b0-7cfcdcace7a8)

