### PR TITLE
fix: modify logic to not hide favorited content items and rather disable them

### DIFF
--- a/backend/src/database/open_content.go
+++ b/backend/src/database/open_content.go
@@ -67,7 +67,6 @@ func (db *DB) GetUserFavoriteGroupings(userID uint) ([]models.OpenContentItem, e
 		JOIN libraries lib ON lib.open_content_provider_id = ocp.id 
 			AND lib.id = f.content_id
 		WHERE f.user_id = ?
-			AND f.content_id IN (SELECT id FROM libraries where visibility_status = true)
 	),
 	ordered_videos AS (
 		SELECT
@@ -90,7 +89,7 @@ func (db *DB) GetUserFavoriteGroupings(userID uint) ([]models.OpenContentItem, e
 		JOIN videos ON videos.open_content_provider_id = ocp.id
 			AND videos.id = f.content_id
 		WHERE f.user_id = ?
-			AND f.content_id IN (SELECT id FROM videos where visibility_status = true AND availability = 'available')
+			AND f.content_id IN (SELECT id FROM videos where availability = 'available')
 	),
 	ordered_helpful_links AS (
 		SELECT
@@ -113,7 +112,6 @@ func (db *DB) GetUserFavoriteGroupings(userID uint) ([]models.OpenContentItem, e
 		JOIN helpful_links hl ON hl.open_content_provider_id = ocp.id
 				AND hl.id = f.content_id
 		WHERE f.user_id = ?
-		AND f.content_id IN (SELECT id from helpful_links WHERE visibility_status = true)
 	)
 	SELECT 
 			content_type,
@@ -188,7 +186,7 @@ func (db *DB) GetUserFavorites(userID uint, page, perPage int) (int64, []models.
         JOIN libraries lib ON lib.open_content_provider_id = ocp.id 
             AND lib.id = f.content_id
         WHERE f.user_id = ?
-            AND f.content_id IN (SELECT id FROM libraries where visibility_status = true)
+
         UNION ALL
 
         SELECT
@@ -210,7 +208,7 @@ func (db *DB) GetUserFavorites(userID uint, page, perPage int) (int64, []models.
         JOIN videos ON videos.open_content_provider_id = ocp.id
             AND videos.id = f.content_id
         WHERE f.user_id = ?
-            AND f.content_id IN (SELECT id FROM videos where visibility_status = true AND availability = 'available')
+            AND f.content_id IN (SELECT id FROM videos where availability = 'available')
        UNION ALL
 
         SELECT
@@ -232,7 +230,6 @@ func (db *DB) GetUserFavorites(userID uint, page, perPage int) (int64, []models.
         JOIN helpful_links hl ON hl.open_content_provider_id = ocp.id
             AND hl.id = f.content_id
         WHERE f.user_id = ?
-          AND f.content_id IN (SELECT id from helpful_links WHERE visibility_status = true)
     ) AS all_favorites
     ORDER BY created_at DESC
     LIMIT ? OFFSET ?`

--- a/backend/src/models/open_content.go
+++ b/backend/src/models/open_content.go
@@ -55,7 +55,7 @@ type OpenContentItem struct {
 	Url                   string `json:"url"`
 	ThumbnailUrl          string `json:"thumbnail_url"`
 	Description           string `json:"description,omitempty"`
-	VisibilityStatus      bool   `json:"visibility_status,omitempty"`
+	VisibilityStatus      *bool  `json:"visibility_status"`
 	OpenContentProviderId uint   `json:"open_content_provider_id"`
 	ContentId             uint   `json:"content_id"`
 	ContentType           string `json:"content_type"`

--- a/frontend/src/Components/FavoriteCard.tsx
+++ b/frontend/src/Components/FavoriteCard.tsx
@@ -57,7 +57,7 @@ const FavoriteCard: React.FC<FavoriteCardProps> = ({
                     : 'bg-grey-2 cursor-not-allowed'
             } tooltip `}
             {...(!favorite.visibility_status && {
-                'data-tip': 'Unavailable Content'
+                'data-tip': 'This content is no longer accessible'
             })}
             onClick={favorite.visibility_status ? handleCardClick : undefined}
         >

--- a/frontend/src/Components/OpenContentItemAccordion.tsx
+++ b/frontend/src/Components/OpenContentItemAccordion.tsx
@@ -74,8 +74,8 @@ export default function OpenContentItemAccordion({
                         </span>
                     </button>
                     <div
-                        className={`overflow-hidden transition-[max-height] duration-700 ${
-                            activeKey === title ? 'max-h-[800px]' : 'max-h-0'
+                        className={`transition-[max-height] duration-400 ${
+                            activeKey === title ? 'overflow-visible max-h-[800px]' : 'max-h-0 overflow-hidden'
                         }`}
                     >
                         <div className="flex flex-col gap-4">

--- a/frontend/src/Components/cards/OpenContentCard.tsx
+++ b/frontend/src/Components/cards/OpenContentCard.tsx
@@ -8,16 +8,19 @@ export default function OpenContentCardRow({
 }) {
     const navigate = useNavigate();
     function redirectToViewer() {
+        if (content.visibility_status != null && !content.visibility_status) return;
         const basePath =
             content.content_type === 'video'
                 ? `/viewer/videos/${content.content_id}`
                 : `/viewer/libraries/${content.content_id}`;
         navigate(basePath);
     }
-
     return (
         <div
-            className="card cursor-pointer flex flex-row w-full gap-3 px-4 py-2"
+            className={`card ${content.visibility_status == null || content.visibility_status ? 'cursor-pointer' : 'bg-grey-2 cursor-not-allowed'} flex flex-row w-full gap-3 px-4 py-2 tooltip`}
+            {...((content.visibility_status != null && !content.visibility_status) && {
+                'data-tip': 'This content is no longer accessible'
+            })}
             onClick={redirectToViewer}
         >
             <div className="w-[100px]">


### PR DESCRIPTION
## Description of the change

Modified the associated SQL queries to not filter out favorites associated to hidden libraries. Also added CSS to disable the content card from being clickable and added tooltip text per request.

- **Related issues**: Closes #672 .

## Screenshot(s)
![image](https://github.com/user-attachments/assets/c487b918-d5bd-4803-952d-7ccedd9c8db9)
![image](https://github.com/user-attachments/assets/3e4c739f-b195-4205-98a8-6b429d2db15f)
