### PR TITLE
fix: remove featured content box if empty and not admin

### DIFF
--- a/frontend/src/Components/dashboard/FeaturedContent.tsx
+++ b/frontend/src/Components/dashboard/FeaturedContent.tsx
@@ -14,19 +14,21 @@ export default function FeaturedContent({
     const [expanded, setExpanded] = useState<boolean>(false);
     const cols = user?.role == UserRole.Student ? 3 : 4;
     const slice = expanded ? featured.length : cols;
+    const isAdmin =
+        user?.role === UserRole.Admin || user?.role === UserRole.SystemAdmin;
 
     const navigate = useNavigate();
 
     const handleEmptyStateClick = () => {
-        if (
-            user?.role === UserRole.Admin ||
-            user?.role === UserRole.SystemAdmin
-        ) {
+        if (isAdmin) {
             navigate('/knowledge-center-management/libraries', {
                 replace: true
             });
         }
     };
+    if (!featured.length && !isAdmin) {
+        return null;
+    }
 
     return (
         <>


### PR DESCRIPTION
## Description of the change
Fixes there being a "Featured Content" box if there is no featured content and the user is not an admin.

- **Related issues**: Closes #654 

## Screenshot(s)
Student side is on the left, admin is on the right. 
![image](https://github.com/user-attachments/assets/ab9990e2-84a3-49bc-95f8-b59a6c01aad7)

