### PR TITLE
fix: remove breadcrumbs, move page titles

### DIFF
--- a/frontend/src/Components/Navbar.tsx
+++ b/frontend/src/Components/Navbar.tsx
@@ -75,10 +75,10 @@ export default function Navbar({
 
     return (
         <div className="w-60 min-w-[240px] flex flex-col bg-background group h-screen">
-            <div className="hidden lg:flex self-end py-6 mr-4">
+            <div className="hidden lg:flex self-end py-8 mr-4">
                 {isPinned ? (
                     <div
-                        className="tooltip tooltip-left py-8 "
+                        className="tooltip tooltip-left"
                         data-tip="Close sidebar"
                     >
                         <ChevronDoubleLeftIcon

--- a/frontend/src/Components/Navbar.tsx
+++ b/frontend/src/Components/Navbar.tsx
@@ -78,7 +78,7 @@ export default function Navbar({
             <div className="hidden lg:flex self-end py-6 mr-4">
                 {isPinned ? (
                     <div
-                        className="tooltip tooltip-left"
+                        className="tooltip tooltip-left py-8 "
                         data-tip="Close sidebar"
                     >
                         <ChevronDoubleLeftIcon
@@ -99,7 +99,7 @@ export default function Navbar({
                 )}
             </div>
 
-            <Link to="/" className="mt-16">
+            <Link to="/" className="mt-14">
                 <Brand />
             </Link>
 
@@ -190,7 +190,7 @@ export default function Navbar({
                                     </li>
                                 )}
                                 <li>
-                                    <Link to="/students">
+                                    <Link to="/residents">
                                         <ULIComponent icon={AcademicCapIcon} />
                                         Residents
                                     </Link>

--- a/frontend/src/Components/PageNav.tsx
+++ b/frontend/src/Components/PageNav.tsx
@@ -1,14 +1,12 @@
-import { useEffect, useRef } from 'react';
+import { useState, useEffect, useRef } from 'react';
 import { isAdministrator, useAuth } from '@/useAuth';
 import { Bars3Icon, BuildingOffice2Icon } from '@heroicons/react/24/solid';
 import ULIComponent from '@/Components/ULIComponent.tsx';
-import { Facility } from '@/common';
+import { Facility, TitleHandler } from '@/common';
 import { useMatches, useLoaderData } from 'react-router-dom';
 import API from '@/api/api';
 
-interface HandleType {
-    title: string;
-}
+let setGlobalPageTitle: (newTitle: string) => void;
 
 export default function PageNav({
     showOpenMenu,
@@ -22,7 +20,11 @@ export default function PageNav({
     const facilityNames = useLoaderData() as Facility[] | null;
     const matches = useMatches();
     const currentRoute = matches[matches.length - 1];
-    const pageTitle = (currentRoute?.handle as HandleType)?.title;
+    const pageTitle = (currentRoute?.handle as TitleHandler)?.title;
+    const [globalPageTitle, _setGlobalPageTitle] = useState<string>(
+        pageTitle || 'Library Viewer'
+    );
+    setGlobalPageTitle = _setGlobalPageTitle;
 
     useEffect(() => {
         const closeDropdown = ({ target }: MouseEvent) => {
@@ -66,7 +68,11 @@ export default function PageNav({
                         iconClassName="lg:hidden cursor-pointer"
                     />
                 )}
-                <h1>{pageTitle}</h1>
+                <h1 className="text-2xl font-lexend font-semibold">
+                    {pageTitle == 'Library Viewer'
+                        ? globalPageTitle
+                        : pageTitle}
+                </h1>
             </div>
             {user && isAdministrator(user) ? (
                 <ul className="menu menu-horizontal px-1">
@@ -109,3 +115,4 @@ export default function PageNav({
         </div>
     );
 }
+export { setGlobalPageTitle };

--- a/frontend/src/Components/PageNav.tsx
+++ b/frontend/src/Components/PageNav.tsx
@@ -68,7 +68,7 @@ export default function PageNav({
                         iconClassName="lg:hidden cursor-pointer"
                     />
                 )}
-                <h1 className="text-2xl font-lexend font-semibold">
+                <h1>
                     {pageTitle == 'Library Viewer'
                         ? globalPageTitle
                         : pageTitle}

--- a/frontend/src/Components/PageNav.tsx
+++ b/frontend/src/Components/PageNav.tsx
@@ -1,48 +1,28 @@
-import { useEffect, useRef, useState } from 'react';
+import { useEffect, useRef } from 'react';
 import { isAdministrator, useAuth } from '@/useAuth';
-import {
-    Bars3Icon,
-    BuildingOffice2Icon,
-    HomeIcon
-} from '@heroicons/react/24/solid';
+import { Bars3Icon, BuildingOffice2Icon } from '@heroicons/react/24/solid';
 import ULIComponent from '@/Components/ULIComponent.tsx';
 import { Facility } from '@/common';
-import { useLoaderData } from 'react-router-dom';
+import { useMatches, useLoaderData } from 'react-router-dom';
 import API from '@/api/api';
-import { usePathValue } from '@/Context/PathValueCtx';
+
+interface HandleType {
+    title: string;
+}
 
 export default function PageNav({
-    path,
     showOpenMenu,
     onShowNav
 }: {
-    path: string[];
     showOpenMenu: boolean;
     onShowNav?: () => void;
 }) {
     const { user } = useAuth();
     const detailsRef = useRef<HTMLDetailsElement>(null);
-    const { pathVal } = usePathValue();
-    const [customPath, setCustomPath] = useState<string[]>(path ?? []);
     const facilityNames = useLoaderData() as Facility[] | null;
-
-    useEffect(() => {
-        const handlePathChange = () => {
-            const newPath = [...path];
-            if (newPath && newPath.length > 0) {
-                setCustomPath(
-                    newPath.map((p) => {
-                        return (
-                            pathVal?.find((pv) => pv.path_id === p)?.value ?? p
-                        );
-                    })
-                );
-                return;
-            }
-            setCustomPath(path);
-        };
-        handlePathChange();
-    }, [path, pathVal]);
+    const matches = useMatches();
+    const currentRoute = matches[matches.length - 1];
+    const pageTitle = (currentRoute?.handle as HandleType)?.title;
 
     useEffect(() => {
         const closeDropdown = ({ target }: MouseEvent) => {
@@ -72,40 +52,23 @@ export default function PageNav({
 
     return (
         <div className="px-6 py-3 flex justify-between items-center">
-            <div className="breadcrumbs">
-                <ul>
-                    {showOpenMenu ? (
-                        <li>
-                            <ULIComponent
-                                onClick={() => {
-                                    if (onShowNav) onShowNav();
-                                }}
-                                icon={Bars3Icon}
-                                iconClassName={'cursor-pointer'}
-                            />
-                        </li>
-                    ) : (
-                        <li>
-                            <ULIComponent
-                                onClick={() => {
-                                    if (onShowNav) onShowNav();
-                                }}
-                                icon={Bars3Icon}
-                                iconClassName={'lg:hidden cursor-pointer'}
-                            />
-                            <ULIComponent
-                                icon={HomeIcon}
-                                iconClassName={'hidden lg:block'}
-                            />
-                        </li>
-                    )}
-
-                    {customPath?.map((p) => (
-                        <li className="capitalize body" key={p}>
-                            {p}
-                        </li>
-                    ))}
-                </ul>
+            <div className="flex items-center gap-3">
+                {showOpenMenu ? (
+                    <ULIComponent
+                        onClick={onShowNav}
+                        icon={Bars3Icon}
+                        iconClassName="cursor-pointer"
+                    />
+                ) : (
+                    <ULIComponent
+                        onClick={onShowNav}
+                        icon={Bars3Icon}
+                        iconClassName="lg:hidden cursor-pointer"
+                    />
+                )}
+                <h1 className="text-2xl font-lexend font-semibold">
+                    {pageTitle}
+                </h1>
             </div>
             {user && isAdministrator(user) ? (
                 <ul className="menu menu-horizontal px-1">

--- a/frontend/src/Components/PageNav.tsx
+++ b/frontend/src/Components/PageNav.tsx
@@ -66,9 +66,7 @@ export default function PageNav({
                         iconClassName="lg:hidden cursor-pointer"
                     />
                 )}
-                <h1 className="text-2xl font-lexend font-semibold">
-                    {pageTitle}
-                </h1>
+                <h1>{pageTitle}</h1>
             </div>
             {user && isAdministrator(user) ? (
                 <ul className="menu menu-horizontal px-1">

--- a/frontend/src/Components/VideoEmbedViewer.tsx
+++ b/frontend/src/Components/VideoEmbedViewer.tsx
@@ -40,7 +40,6 @@ export default function VideoViewer() {
     };
     return (
         <div className="px-8 pb-4">
-            <h1>Video Viewer</h1>
             <div className="w-2/3 pt-4 justify-center">
                 {isLoading ? (
                     <div className="flex h-screen gap-4 justify-center content-center">

--- a/frontend/src/Layouts/AuthenticatedLayout.tsx
+++ b/frontend/src/Layouts/AuthenticatedLayout.tsx
@@ -13,7 +13,6 @@ export default function AuthenticatedLayout() {
     const matches = useMatches() as CustomRouteMatch[];
     const currentMatch = matches.find((match) => match?.handle?.title);
     const title = currentMatch?.handle?.title ?? 'UnlockEd';
-    const path = currentMatch?.handle?.path;
     // We have three states we need to factor for.
     // 1. If the nav is open & pinned (Large screens only & uses lg:drawer-open)
     // 2. If the nav is open & not pinned (Large screens only)
@@ -46,7 +45,6 @@ export default function AuthenticatedLayout() {
                 <div className="drawer-content flex flex-col border-l border-grey-1">
                     <main className="w-full min-h-screen bg-background flex flex-col">
                         <PageNav
-                            path={path ?? []}
                             showOpenMenu={!isNavPinned}
                             onShowNav={showNav}
                         />

--- a/frontend/src/Pages/AdminLayer2.tsx
+++ b/frontend/src/Pages/AdminLayer2.tsx
@@ -36,9 +36,6 @@ export default function AdminLayer2() {
             {!data || (isLoading && <div>Loading...</div>)}
             {data && layer2_metrics && (
                 <>
-                    <div className="pb-4">
-                        <h1>Learning Insights</h1>
-                    </div>
                     <div className="flex flex-row justify-between mb-6">
                         <select
                             id="facility"

--- a/frontend/src/Pages/AdminManagement.tsx
+++ b/frontend/src/Pages/AdminManagement.tsx
@@ -156,7 +156,6 @@ export default function AdminManagement() {
     return (
         <div>
             <div className="flex flex-col space-y-6 overflow-x-auto rounded-lg p-4 px-8">
-                <h1>Admins</h1>
                 <div className="flex justify-between">
                     <div className="flex flex-row gap-x-2">
                         <SearchBar

--- a/frontend/src/Pages/CourseCatalog.tsx
+++ b/frontend/src/Pages/CourseCatalog.tsx
@@ -31,7 +31,7 @@ export default function CourseCatalog() {
     return (
         <div className="px-8 py-4">
             <div className="flex flex-row justify-between">
-                <h1>Course Catalog</h1>
+                <h1 className="invisible">Placeholder</h1>
                 <ToggleView
                     activeView={activeView}
                     setActiveView={setActiveView}

--- a/frontend/src/Pages/CourseCatalog.tsx
+++ b/frontend/src/Pages/CourseCatalog.tsx
@@ -30,8 +30,7 @@ export default function CourseCatalog() {
 
     return (
         <div className="px-8 py-4">
-            <div className="flex flex-row justify-between">
-                <h1 className="invisible">Placeholder</h1>
+            <div className="flex flex-row justify-end">
                 <ToggleView
                     activeView={activeView}
                     setActiveView={setActiveView}

--- a/frontend/src/Pages/FacilityManagement.tsx
+++ b/frontend/src/Pages/FacilityManagement.tsx
@@ -110,7 +110,6 @@ export default function FacilityManagement() {
     return (
         <>
             <div className="px-8 py-4 flex flex-col justify-center gap-4">
-                <h1>Facility Management</h1>
                 <div className="flex flex-row justify-between">
                     <div>
                         {/* TO DO: this is where SEARCH and SORT will go */}

--- a/frontend/src/Pages/LibraryViewer.tsx
+++ b/frontend/src/Pages/LibraryViewer.tsx
@@ -10,6 +10,7 @@ export default function LibraryViewer() {
     const [src, setSrc] = useState<string>('');
     const [error, setError] = useState<string | null>(null);
     const [isLoading, setIsLoading] = useState<boolean>(true);
+    const [libraryTitle, setLibraryTitle] = useState<string>('');
     const { setPathVal } = usePathValue();
 
     useEffect(() => {
@@ -20,6 +21,7 @@ export default function LibraryViewer() {
                     `libraries/${libraryId}`
                 )) as ServerResponseOne<Library>;
                 if (resp.success) {
+                    setLibraryTitle(resp.data.title);
                     setPathVal([
                         { path_id: ':library_name', value: resp.data.title }
                     ]);
@@ -49,7 +51,7 @@ export default function LibraryViewer() {
     return (
         <div>
             <div className="px-8 pb-4">
-                <h1>Library Viewer</h1>
+                <h1 className="text-2xl font-bold">{libraryTitle}</h1>
                 <div className="w-full pt-4 justify-center">
                     {isLoading ? (
                         <div className="flex h-screen gap-4 justify-center content-center">

--- a/frontend/src/Pages/LibraryViewer.tsx
+++ b/frontend/src/Pages/LibraryViewer.tsx
@@ -4,13 +4,13 @@ import Error from '@/Pages/Error';
 import API from '@/api/api';
 import { Library, ServerResponseOne } from '@/common';
 import { usePathValue } from '@/Context/PathValueCtx';
+import { setGlobalPageTitle } from '@/Components/PageNav';
 
 export default function LibraryViewer() {
     const { id: libraryId } = useParams();
     const [src, setSrc] = useState<string>('');
     const [error, setError] = useState<string | null>(null);
     const [isLoading, setIsLoading] = useState<boolean>(true);
-    const [libraryTitle, setLibraryTitle] = useState<string>('');
     const { setPathVal } = usePathValue();
 
     useEffect(() => {
@@ -21,7 +21,7 @@ export default function LibraryViewer() {
                     `libraries/${libraryId}`
                 )) as ServerResponseOne<Library>;
                 if (resp.success) {
-                    setLibraryTitle(resp.data.title);
+                    setGlobalPageTitle(resp.data.title);
                     setPathVal([
                         { path_id: ':library_name', value: resp.data.title }
                     ]);
@@ -51,7 +51,6 @@ export default function LibraryViewer() {
     return (
         <div>
             <div className="px-8 pb-4">
-                <h1 className="text-2xl font-bold">{libraryTitle}</h1>
                 <div className="w-full pt-4 justify-center">
                     {isLoading ? (
                         <div className="flex h-screen gap-4 justify-center content-center">

--- a/frontend/src/Pages/MyCourses.tsx
+++ b/frontend/src/Pages/MyCourses.tsx
@@ -55,7 +55,6 @@ export default function MyCourses() {
 
     return (
         <div className="px-8 py-4">
-            <h1>My Courses</h1>
             <TabView
                 tabs={tabs}
                 activeTab={activeTab}
@@ -81,8 +80,7 @@ export default function MyCourses() {
                                 'order=asc&order_by=start_dt',
                             'Start Date (descending)':
                                 'order=desc&order_by=start_dt',
-                            'End Date (ascending)':
-                                'order=asc&order_by=end_dt',
+                            'End Date (ascending)': 'order=asc&order_by=end_dt',
                             'End Date (descending)':
                                 'order=desc&order_by=end_dt'
                         }}

--- a/frontend/src/Pages/MyProgress.tsx
+++ b/frontend/src/Pages/MyProgress.tsx
@@ -50,7 +50,6 @@ export default function MyProgress() {
 
     return (
         <div className="px-8 py-4">
-            <h1>My Progress</h1>
             {!error && courseData && (
                 <>
                     <div className="grid grid-cols-3 gap-4 mt-6 mb-6">

--- a/frontend/src/Pages/OpenContent.tsx
+++ b/frontend/src/Pages/OpenContent.tsx
@@ -43,8 +43,7 @@ export default function OpenContent() {
 
     return (
         <div className="px-8 pb-4">
-            <div className="flex flex-row justify-between">
-                <h1 className="invisible">Placeholder</h1>
+            <div className="flex flex-row justify-end">
                 {user && isAdministrator(user) && (
                     <button
                         className="button border border-primary bg-transparent text-body-text"

--- a/frontend/src/Pages/OpenContent.tsx
+++ b/frontend/src/Pages/OpenContent.tsx
@@ -44,7 +44,7 @@ export default function OpenContent() {
     return (
         <div className="px-8 pb-4">
             <div className="flex flex-row justify-between">
-                <h1>Knowledge Center</h1>
+                <h1 className="invisible">Placeholder</h1>
                 {user && isAdministrator(user) && (
                     <button
                         className="button border border-primary bg-transparent text-body-text"

--- a/frontend/src/Pages/OpenContentManagement.tsx
+++ b/frontend/src/Pages/OpenContentManagement.tsx
@@ -33,8 +33,7 @@ export default function OpenContentManagement() {
 
     return (
         <div className="px-8 pb-4">
-            <div className="flex flex-row justify-between">
-                <h1 className="invisible">Placeholder</h1>
+            <div className="flex flex-row justify-end">
                 <button
                     className="button border border-primary bg-transparent text-body-text"
                     onClick={navigateToStudentView}

--- a/frontend/src/Pages/OpenContentManagement.tsx
+++ b/frontend/src/Pages/OpenContentManagement.tsx
@@ -34,7 +34,7 @@ export default function OpenContentManagement() {
     return (
         <div className="px-8 pb-4">
             <div className="flex flex-row justify-between">
-                <h1>Knowledge Center Management</h1>
+                <h1 className="invisible">Placeholder</h1>
                 <button
                     className="button border border-primary bg-transparent text-body-text"
                     onClick={navigateToStudentView}

--- a/frontend/src/Pages/OperationalInsights.tsx
+++ b/frontend/src/Pages/OperationalInsights.tsx
@@ -4,7 +4,6 @@ export default function OperationalInsightsPage() {
     return (
         <div>
             <div className="px-8 pb-4 mt-8">
-                <h1>Operational Insights</h1>
                 <OperationalInsights />
             </div>
         </div>

--- a/frontend/src/Pages/ProviderPlatformManagement.tsx
+++ b/frontend/src/Pages/ProviderPlatformManagement.tsx
@@ -179,7 +179,6 @@ export default function ProviderPlatformManagement() {
     return (
         <div>
             <div className="px-8 py-4">
-                <h1>Learning Platforms</h1>
                 <div className="flex flex-row justify-between">
                     <div>
                         {/* TO DO: this is where SEARCH and SORT will go */}

--- a/frontend/src/Pages/StudentLayer1.tsx
+++ b/frontend/src/Pages/StudentLayer1.tsx
@@ -8,7 +8,6 @@ import {
     ServerResponseMany
 } from '@/common';
 import HelpfulLinkCard from '@/Components/cards/HelpfulLinkCard';
-import { useAuth } from '@/useAuth';
 import { useLoaderData, useNavigate } from 'react-router-dom';
 import { FeaturedContent } from '@/Components/dashboard';
 import TopContentList from '@/Components/dashboard/TopContentList';
@@ -17,7 +16,6 @@ import { AxiosError } from 'axios';
 import OpenContentItemAccordion from '@/Components/OpenContentItemAccordion';
 
 export default function StudentLayer1() {
-    const { user } = useAuth();
     const navigate = useNavigate();
     const { topUserContent, topFacilityContent } = useLoaderData() as {
         topUserContent: OpenContentItem[];
@@ -50,9 +48,6 @@ export default function StudentLayer1() {
         <div className="flex flex-row h-full">
             {/* main section */}
             <div className="w-full flex flex-col gap-6 px-6 pb-4">
-                <h1 className="text-5xl">
-                    Hi, {user?.name_first ?? 'Student'}!
-                </h1>
                 <FeaturedContent
                     featured={featured?.data ?? []}
                     mutate={updateFavorites}

--- a/frontend/src/Pages/StudentManagement.tsx
+++ b/frontend/src/Pages/StudentManagement.tsx
@@ -134,7 +134,6 @@ export default function StudentManagement() {
     return (
         <div>
             <div className="flex flex-col space-y-6 overflow-x-auto rounded-lg p-4 px-8">
-                <h1>Students</h1>
                 <div className="flex justify-between">
                     <div className="flex flex-row gap-x-2">
                         <SearchBar

--- a/frontend/src/app.tsx
+++ b/frontend/src/app.tsx
@@ -337,12 +337,12 @@ const router = createBrowserRouter([
                         }
                     },
                     {
-                        path: 'students',
+                        path: 'residents',
                         element: <StudentManagement />,
                         errorElement: <Error />,
                         handle: {
-                            title: 'Students',
-                            path: ['students']
+                            title: 'Residents',
+                            path: ['residents']
                         }
                     },
                     {
@@ -433,7 +433,7 @@ const router = createBrowserRouter([
                                 path: 'knowledge-center-management',
                                 element: <OpenContentManagement />,
                                 handle: {
-                                    title: 'Knowledge Center',
+                                    title: 'Knowledge Center Management',
                                     path: ['knowledge-center', ':kind']
                                 },
                                 children: [
@@ -442,7 +442,7 @@ const router = createBrowserRouter([
                                         element: <LibraryLayout />,
                                         errorElement: <Error />,
                                         handle: {
-                                            title: 'Libraries',
+                                            title: 'Libraries Management',
                                             path: [
                                                 'knowledge-center',
                                                 'libraries'
@@ -453,7 +453,7 @@ const router = createBrowserRouter([
                                         path: 'videos',
                                         element: <VideoManagement />,
                                         handle: {
-                                            title: 'Videos',
+                                            title: 'Videos Management',
                                             path: ['knowledge-center', 'videos']
                                         }
                                     },
@@ -461,7 +461,7 @@ const router = createBrowserRouter([
                                         path: 'helpful-links',
                                         element: <HelpfulLinksManagement />,
                                         handle: {
-                                            title: 'Helpful Links',
+                                            title: 'Helpful Links Management',
                                             path: [
                                                 'knowledge-center',
                                                 'helpful-links'

--- a/frontend/src/common.ts
+++ b/frontend/src/common.ts
@@ -862,7 +862,6 @@ export interface TitleHandler {
     title: string;
     path?: string[];
 }
-
 export interface ActivityMapData {
     date: string;
     total_time: string;


### PR DESCRIPTION
## Description of the change

This PR removes the breadcrumbs from the PageNav, removes the h1 headder tags for the page names throughout the application, I use the react-router-dom's useMatches and the route's title attribute to name the pages and then place those in the respective spot where the old breadcrumbs were, I also made the Home icon navigable, and changed "students" to residents in app.tsx as that is the language we are trying to move to, and I was in there.  

- **Related issues**: Closes #640 

## Screenshot(s)
Admin and student walk through
https://www.loom.com/share/8461ef4247fd4b93b878f457cd4cb703?sid=ea7b1cef-ac49-402d-bcda-2ef88f998f09

