### PR TITLE
Fixes for making entire video card clickable and enhancing course card display

### DIFF
--- a/frontend/src/Components/CatalogCourseCard.tsx
+++ b/frontend/src/Components/CatalogCourseCard.tsx
@@ -52,14 +52,14 @@ export default function CatalogCourseCard({
         ? courseStartDt.toLocaleDateString('en-US', {
               year: 'numeric',
               month: '2-digit',
-              day: 'numeric'
+              day: '2-digit'
           })
         : '';
     const courseEndDtStr = courseEndDt
         ? courseEndDt.toLocaleDateString('en-US', {
               year: 'numeric',
               month: '2-digit',
-              day: 'numeric'
+              day: '2-digit'
           })
         : '';
     const finalDateStr =

--- a/frontend/src/Components/ClampedText.tsx
+++ b/frontend/src/Components/ClampedText.tsx
@@ -1,0 +1,39 @@
+import { useEffect, useRef, useState } from "react";
+
+export default function ClampedText({
+    as: Component = "div",
+    children,
+    lines = 2,
+    className = "",
+}: {
+    as?: React.ElementType;
+    children: React.ReactNode;
+    lines?: number;
+    className?: string;
+}) {
+    const textRef = useRef<HTMLElement>(null);
+    const [isClamped, setIsClamped] = useState(false);
+
+    const checkClamping = () => {
+        if (textRef.current) {
+            const isContentClamped =
+                textRef.current.scrollHeight > textRef.current.clientHeight ||
+                textRef.current.scrollWidth > textRef.current.clientWidth;
+            setIsClamped(isContentClamped);
+        }
+    };
+
+    useEffect(() => {
+        checkClamping();
+        window.addEventListener("resize", checkClamping);
+        return () => {
+            window.removeEventListener("resize", checkClamping);
+        };
+    }, [children]);
+
+    return (
+        <Component ref={textRef} className={`line-clamp-${lines} overflow-hidden ${className}`} title={isClamped ? (typeof children === "string" ? children : "") : ""}>
+            {children}
+        </Component>
+    );
+}

--- a/frontend/src/Components/EnrolledCourseCard.tsx
+++ b/frontend/src/Components/EnrolledCourseCard.tsx
@@ -1,7 +1,7 @@
 import { CheckCircleIcon, ClockIcon } from '@heroicons/react/24/solid';
-import { useRef, useState, useEffect } from 'react';
 import ProgressBar from './ProgressBar';
 import { CourseStatus, RecentCourse, UserCourses, ViewType } from '@/common';
+import ClampedText from './ClampedText';
 
 // this might also want to live within courses, as the type of course it is (ie currently enrolled, completed, pending)
 // recent would probably be a boolean, which would only need to be accessed on the homepage
@@ -17,26 +17,6 @@ export default function EnrolledCourseCard({
     recent,
     view
 }: CourseCard) {
-    //need this for displaying when text is truncated otherwise it will always display a browser tooltip
-    const textReference = useRef<HTMLHeadingElement>(null);
-    const [isTruncated, setIsTruncated] = useState(false);
-    const checkTruncation = () => {
-        if (textReference.current) {
-            const isContentTruncated =
-                textReference.current.scrollHeight >
-                    textReference.current.offsetHeight ||
-                textReference.current.scrollWidth >
-                    textReference.current.offsetWidth;
-            setIsTruncated(isContentTruncated);
-        }
-    };
-    useEffect(() => {
-        checkTruncation();
-        window.addEventListener('resize', checkTruncation); //add resize listner to check for truncated text.
-        return () => {
-            window.removeEventListener('resize', checkTruncation);
-        };
-    }, [course.alt_name, course.course_name]);
     const coverImage = course.thumbnail_url;
     const url = course.external_url;
     let status: CourseStatus | null = null;
@@ -118,13 +98,9 @@ export default function EnrolledCourseCard({
                         )}
                     </figure>
                     <div className="card-body gap-0.5 relative min-h-[150px] pb-10">
-                        <h3
-                            ref={textReference}
-                            className="card-title text-sm line-clamp-2"
-                            title={isTruncated ? courseFullName : ''}
-                        >
+                        <ClampedText as="h3" lines={2} className="card-title text-sm">
                             {courseFullName}
-                        </h3>
+                        </ClampedText>
                         <p className="text-xs h-10 line-clamp-2">
                             {course.provider_platform_name}
                             {finalDateStr}

--- a/frontend/src/Components/EnrolledCourseCard.tsx
+++ b/frontend/src/Components/EnrolledCourseCard.tsx
@@ -98,7 +98,7 @@ export default function EnrolledCourseCard({
                         )}
                     </figure>
                     <div className="card-body gap-0.5 relative min-h-[150px] pb-10">
-                        <ClampedText as="h3" lines={2} className="card-title text-sm">
+                        <ClampedText as="h3" className="card-title text-sm">
                             {courseFullName}
                         </ClampedText>
                         <p className="text-xs h-10 line-clamp-2">

--- a/frontend/src/Components/EnrolledCourseCard.tsx
+++ b/frontend/src/Components/EnrolledCourseCard.tsx
@@ -105,7 +105,7 @@ export default function EnrolledCourseCard({
                             {course.provider_platform_name}
                             {finalDateStr}
                         </p>
-                        <div className="absolute bottom-2 left-4 right-4 z-10">
+                        <div className="absolute bottom-2 left-4 right-4">
                             {status == CourseStatus.Completed ? (
                                 <div className="flex flex-row gap-2 body-small text-teal-3">
                                     <CheckCircleIcon className="h-4" /> Course

--- a/frontend/src/Components/VideoCard.tsx
+++ b/frontend/src/Components/VideoCard.tsx
@@ -72,6 +72,10 @@ export default function VideoCard({
                     ? 'cursor-pointer'
                     : 'cursor-pointer border-3 border-red-500'
             }`}
+            onClick={() =>
+                videoIsAvailable(video) &&
+                navigate(`/viewer/videos/${video.id}`)
+            }
         >
             {!AdminRoles.includes(role) && (
                 <div
@@ -84,10 +88,6 @@ export default function VideoCard({
             )}
             <div
                 className="flex flex-col p-4 gap-2 border-b-2"
-                onClick={() =>
-                    videoIsAvailable(video) &&
-                    navigate(`/viewer/videos/${video.id}`)
-                }
             >
                 <figure className="w-1/2 mx-auto bg-cover">
                     <img


### PR DESCRIPTION
## Description of the change

- #673 
    - Modified CSS to fix the position of the progress bar at the bottom of card.
    - Added javascript and an html element to handle displaying the browser tooltip when course title is truncated
    - Modified javascript date formatter to display 2 digits for day rather than a numeric to align with MM/DD/YYYY format
- #679 
    - Moved onClick handler to parent div HTML element of the Video Card
- **Related issues**:  Closes #673, Closes #679.

## Screenshot(s)
![image](https://github.com/user-attachments/assets/db1cc80d-042e-4a72-ab55-59a8d1c317df)
![image](https://github.com/user-attachments/assets/67791f15-bc2e-42f3-b62f-9be7b336a116)
