### PR TITLE
feat: add workflow to label issues with "Needs verification" when moved to Done

### DIFF
--- a/.github/workflows/add-needs-verification-label.yml
+++ b/.github/workflows/add-needs-verification-label.yml
@@ -1,0 +1,30 @@
+name: Add Needs Verification Label
+
+on:
+  project_card:
+    types: [moved]
+
+jobs:
+  add-label:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check if the issue is moved to Done
+        id: check_move
+        run: |
+          if [[ "${{ github.event.project_card.column_id }}" != "98236657" ]]; then
+            echo "Not moved to Done column. Exiting."
+            exit 0
+          fi
+
+      - name: Add Needs Verification Label
+        if: steps.check_move.outputs.result == 'true'
+        uses: actions/github-script@v6
+        with:
+          script: |
+            const issue_number = context.payload.project_card.content_url.split('/').pop();
+            await github.issues.addLabels({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: issue_number,
+              labels: ['Needs verification']
+            });


### PR DESCRIPTION
…ed to Done

This workflow is triggered when an issue is moved to the "Done" column in the project board. It automatically adds the "Needs verification" label to the issue. The label will be used to indicate that the issue needs to be verified in the staging deployment before it can be considered fully resolved. Once the verification is complete, the label can be manually removed by the person validating the issue.

## Description of the change

Please provide a brief description of the changes included in this PR.

- **Related issues**: Link to related issue(s) this PR addresses, if any (use phrases like "fixes #1234" or "closes #1234").

## Screenshot(s)

If the PR includes changes to the UI, please add screenshots or a brief screengrab to demonstrate the changes.

## Additional context

Please include any additional context or information that the reviewer may need to understand the PR.