### PR TITLE
fix: modify css and add conditional for left-aligning page titles with content on page per #663

### DIFF
--- a/frontend/src/Components/OperationalInsightsCharts.tsx
+++ b/frontend/src/Components/OperationalInsightsCharts.tsx
@@ -33,7 +33,7 @@ const OperationalInsights = () => {
         (metrics?.total_residents ?? 0) + (metrics?.total_admins ?? 0);
 
     return (
-        <div className="p-6 max-w-full overflow-x-hidden">
+        <div className="overflow-x-hidden">
             {error && <div>Error loading data</div>}
             {!data || (isLoading && <div>Loading...</div>)}
             {data && metrics && (

--- a/frontend/src/Components/PageNav.tsx
+++ b/frontend/src/Components/PageNav.tsx
@@ -53,8 +53,8 @@ export default function PageNav({
     };
 
     return (
-        <div className="px-6 py-3 flex justify-between items-center">
-            <div className="flex items-center gap-3">
+        <div className="px-2 py-3 flex justify-between items-center">
+            <div className={`flex items-center gap-3 ${showOpenMenu ? 'px-3' : ''}`}>
                 {showOpenMenu ? (
                     <ULIComponent
                         onClick={onShowNav}

--- a/frontend/src/Components/VideoEmbedViewer.tsx
+++ b/frontend/src/Components/VideoEmbedViewer.tsx
@@ -38,7 +38,7 @@ export default function VideoViewer() {
         setError('Video Currently Unavailable');
     };
     return (
-        <div className="px-8 pb-4">
+        <div className="px-5 pb-4">
             <div className="w-2/3 pt-4 justify-center">
                 {isLoading ? (
                     <div className="flex h-screen gap-4 justify-center content-center">

--- a/frontend/src/Pages/AdminLayer1.tsx
+++ b/frontend/src/Pages/AdminLayer1.tsx
@@ -33,7 +33,7 @@ export default function AdminLayer1() {
         console.log(timeFilter);
     }, [timeFilter]);
     return (
-        <div className="w-full flex flex-col gap-6 px-6 pb-4">
+        <div className="w-full flex flex-col gap-6 px-5 pb-4">
             <FeaturedContent featured={featured} />
             <div className="flex flex-row justify-between items-center">
                 <h2>Insights</h2>

--- a/frontend/src/Pages/AdminLayer2.tsx
+++ b/frontend/src/Pages/AdminLayer2.tsx
@@ -31,7 +31,7 @@ export default function AdminLayer2() {
         return <UnauthorizedNotFound which="unauthorized" />;
     }
     return (
-        <div className="p-8">
+        <div className="w-full flex flex-col gap-2 px-5 pb-4">
             {error && <div>Error loading data</div>}
             {!data || (isLoading && <div>Loading...</div>)}
             {data && layer2_metrics && (

--- a/frontend/src/Pages/AdminManagement.tsx
+++ b/frontend/src/Pages/AdminManagement.tsx
@@ -155,7 +155,7 @@ export default function AdminManagement() {
 
     return (
         <div>
-            <div className="flex flex-col space-y-6 overflow-x-auto rounded-lg p-4 px-8">
+            <div className="flex flex-col space-y-6 overflow-x-auto rounded-lg p-4 px-5">
                 <div className="flex justify-between">
                     <div className="flex flex-row gap-x-2">
                         <SearchBar

--- a/frontend/src/Pages/CourseCatalog.tsx
+++ b/frontend/src/Pages/CourseCatalog.tsx
@@ -29,7 +29,7 @@ export default function CourseCatalog() {
     }
 
     return (
-        <div className="px-8 py-4">
+        <div className="px-5 py-4">
             <div className="flex flex-row justify-end">
                 <ToggleView
                     activeView={activeView}

--- a/frontend/src/Pages/FacilityManagement.tsx
+++ b/frontend/src/Pages/FacilityManagement.tsx
@@ -109,7 +109,7 @@ export default function FacilityManagement() {
     };
     return (
         <>
-            <div className="px-8 py-4 flex flex-col justify-center gap-4">
+            <div className="px-5 py-4 flex flex-col justify-center gap-4">
                 <div className="flex flex-row justify-between">
                     <div>
                         {/* TO DO: this is where SEARCH and SORT will go */}

--- a/frontend/src/Pages/LibraryViewer.tsx
+++ b/frontend/src/Pages/LibraryViewer.tsx
@@ -50,7 +50,7 @@ export default function LibraryViewer() {
 
     return (
         <div>
-            <div className="px-8 pb-4">
+            <div className="px-5 pb-4">
                 <div className="w-full pt-4 justify-center">
                     {isLoading ? (
                         <div className="flex h-screen gap-4 justify-center content-center">

--- a/frontend/src/Pages/MyCourses.tsx
+++ b/frontend/src/Pages/MyCourses.tsx
@@ -54,7 +54,7 @@ export default function MyCourses() {
     };
 
     return (
-        <div className="px-8 py-4">
+        <div className="px-5 py-4">
             <TabView
                 tabs={tabs}
                 activeTab={activeTab}

--- a/frontend/src/Pages/MyProgress.tsx
+++ b/frontend/src/Pages/MyProgress.tsx
@@ -49,7 +49,7 @@ export default function MyProgress() {
     //}
 
     return (
-        <div className="px-8 py-4">
+        <div className="px-5">
             {!error && courseData && (
                 <>
                     <div className="grid grid-cols-3 gap-4 mt-6 mb-6">

--- a/frontend/src/Pages/OpenContent.tsx
+++ b/frontend/src/Pages/OpenContent.tsx
@@ -42,7 +42,7 @@ export default function OpenContent() {
     };
 
     return (
-        <div className="px-8 pb-4">
+        <div className="px-5 pb-4">
             <div className="flex flex-row justify-end">
                 {user && isAdministrator(user) && (
                     <button

--- a/frontend/src/Pages/OpenContentManagement.tsx
+++ b/frontend/src/Pages/OpenContentManagement.tsx
@@ -32,7 +32,7 @@ export default function OpenContentManagement() {
     }
 
     return (
-        <div className="px-8 pb-4">
+        <div className="px-5 pb-4">
             <div className="flex flex-row justify-end">
                 <button
                     className="button-outline"

--- a/frontend/src/Pages/OperationalInsights.tsx
+++ b/frontend/src/Pages/OperationalInsights.tsx
@@ -3,7 +3,7 @@ import OperationalInsights from '@/Components/OperationalInsightsCharts';
 export default function OperationalInsightsPage() {
     return (
         <div>
-            <div className="px-8 pb-4 mt-8">
+            <div className="w-full flex flex-col gap-6 px-5 pb-4">
                 <OperationalInsights />
             </div>
         </div>

--- a/frontend/src/Pages/Programs.tsx
+++ b/frontend/src/Pages/Programs.tsx
@@ -34,7 +34,7 @@ export default function Programs() {
     }
 
     return (
-        <div className="px-8 py-4">
+        <div className="px-5 py-4">
             <div className="flex flex-row justify-between items-center mb-4">
                 <div className="flex flex-row items-center space-x-4">
                     <SearchBar

--- a/frontend/src/Pages/ProviderPlatformManagement.tsx
+++ b/frontend/src/Pages/ProviderPlatformManagement.tsx
@@ -178,7 +178,7 @@ export default function ProviderPlatformManagement() {
 
     return (
         <div>
-            <div className="px-8 py-4">
+            <div className="px-5 py-4">
                 <div className="flex flex-row justify-between">
                     <div>
                         {/* TO DO: this is where SEARCH and SORT will go */}

--- a/frontend/src/Pages/StudentDashboard.tsx
+++ b/frontend/src/Pages/StudentDashboard.tsx
@@ -30,7 +30,7 @@ export default function StudentLayer2() {
     );
 
     return (
-        <div className="w-full flex flex-col gap-6 px-6 pb-4">
+        <div className="w-full flex flex-col gap-6 px-5 pb-4">
             <h1 className="text-5xl">Hi, {user.name_first ?? 'Student'}!</h1>
             <h2> Pick Up Where You Left Off</h2>
             <div className="card card-row-padding flex flex-col gap-3">

--- a/frontend/src/Pages/StudentLayer1.tsx
+++ b/frontend/src/Pages/StudentLayer1.tsx
@@ -47,7 +47,7 @@ export default function StudentLayer1() {
     return (
         <div className="flex flex-row h-full">
             {/* main section */}
-            <div className="w-full flex flex-col gap-6 px-6 pb-4">
+            <div className="w-full flex flex-col gap-6 px-5 pb-4">
                 <FeaturedContent
                     featured={featured?.data ?? []}
                     mutate={updateFavorites}

--- a/frontend/src/Pages/StudentManagement.tsx
+++ b/frontend/src/Pages/StudentManagement.tsx
@@ -133,7 +133,7 @@ export default function StudentManagement() {
     };
     return (
         <div>
-            <div className="flex flex-col space-y-6 overflow-x-auto rounded-lg p-4 px-8">
+            <div className="flex flex-col space-y-6 overflow-x-auto rounded-lg p-4 px-5">
                 <div className="flex justify-between">
                     <div className="flex flex-row gap-x-2">
                         <SearchBar


### PR DESCRIPTION
## Description of the change

Modified CSS padding styles on several pages for aligning Page titles with the content found on the pages. 

- **Related issues**: Closes #663.

## Screenshot(s)
![image](https://github.com/user-attachments/assets/501e1286-2eea-4b94-8040-786d28fc56e3)
![image](https://github.com/user-attachments/assets/39ec57c2-9933-4dae-ac22-e84c9f377417)