### PR TITLE
chore: updated pr-template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -11,3 +11,5 @@ If the PR includes changes to the UI, please add screenshots or a brief screengr
 ## Additional context
 
 Please include any additional context or information that the reviewer may need to understand the PR.
+
+If any core features or components were removed with this PR, please note them here so that they can be added to the wiki (see [Deprecated features and Components](https://github.com/UnlockedLabs/UnlockEdv2/wiki/Deprecated-Features-and-Components)).


### PR DESCRIPTION
A page was added to the repository wiki (https://github.com/UnlockedLabs/UnlockEdv2/wiki/Deprecated-Features-and-Components) to track when we remove deprecated features & components. 

This change updates the PR template to remind the author to update the wiki page when they remove features or components that might be reintroduced or took significant development.