### PR TITLE
fix: modals reset now upon close and reopen

### DIFF
--- a/frontend/src/Components/Modal.tsx
+++ b/frontend/src/Components/Modal.tsx
@@ -1,18 +1,23 @@
 import { ModalProps } from '@/common';
-import { forwardRef } from 'react';
+import { forwardRef, useState } from 'react';
 
 const Modal = forwardRef<HTMLDialogElement, ModalProps>(function Modal(
     { type, item, form },
     ref
 ) {
+    const [formKey, setFormKey] = useState(0);
     return (
-        <dialog ref={ref} className="modal">
+        <dialog
+            ref={ref}
+            className="modal"
+            onClose={() => setFormKey((prev) => prev + 1)}
+        >
             <div className="modal-box">
                 <div className="flex flex-col">
                     <span className="text-3xl font-semibold pb-6 text-neutral">
                         {type} {item}
                     </span>
-                    <div>{form}</div>
+                    <div key={formKey}>{form}</div>
                 </div>
             </div>
         </dialog>

--- a/frontend/src/Components/forms/EditFacilityForm.tsx
+++ b/frontend/src/Components/forms/EditFacilityForm.tsx
@@ -1,5 +1,5 @@
 import { Facility, ToastState, Timezones } from '@/common';
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
 import { SubmitHandler, useForm } from 'react-hook-form';
 import { CloseX, SubmitButton, DropdownInput, TextInput } from '../inputs';
 import API from '@/api/api';
@@ -58,6 +58,13 @@ export default function EditFacilityForm({
         reset();
         onSuccess(ToastState.success, 'Facility updated successfully');
     };
+
+    useEffect(() => {
+        reset({
+            name: facility.name || '',
+            timezone: facility.timezone || ''
+        });
+    }, [facility, reset]);
 
     function closeAndReset() {
         onSuccess(ToastState.null, '');

--- a/frontend/src/Components/forms/EditProviderForm.tsx
+++ b/frontend/src/Components/forms/EditProviderForm.tsx
@@ -7,7 +7,7 @@ import {
     ToastState
 } from '@/common';
 import { EyeIcon, EyeSlashIcon } from '@heroicons/react/24/solid';
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
 import { SubmitHandler, useForm } from 'react-hook-form';
 import { CloseX, DropdownInput, SubmitButton, TextInput } from '../inputs';
 import API from '@/api/api';
@@ -78,7 +78,10 @@ export default function EditProviderForm({
     const onSubmit: SubmitHandler<ProviderInputs> = async (data) => {
         const cleanData = diffFormData(data, provider);
         setErrorMessage('');
-        const response = (await API.patch<ProviderResponse, Partial<ProviderPlatform>>(
+        const response = (await API.patch<
+            ProviderResponse,
+            Partial<ProviderPlatform>
+        >(
             `provider-platforms/${provider?.id}`,
             cleanData
         )) as ServerResponseOne<ProviderResponse>;
@@ -86,13 +89,24 @@ export default function EditProviderForm({
             onSuccess(ToastState.error, 'Failed to update provider platform');
             return;
         }
-        if(response.data.oauth2Url){
+        if (response.data.oauth2Url) {
             window.location.href = response.data.oauth2Url;
             return;
         }
         reset();
         onSuccess(ToastState.success, 'Provider platform updated successfully');
     };
+    useEffect(() => {
+        reset({
+            name: provider.name || '',
+            type: provider.type || '',
+            base_url: provider.base_url || '',
+            account_id: provider.account_id || '',
+            state: provider.state || '',
+            access_key: provider.access_key || ''
+        });
+        setAccessKey(provider.access_key || '');
+    }, [provider, reset]);
 
     function closeAndReset() {
         onSuccess(ToastState.null, '');

--- a/frontend/src/Components/forms/EditUserForm.tsx
+++ b/frontend/src/Components/forms/EditUserForm.tsx
@@ -1,5 +1,5 @@
 import { ServerResponseOne, User, UserRole } from '@/common.ts';
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { SubmitHandler, useForm } from 'react-hook-form';
 import { TextInput, SubmitButton, CloseX } from '@/Components/inputs';
 import API from '@/api/api';
@@ -24,6 +24,7 @@ export default function EditUserForm({
         register,
         handleSubmit,
         setError,
+        reset,
         formState: { errors }
     } = useForm<Inputs>({
         defaultValues: {
@@ -33,6 +34,18 @@ export default function EditUserForm({
             email: user.email
         }
     });
+
+    function mapUserToInputs(user: User): Inputs {
+        return {
+            name_first: user.name_first || '',
+            name_last: user.name_last || '',
+            email: user.email || ''
+        };
+    }
+
+    useEffect(() => {
+        reset(mapUserToInputs(user));
+    }, [user, reset]);
 
     function diffFormData(formData: Inputs, currentUserData: User) {
         const changes: Partial<User> = {};


### PR DESCRIPTION
## Description of the change
This PR makes sure that modal forms are reset to defaults, and or relevant data when a user exits out of them through the ESC key. Prior to this if you opened a modal, input data, and then used the ESC key to exit, it was holding onto that stale input/data/information, this no longer happens. 

- **Related issues**: Closes #638 

## Screenshot(s)

https://www.loom.com/share/d0edbeac9c754cdfbcb0ebd52fcdbb47?sid=4eae16cd-3dc7-4aca-8041-c56a3087af0b
