### PR TITLE
fix: fix helpful links name persistence and accidental navigation on helpful links

### DIFF
--- a/frontend/src/Components/cards/HelpfulLinkCard.tsx
+++ b/frontend/src/Components/cards/HelpfulLinkCard.tsx
@@ -14,7 +14,6 @@ import { AdminRoles } from '@/useAuth';
 import { useToast } from '@/Context/ToastCtx';
 import { StarIcon } from '@heroicons/react/24/solid';
 import { StarIcon as StarIconOutline } from '@heroicons/react/24/outline';
-import { useNavigate } from 'react-router-dom';
 
 export default function HelpfulLinkCard({
     link,
@@ -33,7 +32,6 @@ export default function HelpfulLinkCard({
 }) {
     const [visible, setVisible] = useState<boolean>(link.visibility_status);
     const { toaster } = useToast();
-    const navigate = useNavigate();
 
     function changeVisibility(visibilityStatus: boolean) {
         if (visibilityStatus == !visible) {
@@ -78,7 +76,6 @@ export default function HelpfulLinkCard({
         )) as ServerResponseOne<{ url: string }>;
         if (resp.success) {
             window.open(resp.data.url, '_blank');
-            navigate('/knowledge-center/libraries');
         }
     }
 

--- a/frontend/src/Components/forms/EditLinkForm.tsx
+++ b/frontend/src/Components/forms/EditLinkForm.tsx
@@ -55,7 +55,7 @@ export default function EditLinkForm({
             >
                 <TextInput
                     label="Name"
-                    interfaceRef="name"
+                    interfaceRef="title"
                     required
                     length={25}
                     errors={errors}


### PR DESCRIPTION

## Description of the change
Fixes user being navigated away from the helpful links page when they click on a link, the user will now stay on the helpful links page in the original tab, without switching from admin to student view and vice versa. Also persists the "name" of the helpful link upon edit. 

- **Related issues**: Closes #642 Closes #644 

## Screenshot(s)

When i hit ESC in the modal, the form doesnt escape because the other bug I just fixed hasn't been merged in yet, that issue shouldn't persist after my last PR gets merged. 
https://www.loom.com/share/e3668c6b30db47388a665bd5647510cf?sid=ac98bdcc-696a-41ad-916b-fa06f0169dff

