### PR TITLE
Fixes for admin and resident side nav, helpful link card consistency, and unfavoriting a helpful link per issues #658, #678, and #692

### DIFF
--- a/backend/src/database/helpful_links.go
+++ b/backend/src/database/helpful_links.go
@@ -16,7 +16,8 @@ func (db *DB) GetHelpfulLinks(page, perPage int, search, orderBy string, onlyVis
 
 	subQuery := db.Table("open_content_favorites f").
 		Select("1").
-		Where("f.content_id = helpful_links.id AND f.user_id = ?", userID)
+		Where(`f.content_id = helpful_links.id AND f.user_id = ?
+			AND f.open_content_provider_id = helpful_links.open_content_provider_id`, userID)
 	tx := db.Model(&models.HelpfulLink{}).Select("helpful_links.*, EXISTS(?) as is_favorited", subQuery)
 	var total int64
 

--- a/frontend/src/Components/Navbar.tsx
+++ b/frontend/src/Components/Navbar.tsx
@@ -16,15 +16,11 @@ import {
     RssIcon,
     RectangleStackIcon,
     CogIcon,
-    LightBulbIcon
+    LightBulbIcon,
+    RocketLaunchIcon,
+    ArrowTrendingUpIcon
 } from '@heroicons/react/24/solid';
-import {
-    getDashboardLink,
-    handleLogout,
-    hasFeature,
-    isAdministrator,
-    useAuth
-} from '@/useAuth';
+import { handleLogout, hasFeature, isAdministrator, useAuth } from '@/useAuth';
 import Modal from '@/Components/Modal';
 import ULIComponent from './ULIComponent';
 import { Link } from 'react-router-dom';
@@ -51,12 +47,6 @@ export default function Navbar({
     const { toaster } = useToast();
     const confirmSeedModal = useRef<HTMLDialogElement | null>(null);
     const [seedInProgress, setSeedInProgress] = useState<boolean>(false);
-
-    const dashboardTitleStudent = new Map([
-        ['/trending-content', 'Trending Content'],
-        ['/learning-path', 'Learning Path'],
-        ['/program-tracker', 'Program Tracker']
-    ]);
 
     const handleSeedDemoData = async () => {
         setSeedInProgress(true);
@@ -134,18 +124,29 @@ export default function Navbar({
                                     Operational Insights
                                 </Link>
                             </li>
+                            {hasFeature(
+                                user,
+                                FeatureAccess.OpenContentAccess
+                            ) && (
+                                <li>
+                                    <Link to="/knowledge-center-management/libraries">
+                                        <ULIComponent icon={BookOpenIcon} />
+                                        Knowledge Center
+                                    </Link>
+                                </li>
+                            )}
                             {hasFeature(user, FeatureAccess.ProviderAccess) && (
                                 <>
-                                    <li>
-                                        <Link to="/course-catalog-admin">
-                                            <ULIComponent icon={CloudIcon} />
-                                            Course Catalog
-                                        </Link>
-                                    </li>
                                     <li>
                                         <Link to="/learning-platforms">
                                             <ULIComponent icon={CloudIcon} />
                                             Learning Platforms
+                                        </Link>
+                                    </li>
+                                    <li>
+                                        <Link to="/course-catalog-admin">
+                                            <ULIComponent icon={CloudIcon} />
+                                            Course Catalog
                                         </Link>
                                     </li>
                                 </>
@@ -155,17 +156,6 @@ export default function Navbar({
                                     <Link to="/programs">
                                         <ULIComponent icon={DocumentTextIcon} />
                                         Programs
-                                    </Link>
-                                </li>
-                            )}
-                            {hasFeature(
-                                user,
-                                FeatureAccess.OpenContentAccess
-                            ) && (
-                                <li>
-                                    <Link to="/knowledge-center-management/libraries">
-                                        <ULIComponent icon={BookOpenIcon} />
-                                        Knowledge Center
                                     </Link>
                                 </li>
                             )}
@@ -192,25 +182,54 @@ export default function Navbar({
                         </>
                     ) : (
                         <>
-                            <li>
-                                <Link to={getDashboardLink(user)}>
-                                    <ULIComponent icon={HomeIcon} />
-                                    {dashboardTitleStudent.get(
-                                        getDashboardLink(user)
-                                    ) ?? 'Home'}
-                                </Link>
-                            </li>
-                            {hasFeature(user, FeatureAccess.ProviderAccess) && (
-                                <>
-                                    {getDashboardLink(user) !==
-                                        '/learning-path' && (
+                            {!hasFeature(
+                                user,
+                                FeatureAccess.OpenContentAccess
+                            ) &&
+                                !hasFeature(
+                                    user,
+                                    FeatureAccess.ProviderAccess
+                                ) &&
+                                !hasFeature(
+                                    user,
+                                    FeatureAccess.ProgramAccess
+                                ) && (
+                                    <>
                                         <li>
-                                            <Link to="/learning-path">
+                                            <Link to="/home">
                                                 <ULIComponent icon={HomeIcon} />
-                                                My Learning
+                                                Home
                                             </Link>
                                         </li>
-                                    )}
+                                    </>
+                                )}
+                            {hasFeature(
+                                user,
+                                FeatureAccess.OpenContentAccess
+                            ) && (
+                                <>
+                                    <li>
+                                        <Link to="/trending-content">
+                                            <ULIComponent icon={ArrowTrendingUpIcon} />
+                                            Trending Content
+                                        </Link>
+                                    </li>
+                                    <li>
+                                        <Link to="/knowledge-center/libraries">
+                                            <ULIComponent icon={BookOpenIcon} />
+                                            Knowledge Center
+                                        </Link>
+                                    </li>
+                                </>
+                            )}
+                            {hasFeature(user, FeatureAccess.ProviderAccess) && (
+                                <>
+                                    <li>
+                                        <Link to="/learning-path">
+                                            <ULIComponent icon={RocketLaunchIcon} />
+                                            Learning Path
+                                        </Link>
+                                    </li>
                                     <li>
                                         <Link to="/my-courses">
                                             <ULIComponent
@@ -225,29 +244,6 @@ export default function Navbar({
                                                 icon={AcademicCapIcon}
                                             />
                                             My Progress
-                                        </Link>
-                                    </li>
-                                </>
-                            )}
-                            {hasFeature(
-                                user,
-                                FeatureAccess.OpenContentAccess
-                            ) && (
-                                <>
-                                    {user.feature_access.length > 1 && (
-                                        <li>
-                                            <Link to="/trending-content">
-                                                <ULIComponent
-                                                    icon={BookOpenIcon}
-                                                />
-                                                Trending Content
-                                            </Link>
-                                        </li>
-                                    )}
-                                    <li>
-                                        <Link to="/knowledge-center/libraries">
-                                            <ULIComponent icon={BookOpenIcon} />
-                                            Knowledge Center
                                         </Link>
                                     </li>
                                 </>

--- a/frontend/src/Components/cards/HelpfulLinkCard.tsx
+++ b/frontend/src/Components/cards/HelpfulLinkCard.tsx
@@ -73,11 +73,17 @@ export default function HelpfulLinkCard({
 
     return (
         <div
-            className="card p-4 space-y-2 relative"
+            className="card cursor-pointer"
             onClick={() => {
                 void handleHelpfulLinkClick(link.id);
             }}
         >
+            <div className="flex p-4 gap-2 border-b-2">
+                <figure className="w-[48px] h-[48px] bg-cover">
+                    <img src={link.thumbnail_url ?? ''} alt={link.title} />
+                </figure>
+                <h3 className="w-3/4 body my-auto mr-7">{link.title}</h3>
+            </div>
             {AdminRoles.includes(role) ? (
                 showModal != undefined && (
                     <div className="flex flex-row gap-2 absolute top-4 right-4 z-100">
@@ -98,28 +104,31 @@ export default function HelpfulLinkCard({
                     </div>
                 )
             ) : (
-                <ULIComponent
-                    iconClassName={`absolute right-1 w-6 h-6 cursor-pointer ${link.is_favorited ? 'text-primary-yellow' : ''}`}
-                    icon={link.is_favorited ? StarIcon : StarIconOutline}
-                    onClick={(e) => {
-                        if (e) void handleToggleAction('favorite', e);
-                    }}
-                />
+                <div
+                    className="absolute right-2 top-2 z-100"
+                    onClick={(e) => void handleToggleAction('favorite', e)}
+                >
+                    <ULIComponent
+                        tooltipClassName="absolute right-2 top-2 z-100"
+                        iconClassName={`w-6 h-6 cursor-pointer ${link.is_favorited ? 'text-primary-yellow' : ''}`}
+                        icon={link.is_favorited ? StarIcon : StarIconOutline}
+                        dataTip="Favorite Helpful Link"
+                    />
+                </div>
             )}
-            <img
-                src={link.thumbnail_url}
-                alt={link.title}
-                className="h-16 mx-auto object-contain"
-            />
-            <h3 className="body">{link.title}</h3>
-            <p className="body line-clamp-2 h-10">{link.description}</p>
-
-            {AdminRoles.includes(role) && (
-                <VisibleHiddenToggle
-                    visible={visible}
-                    changeVisibility={() => void handleToggleAction('toggle')}
-                />
-            )}
+            <div className="p-4 space-y-2">
+                <p className="body-small h-[40px] leading-5 line-clamp-2">
+                    {link.description}
+                </p>
+                {AdminRoles.includes(role) && (
+                    <VisibleHiddenToggle
+                        visible={visible}
+                        changeVisibility={() =>
+                            void handleToggleAction('toggle')
+                        }
+                    />
+                )}
+            </div>
         </div>
     );
 }

--- a/frontend/src/Pages/HelpfulLinks.tsx
+++ b/frontend/src/Pages/HelpfulLinks.tsx
@@ -5,41 +5,68 @@ import {
     UserRole
 } from '@/common';
 import HelpfulLinkCard from '@/Components/cards/HelpfulLinkCard';
+import Pagination from '@/Components/Pagination';
 import { AxiosError } from 'axios';
+import { useState } from 'react';
 import useSWR from 'swr';
 
 export default function HelpfulLinks() {
+    const [perPage, setPerPage] = useState(20);
+    const [pageQuery, setPageQuery] = useState<number>(1);
     const {
         data: helpfulLinks,
         mutate: mutateHelpfulFavs,
         isLoading,
         error
     } = useSWR<ServerResponseOne<HelpfulLinkAndSort>, AxiosError>(
-        `/api/helpful-links`
+        `/api/helpful-links?page=${pageQuery}&per_page=${perPage}`
     );
     function updateFavorites() {
         void mutateHelpfulFavs();
     }
+    const handleSetPerPage = (perPage: number) => {
+        setPerPage(perPage);
+        setPageQuery(1);
+        updateFavorites();
+    };
+    const helpfulLinksMeta = helpfulLinks?.data?.meta ?? {
+        total: 0,
+        per_page: 20,
+        page: 1,
+        current_page: 1,
+        last_page: 1
+    };
     return (
-        <div className="grid grid-cols-4 gap-6">
-            {helpfulLinks?.data?.helpful_links.map((link: HelpfulLink) => (
-                <HelpfulLinkCard
-                    key={link.id}
-                    link={link}
-                    mutate={updateFavorites}
-                    role={UserRole.Student}
-                />
-            ))}
-            {error && (
-                <span className="text-error">
-                    Failed to load helpful links.
-                </span>
-            )}
-            {!isLoading &&
-                !error &&
-                helpfulLinks?.data.helpful_links.length === 0 && (
-                    <span className="text-error">No results</span>
+        <>
+            <div className="grid grid-cols-4 gap-6">
+                {helpfulLinks?.data?.helpful_links.map((link: HelpfulLink) => (
+                    <HelpfulLinkCard
+                        key={link.id}
+                        link={link}
+                        mutate={updateFavorites}
+                        role={UserRole.Student}
+                    />
+                ))}
+                {error && (
+                    <span className="text-error">
+                        Failed to load helpful links.
+                    </span>
                 )}
-        </div>
+                {!isLoading &&
+                    !error &&
+                    helpfulLinks?.data.helpful_links.length === 0 && (
+                        <span className="text-error">No results</span>
+                    )}
+            </div>
+            {!isLoading && !error && helpfulLinksMeta && (
+                <div className="flex justify-center">
+                    <Pagination
+                        meta={helpfulLinksMeta}
+                        setPage={setPageQuery}
+                        setPerPage={handleSetPerPage}
+                    />
+                </div>
+            )}
+        </>
     );
 }

--- a/frontend/src/useAuth.ts
+++ b/frontend/src/useAuth.ts
@@ -153,30 +153,11 @@ export async function handleLogout(): Promise<void> {
     }
 }
 
-const accessValues = new Map<FeatureAccess, number>([
-    [FeatureAccess.OpenContentAccess, 1],
-    [FeatureAccess.ProviderAccess, 2],
-    [FeatureAccess.ProgramAccess, 3]
-]);
-
-export const studentAccessLinks = [
-    '/home', // temporary layer 0 until implemented
-    '/trending-content',
-    '/learning-path', // temporary until layer 3 is implemented
-    '/learning-path' // temporary until layer 3 is implemented
-];
-
 export const getDashboardLink = (user?: User) => {
     if (!user) return '/';
-
-    const maxFeature =
-        user?.feature_access
-            .map((ax) => accessValues.get(ax) ?? 0)
-            .sort((a, b) => a - b)
-            .pop() ?? 0;
     return isAdministrator(user)
         ? getAdminLink(user)
-        : studentAccessLinks[maxFeature];
+        : getResidentLink(user);
 };
 
 const getAdminLink = (user: User): string => {
@@ -187,4 +168,14 @@ const getAdminLink = (user: User): string => {
         return "/learning-insights";
     }
     return "/operational-insights";
+};
+
+const getResidentLink = (user: User): string => {
+    if (user.feature_access.includes(FeatureAccess.OpenContentAccess)) {
+        return "/trending-content";
+    }
+    if (user.feature_access.includes(FeatureAccess.ProviderAccess)) {
+        return "/learning-path";
+    }
+    return "/home";
 };


### PR DESCRIPTION
## Description of the change

NOTE: In screenshot below for ticket #658, I highlighted an icon, confirming if this icon is correct for 'Trending Content'?)

- #658 
    - Modified/Removed Javascript associated with layering changes
    - Modified/Moved around HTML elements.
- #678 
    - Modified CSS on the helpful link card to be consistent with how the LibraryCard is styled. (Clickable Cursor Icon, Bottom Border Below Title, Horizontal Alignment of Image and Title). Also, #682 is related to this modification
    - Added tooltip to favorite icon
    - Added missing pager component to the Helpful links page
- #692 
    - Added criteria to the SQL scalar query to join on open_content_provider_id between the tables open_content_favorites and helpful_links. 
- #667 
    - Changed icons for Trending Content and Learning Path on the nav bar

- **Related issues**:  closes #658, closes #667, closes #678, closes #682, closes #692.

## Screenshot(s)
#658 Admin
![image](https://github.com/user-attachments/assets/c5248803-d36d-4a1e-85d6-09346513e78f)
![image](https://github.com/user-attachments/assets/7c72a74e-fd3e-43a5-b90a-2763cdb4fe19)
![image](https://github.com/user-attachments/assets/e02b230e-c168-4a0f-9e0a-3d5b54f0f82e)

#658 Student (**note the highlighted icon**---should this icon be different?)
![image](https://github.com/user-attachments/assets/8eb5c734-0f82-40e7-8c92-ab107471ee3a)
![image](https://github.com/user-attachments/assets/1db8ca12-992f-40bb-9f1b-e6a056f529c9)
![image](https://github.com/user-attachments/assets/50db528b-dd37-46de-9a25-3da95756f55a)

#678 
![image](https://github.com/user-attachments/assets/7dfc350d-540e-4e51-9f8a-e8549a59a438)

#692 
![image](https://github.com/user-attachments/assets/6577c2a0-19fe-4a4b-866e-3237af7f4728)

#667 
![image](https://github.com/user-attachments/assets/998e6cd5-f81a-479b-8794-cba66339888a)

