### PR TITLE
Fixes for moving links on menu and layer inconsistencies

### DIFF
--- a/frontend/src/Components/Navbar.tsx
+++ b/frontend/src/Components/Navbar.tsx
@@ -15,7 +15,8 @@ import {
     CloudIcon,
     RssIcon,
     RectangleStackIcon,
-    CogIcon
+    CogIcon,
+    LightBulbIcon
 } from '@heroicons/react/24/solid';
 import {
     getDashboardLink,
@@ -50,11 +51,6 @@ export default function Navbar({
     const { toaster } = useToast();
     const confirmSeedModal = useRef<HTMLDialogElement | null>(null);
     const [seedInProgress, setSeedInProgress] = useState<boolean>(false);
-    const dashboardTitleAdmin = new Map([
-        ['/learning-insights', 'Learning'],
-        ['/knowledge-insights', 'Knowledge'],
-        ['/operational-insights', 'Operational']
-    ]);
     const dashboardTitleStudent = new Map([
         ['/trending-content', 'Trending Content'],
         ['/learning-path', 'Learning Path'],
@@ -109,42 +105,41 @@ export default function Navbar({
 
             <div className="h-full">
                 <ul className="menu h-full flex flex-col justify-between">
-                    <div>
+                    <div className="mt-16">
                         {/* admin view */}
                         {user && isAdministrator(user) ? (
                             <>
-                                <li className="mt-16">
-                                    <Link to={getDashboardLink(user)}>
-                                        <ULIComponent icon={HomeIcon} />
-                                        {dashboardTitleAdmin.get(
-                                            getDashboardLink(user)
-                                        ) ?? 'Operational'}{' '}
-                                        Insights
-                                    </Link>
-                                </li>
                                 {hasFeature(
                                     user,
                                     FeatureAccess.OpenContentAccess
-                                ) &&
-                                    user.feature_access.length > 1 && (
-                                        <li>
-                                            <Link to="/knowledge-insights">
-                                                <ULIComponent
-                                                    icon={BookOpenIcon}
-                                                />
-                                                Knowledge Insights
-                                            </Link>
-                                        </li>
-                                    )}
-                                {/* this acts as the dashboard in the case there are no features enabled */}
-                                {user.feature_access.length > 0 && (
+                                ) && (
                                     <li>
-                                        <Link to="/operational-insights">
-                                            <ULIComponent icon={CogIcon} />
-                                            Operational Insights
+                                        <Link to="/knowledge-insights">
+                                            <ULIComponent icon={BookOpenIcon} />
+                                            Knowledge Insights
                                         </Link>
                                     </li>
                                 )}
+                                {hasFeature(
+                                    user,
+                                    FeatureAccess.ProviderAccess
+                                ) && (
+                                    <li>
+                                        <Link to="/learning-insights">
+                                            <ULIComponent
+                                                icon={LightBulbIcon}
+                                            />
+                                            Learning Insights
+                                        </Link>
+                                    </li>
+                                )}
+                                {/* this acts as the dashboard in the case there are no features enabled */}
+                                <li>
+                                    <Link to="/operational-insights">
+                                        <ULIComponent icon={CogIcon} />
+                                        Operational Insights
+                                    </Link>
+                                </li>
                                 {hasFeature(
                                     user,
                                     FeatureAccess.ProviderAccess

--- a/frontend/src/useAuth.ts
+++ b/frontend/src/useAuth.ts
@@ -158,12 +158,6 @@ const accessValues = new Map<FeatureAccess, number>([
     [FeatureAccess.ProviderAccess, 2],
     [FeatureAccess.ProgramAccess, 3]
 ]);
-const adminAccessLinks = [
-    '/operational-insights', // temporary layer 0 until implemented
-    '/knowledge-insights',
-    '/learning-insights',
-    '/learning-insights' // temporary until layer 3 is implemented
-];
 
 export const studentAccessLinks = [
     '/home', // temporary layer 0 until implemented
@@ -181,6 +175,16 @@ export const getDashboardLink = (user?: User) => {
             .sort((a, b) => a - b)
             .pop() ?? 0;
     return isAdministrator(user)
-        ? adminAccessLinks[maxFeature]
+        ? getAdminLink(user)
         : studentAccessLinks[maxFeature];
+};
+
+const getAdminLink = (user: User): string => {
+    if (user.feature_access.includes(FeatureAccess.OpenContentAccess)) {
+        return "/knowledge-insights";
+    }
+    if (user.feature_access.includes(FeatureAccess.ProviderAccess)) {
+        return "/learning-insights";
+    }
+    return "/operational-insights";
 };


### PR DESCRIPTION
## Description of the change

- #611
    - Consisted of moving html elements around as well as some css due to the gap between the logo and top list item.
- #647 
    - Consisted of modifying and conditionally displaying html per layer selected and reworking some javascript to handle the page that gets displayed to the user based on the layer selected.

- **Related issues**: closes #611, closes #647

## Screenshot(s)
![connectedlearning](https://github.com/user-attachments/assets/a92af95e-6d12-41a4-8076-97c77efe0fa7)

![allturnedon](https://github.com/user-attachments/assets/cd13e7d6-c394-437b-9e43-c7d75af8f0c4)

![programminghub](https://github.com/user-attachments/assets/21356ece-3c39-40f9-9ef2-500e45a32239)
