### PR TITLE
fix: add NATS cache to AdminLayer2

### DIFF
--- a/backend/src/handlers/dashboard.go
+++ b/backend/src/handlers/dashboard.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/nats-io/nats.go"
 )
@@ -23,97 +24,39 @@ func (srv *Server) registerDashboardRoutes() []routeDef {
 }
 
 func (srv *Server) handleAdminLayer2(w http.ResponseWriter, r *http.Request, log sLog) error {
-	facility := r.URL.Query().Get("facility")
 	claims := r.Context().Value(ClaimsKey).(*Claims)
-	var facilityId *uint
 	clearCache := r.URL.Query().Get("reset") == "true"
-	switch facility {
-	case "all":
-		facilityId = nil
-	case "":
-		facilityId = &claims.FacilityID
-	default:
-		facilityIdInt, err := strconv.Atoi(facility)
-		if err != nil {
-			return newInvalidIdServiceError(err, "facility")
+	if !srv.isTesting(r) {
+		key := fmt.Sprintf("admin-layer2-%d", claims.FacilityID)
+		cached, err := srv.buckets[AdminLayer2].Get(key)
+		if err != nil && errors.Is(err, nats.ErrKeyNotFound) || clearCache {
+			newCacheData, err := srv.getLayer2Data(r, log)
+			if err != nil {
+				return newInternalServerServiceError(err, "Error getting admin layer 2 data")
+			}
+			cacheBytes, err := json.Marshal(newCacheData)
+			if err != nil {
+				return newMarshallingBodyServiceError(err)
+			}
+			_, err = srv.buckets[AdminLayer2].Put(key, cacheBytes)
+			if err != nil {
+				return newInternalServerServiceError(err, "Error caching admin layer 2 data")
+			}
+			return writeJsonResponse(w, http.StatusOK, newCacheData)
 		}
-		ref := uint(facilityIdInt)
-		facilityId = &ref
+		var cachedData models.CachedDashboard[models.AdminLayer2Join]
+		err = json.Unmarshal(cached.Value(), &cachedData)
+		if err != nil {
+			return newInternalServerServiceError(err, "Error unmarshalling cached data")
+		}
+		return writeJsonResponse(w, http.StatusOK, cachedData)
+	} else {
+		newCacheData, err := srv.getLayer2Data(r, log)
+		if err != nil {
+			return newInternalServerServiceError(err, "Error retrieving admin layer 2 data")
+		}
+		return writeJsonResponse(w, http.StatusOK, newCacheData)
 	}
-
-	if srv.isTesting(r) {
-		totalCourses, err := srv.Db.GetTotalCoursesOffered(facilityId)
-		if err != nil {
-			return newDatabaseServiceError(err)
-		}
-		totalStudents, err := srv.Db.GetTotalStudentsEnrolled(facilityId)
-		if err != nil {
-			return newDatabaseServiceError(err)
-		}
-		totalActivity, err := srv.Db.GetTotalHourlyActivity(facilityId)
-		if err != nil {
-			return newDatabaseServiceError(err)
-		}
-		learningInsights, err := srv.Db.GetLearningInsights(facilityId)
-		if err != nil {
-			return newDatabaseServiceError(err)
-		}
-
-		adminDashboard := models.AdminLayer2Join{
-			TotalCoursesOffered:   int64(totalCourses),
-			TotalStudentsEnrolled: int64(totalStudents),
-			TotalHourlyActivity:   int64(totalActivity),
-			LearningInsights:      learningInsights,
-		}
-
-		return writeJsonResponse(w, http.StatusOK, adminDashboard)
-	}
-
-	key := fmt.Sprintf("admin-layer2-%d", claims.FacilityID)
-	cached, err := srv.buckets[AdminLayer2].Get(key)
-	if err != nil && errors.Is(err, nats.ErrKeyNotFound) || clearCache {
-		totalCourses, err := srv.Db.GetTotalCoursesOffered(facilityId)
-		if err != nil {
-			log.add("facilityId", claims.FacilityID)
-			return newDatabaseServiceError(err)
-		}
-
-		totalStudents, err := srv.Db.GetTotalStudentsEnrolled(facilityId)
-		if err != nil {
-			log.add("facilityId", claims.FacilityID)
-			return newDatabaseServiceError(err)
-		}
-
-		totalActivity, err := srv.Db.GetTotalHourlyActivity(facilityId)
-		if err != nil {
-			log.add("facilityId", claims.FacilityID)
-			return newDatabaseServiceError(err)
-		}
-
-		learningInsights, err := srv.Db.GetLearningInsights(facilityId)
-		if err != nil {
-			log.add("facilityId", claims.FacilityID)
-			return newDatabaseServiceError(err)
-		}
-
-		adminDashboard := models.AdminLayer2Join{
-			TotalCoursesOffered:   int64(totalCourses),
-			TotalStudentsEnrolled: int64(totalStudents),
-			TotalHourlyActivity:   int64(totalActivity),
-			LearningInsights:      learningInsights,
-		}
-		jsonB, err := json.Marshal(models.DefaultResource(adminDashboard))
-		if err != nil {
-			return newMarshallingBodyServiceError(err)
-		}
-		_, err = w.Write(jsonB)
-		return err
-
-	} else if err != nil {
-		return newInternalServerServiceError(err, "Error retrieving admin layer2")
-	}
-	_, err = w.Write(cached.Value())
-	return err
 }
 
 func (srv *Server) handleLoginMetrics(w http.ResponseWriter, r *http.Request, log sLog) error {
@@ -205,21 +148,32 @@ func (srv *Server) handleLoginMetrics(w http.ResponseWriter, r *http.Request, lo
 			NewAdminsAdded:    newAdminsAdded,
 			PeakLoginTimes:    loginTimes,
 		}
-		jsonB, err := json.Marshal(models.DefaultResource(activityMetrics))
+		var cachedData models.CachedDashboard[interface{}]
+		cachedData.LastCache = time.Now()
+		cachedData.Data = activityMetrics
+
+		cacheBytes, err := json.Marshal(cachedData)
 		if err != nil {
 			return newMarshallingBodyServiceError(err)
 		}
-		_, err = srv.buckets[LoginMetrics].Put(key, jsonB)
+		_, err = srv.buckets[LoginMetrics].Put(key, cacheBytes)
 		if err != nil {
 			return newInternalServerServiceError(err, "Error caching login metrics")
 		}
-		_, err = w.Write(jsonB)
-		return err
+		return writeJsonResponse(w, http.StatusOK, cachedData)
 	} else if err != nil {
 		return newInternalServerServiceError(err, "Error retrieving login metrics")
 	}
-	_, err = w.Write(cached.Value())
-	return err
+	var cachedData models.CachedDashboard[interface{}]
+	err = json.Unmarshal(cached.Value(), &cachedData)
+	if err != nil {
+		return newInternalServerServiceError(err, "Error unmarshalling cached data")
+	}
+
+	return writeJsonResponse(w, http.StatusOK, cachedData)
+
+	// _, err = w.Write(cached.Value())
+	// return err
 }
 
 /**
@@ -272,4 +226,57 @@ func (srv *Server) handleUserCourses(w http.ResponseWriter, r *http.Request, log
 		return newDatabaseServiceError(err)
 	}
 	return writeJsonResponse(w, http.StatusOK, userCourses)
+}
+
+func (srv *Server) getLayer2Data(r *http.Request, log sLog) (models.CachedDashboard[models.AdminLayer2Join], error) {
+	facility := r.URL.Query().Get("facility")
+	claims := r.Context().Value(ClaimsKey).(*Claims)
+	var facilityId *uint
+	switch facility {
+	case "all":
+		facilityId = nil
+	case "":
+		facilityId = &claims.FacilityID
+	default:
+		facilityIdInt, err := strconv.Atoi(facility)
+		if err != nil {
+			return models.CachedDashboard[models.AdminLayer2Join]{}, newInvalidIdServiceError(err, "facility")
+		}
+		ref := uint(facilityIdInt)
+		facilityId = &ref
+	}
+	totalCourses, err := srv.Db.GetTotalCoursesOffered(facilityId)
+	if err != nil {
+		log.add("facilityId", claims.FacilityID)
+		return models.CachedDashboard[models.AdminLayer2Join]{}, newDatabaseServiceError(err)
+	}
+
+	totalStudents, err := srv.Db.GetTotalStudentsEnrolled(facilityId)
+	if err != nil {
+		log.add("facilityId", claims.FacilityID)
+		return models.CachedDashboard[models.AdminLayer2Join]{}, newDatabaseServiceError(err)
+	}
+
+	totalActivity, err := srv.Db.GetTotalHourlyActivity(facilityId)
+	if err != nil {
+		log.add("facilityId", claims.FacilityID)
+		return models.CachedDashboard[models.AdminLayer2Join]{}, newDatabaseServiceError(err)
+	}
+
+	learningInsights, err := srv.Db.GetLearningInsights(facilityId)
+	if err != nil {
+		log.add("facilityId", claims.FacilityID)
+		return models.CachedDashboard[models.AdminLayer2Join]{}, newDatabaseServiceError(err)
+	}
+
+	adminDashboard := models.AdminLayer2Join{
+		TotalCoursesOffered:   int64(totalCourses),
+		TotalStudentsEnrolled: int64(totalStudents),
+		TotalHourlyActivity:   int64(totalActivity),
+		LearningInsights:      learningInsights,
+	}
+	var cachedData models.CachedDashboard[models.AdminLayer2Join]
+	cachedData.LastCache = time.Now()
+	cachedData.Data = adminDashboard
+	return cachedData, nil
 }

--- a/backend/src/handlers/dashboard_test.go
+++ b/backend/src/handlers/dashboard_test.go
@@ -15,11 +15,11 @@ import (
 func TestHandleAdminLayer2(t *testing.T) {
 	httpTests := []httpTest{
 		{"TestAdminDashboardAsAdmin", "admin", map[string]any{"id": "1"}, http.StatusOK, ""},
-		{"TestAdminDashboardAsUser", "student", map[string]any{"id": "4"}, http.StatusUnauthorized, ""},
+		{"TestAdminDashboardAsUser", "student", map[string]any{"id": "1"}, http.StatusUnauthorized, ""},
 	}
 	for _, test := range httpTests {
 		t.Run(test.testName, func(t *testing.T) {
-			req, err := http.NewRequest(http.MethodGet, "/api/users/{id}/admin-layer2", nil)
+			req, err := http.NewRequest(http.MethodGet, "/api/users/{id}/admin-layer2?facility=1&reset=true", nil)
 			if err != nil {
 				t.Fatalf("unable to create new request, error is %v", err)
 			}
@@ -28,7 +28,6 @@ func TestHandleAdminLayer2(t *testing.T) {
 			rr := executeRequest(t, req, handler, test)
 			id, _ := strconv.Atoi(test.mapKeyValues["id"].(string))
 			if test.expectedStatusCode == http.StatusOK {
-
 				id := uint(id)
 				totalCourses, err := server.Db.GetTotalCoursesOffered(&id)
 				if err != nil {

--- a/backend/src/handlers/dashboard_test.go
+++ b/backend/src/handlers/dashboard_test.go
@@ -53,11 +53,11 @@ func TestHandleAdminLayer2(t *testing.T) {
 				}
 
 				received := rr.Body.String()
-				resource := models.Resource[models.AdminLayer2Join]{}
+				resource := models.Resource[models.CachedDashboard[models.AdminLayer2Join]]{}
 				if err := json.Unmarshal([]byte(received), &resource); err != nil {
 					t.Errorf("failed to unmarshal resource, error is %v", err)
 				}
-				if diff := cmp.Diff(&adminDashboard, &resource.Data); diff != "" {
+				if diff := cmp.Diff(&adminDashboard, &resource.Data.Data); diff != "" {
 					t.Errorf("handler returned unexpected response body: %v", diff)
 				}
 			}

--- a/backend/src/handlers/server.go
+++ b/backend/src/handlers/server.go
@@ -213,6 +213,7 @@ const (
 	LibraryPaths string = "library_paths"
 	OAuthState   string = "oauth_state"
 	LoginMetrics string = "login_metrics"
+	AdminLayer2  string = "admin_layer_2"
 )
 
 func (srv *Server) setupNatsKvBuckets() error {
@@ -222,7 +223,7 @@ func (srv *Server) setupNatsKvBuckets() error {
 		return err
 	}
 	buckets := map[string]nats.KeyValue{}
-	for _, bucket := range []string{CachedUsers, LibraryPaths, LoginMetrics, OAuthState} {
+	for _, bucket := range []string{CachedUsers, LibraryPaths, LoginMetrics, OAuthState, AdminLayer2} {
 		kv, err := js.KeyValue(bucket)
 		if err != nil {
 			cfg := &nats.KeyValueConfig{
@@ -236,6 +237,8 @@ func (srv *Server) setupNatsKvBuckets() error {
 				cfg.TTL = time.Hour * 24
 			case OAuthState:
 				cfg.TTL = time.Minute * 10
+			case AdminLayer2:
+				cfg.TTL = time.Hour * 24
 			}
 			kv, err = js.CreateKeyValue(cfg)
 			if err != nil {

--- a/backend/src/handlers/server.go
+++ b/backend/src/handlers/server.go
@@ -233,11 +233,9 @@ func (srv *Server) setupNatsKvBuckets() error {
 			switch bucket {
 			case CachedUsers:
 				cfg.TTL = time.Hour * 1
-			case LoginMetrics:
-				cfg.TTL = time.Hour * 24
 			case OAuthState:
 				cfg.TTL = time.Minute * 10
-			case AdminLayer2:
+			default:
 				cfg.TTL = time.Hour * 24
 			}
 			kv, err = js.CreateKeyValue(cfg)

--- a/backend/src/models/course.go
+++ b/backend/src/models/course.go
@@ -67,3 +67,8 @@ type AdminLayer2Join struct {
 	TotalHourlyActivity   int64             `json:"total_hourly_activity"`
 	LearningInsights      []LearningInsight `json:"learning_insights"`
 }
+
+type AdminLayer2Response struct {
+	Data      AdminLayer2Join `json:"data"`
+	LastCache time.Time       `json:"last_cache"`
+}

--- a/backend/src/models/dashboard.go
+++ b/backend/src/models/dashboard.go
@@ -1,6 +1,8 @@
 package models
 
 import (
+	"time"
+
 	"gorm.io/gorm"
 )
 
@@ -41,4 +43,9 @@ type ProgramFavorite struct {
 
 func (ProgramFavorite) TableName() string {
 	return "program_favorites"
+}
+
+type CachedDashboard[T any] struct {
+	LastCache time.Time `json:"last_cache"`
+	Data      T         `json:"data"`
 }

--- a/frontend/src/Components/OperationalInsightsCharts.tsx
+++ b/frontend/src/Components/OperationalInsightsCharts.tsx
@@ -27,11 +27,12 @@ const OperationalInsights = () => {
     const facilities = facilitiesData?.data;
 
     const metrics = data?.data;
-    console.log('Here is the metrics: ', metrics);
+    const formattedDate =
+        metrics && new Date(metrics.last_cache).toLocaleString('en-US', {});
 
     const totalUsers =
-        (metrics?.total_residents ?? 0) + (metrics?.total_admins ?? 0);
-
+        (metrics?.data.total_residents ?? 0) +
+        (metrics?.data.total_admins ?? 0);
     return (
         <div className="overflow-x-hidden">
             {error && <div>Error loading data</div>}
@@ -85,12 +86,17 @@ const OperationalInsights = () => {
                                 </select>
                             </div>
                         </div>
-                        <button
-                            className="button "
-                            onClick={() => setResetCache(!resetCache)}
-                        >
-                            Refresh Data
-                        </button>
+                        <div>
+                            <p className="label label-text text-grey-3">
+                                Last updated: {formattedDate}
+                            </p>
+                            <button
+                                className="button justify-self-end"
+                                onClick={() => setResetCache(!resetCache)}
+                            >
+                                Refresh Data
+                            </button>
+                        </div>
                     </div>
 
                     <div className="grid grid-cols-3 gap-4 mb-6">
@@ -102,9 +108,9 @@ const OperationalInsights = () => {
                         />
                         <StatsCard
                             title="Active Users"
-                            number={metrics.active_users.toString()}
+                            number={metrics.data.active_users.toString()}
                             label={`${(
-                                (metrics.active_users / totalUsers) *
+                                (metrics.data.active_users / totalUsers) *
                                 100
                             ).toFixed(2)}% of total`}
                             tooltip={`Number of users who have logged in in the last ${days} days`}
@@ -112,10 +118,10 @@ const OperationalInsights = () => {
                         <StatsCard
                             title="Inactive Users"
                             number={(
-                                totalUsers - metrics.active_users
+                                totalUsers - metrics.data.active_users
                             ).toString()}
                             label={
-                                totalUsers - metrics.active_users === 1
+                                totalUsers - metrics.data.active_users === 1
                                     ? 'User'
                                     : 'Users'
                             }
@@ -123,9 +129,9 @@ const OperationalInsights = () => {
                         />
                         <StatsCard
                             title="New Admins Added"
-                            number={metrics.new_admins_added.toString()}
+                            number={metrics.data.new_admins_added.toString()}
                             label={
-                                metrics.new_admins_added === 1
+                                metrics.data.new_admins_added === 1
                                     ? 'Admin'
                                     : 'Admins'
                             }
@@ -133,9 +139,9 @@ const OperationalInsights = () => {
                         />
                         <StatsCard
                             title="New Residents Added"
-                            number={metrics.new_residents_added.toString()}
+                            number={metrics.data.new_residents_added.toString()}
                             label={
-                                metrics.new_residents_added === 1
+                                metrics.data.new_residents_added === 1
                                     ? 'Resident'
                                     : 'Residents'
                             }
@@ -143,9 +149,11 @@ const OperationalInsights = () => {
                         />
                         <StatsCard
                             title="Total Logins"
-                            number={metrics.total_logins.toString()}
+                            number={metrics.data.total_logins.toString()}
                             label={
-                                metrics.total_logins === 1 ? 'Login' : 'Logins'
+                                metrics.data.total_logins === 1
+                                    ? 'Login'
+                                    : 'Logins'
                             }
                             tooltip={`Total number of logins in the last ${days} days`}
                         />
@@ -163,7 +171,7 @@ const OperationalInsights = () => {
                                 >
                                     <EngagementRateGraph
                                         peak_login_times={
-                                            metrics?.peak_login_times || []
+                                            metrics?.data.peak_login_times || []
                                         }
                                     />
                                 </ResponsiveContainer>

--- a/frontend/src/Pages/AdminLayer2.tsx
+++ b/frontend/src/Pages/AdminLayer2.tsx
@@ -10,11 +10,12 @@ import {
 import useSWR from 'swr';
 import { AxiosError } from 'axios';
 import UnauthorizedNotFound from './Unauthorized';
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
 
 export default function AdminLayer2() {
     const { user } = useAuth();
     const [facility, setFacility] = useState('all');
+    const [resetCache, setResetCache] = useState(false);
     const { data: facilities, error: errorFacilitiesFetch } = useSWR<
         ServerResponseMany<Facility>,
         AxiosError
@@ -22,7 +23,12 @@ export default function AdminLayer2() {
     const { data, error, isLoading, mutate } = useSWR<
         ServerResponseOne<AdminLayer2Join>,
         AxiosError
-    >(`/api/users/${user?.id}/admin-layer2?facility=${facility}`);
+    >(
+        `/api/users/${user?.id}/admin-layer2?facility=${facility}&reset=${resetCache}`
+    );
+    useEffect(() => {
+        void mutate();
+    }, [facility, resetCache]);
 
     const layer2_metrics = data?.data;
 
@@ -61,7 +67,7 @@ export default function AdminLayer2() {
                         </select>
                         <button
                             className="button"
-                            onClick={() => void mutate()}
+                            onClick={() => setResetCache(!resetCache)}
                         >
                             Refresh Data
                         </button>

--- a/frontend/src/Pages/AdminLayer2.tsx
+++ b/frontend/src/Pages/AdminLayer2.tsx
@@ -31,66 +31,87 @@ export default function AdminLayer2() {
     }, [facility, resetCache]);
 
     const layer2_metrics = data?.data;
+    const formattedDate =
+        layer2_metrics &&
+        new Date(layer2_metrics?.last_cache).toLocaleString('en-US', {});
 
     if (error || isLoading || !user) return <div></div>;
     if (!isAdministrator(user)) {
         return <UnauthorizedNotFound which="unauthorized" />;
     }
     return (
-        <div className="w-full flex flex-col gap-2 px-5 pb-4">
+        <div className="w-full flex flex-col gap-2 pb-4 px-5">
             {error && <div>Error loading data</div>}
             {!data || (isLoading && <div>Loading...</div>)}
             {data && layer2_metrics && (
                 <>
-                    <div className="flex flex-row justify-between mb-6">
-                        <select
-                            id="facility"
-                            className="select select-bordered w-full max-w-xs"
-                            value={facility}
-                            onChange={(e) => setFacility(e.target.value)}
-                        >
-                            <option key={'all'} value={'all'}>
-                                All Facilities
-                            </option>
-                            {errorFacilitiesFetch ? (
-                                <div>Error fetching facilities</div>
-                            ) : (
-                                facilities?.data?.map((facility: Facility) => (
-                                    <option
-                                        key={facility.id}
-                                        value={facility.id}
-                                    >
-                                        {facility.name}
+                    <div className="flex items-end justify-between pb-4">
+                        <div className="flex flex-row gap-4">
+                            <div>
+                                <label htmlFor="facility" className="label">
+                                    <span className="label-text">Facility</span>
+                                </label>
+                                <select
+                                    id="facility"
+                                    className="select select-bordered w-full max-w-xs"
+                                    value={facility}
+                                    onChange={(e) =>
+                                        setFacility(e.target.value)
+                                    }
+                                >
+                                    <option key={'all'} value={'all'}>
+                                        All Facilities
                                     </option>
-                                ))
-                            )}
-                        </select>
-                        <button
-                            className="button"
-                            onClick={() => setResetCache(!resetCache)}
-                        >
-                            Refresh Data
-                        </button>
+                                    {errorFacilitiesFetch ? (
+                                        <div>Error fetching facilities</div>
+                                    ) : (
+                                        facilities?.data?.map(
+                                            (facility: Facility) => (
+                                                <option
+                                                    key={facility.id}
+                                                    value={facility.id}
+                                                >
+                                                    {facility.name}
+                                                </option>
+                                            )
+                                        )
+                                    )}
+                                </select>
+                            </div>
+                        </div>
+                        <div>
+                            <p className="label label-text text-grey-3">
+                                Last updated: {formattedDate}
+                            </p>
+                            <button
+                                className="button justify-self-end"
+                                onClick={() => setResetCache(!resetCache)}
+                            >
+                                Refresh Data
+                            </button>
+                        </div>
                     </div>
-                    <div className="grid grid-cols-3 gap-4 mb-6">
-                        <StatsCard
-                            title="Total Courses Offered"
-                            number={layer2_metrics.total_courses_offered.toString()}
-                            label="courses"
-                        />
-                        <StatsCard
-                            title="Total Students Enrolled"
-                            number={layer2_metrics.total_students_enrolled.toString()}
-                            label={'students'}
-                        />
-                        <StatsCard
-                            title="Total Activity Time"
-                            number={layer2_metrics.total_hourly_activity.toLocaleString(
-                                'en-US'
-                            )}
-                            label="Hours"
-                        />
-                    </div>
+                    {layer2_metrics && (
+                        <div className="grid grid-cols-3 gap-4 mb-6">
+                            <StatsCard
+                                title="Total Courses Offered"
+                                number={layer2_metrics.data.total_courses_offered.toString()}
+                                label="courses"
+                            />
+                            <StatsCard
+                                title="Total Students Enrolled"
+                                number={layer2_metrics.data.total_students_enrolled.toString()}
+                                label={'students'}
+                            />
+                            <StatsCard
+                                title="Total Activity Time"
+                                number={layer2_metrics.data.total_hourly_activity.toLocaleString(
+                                    'en-US'
+                                )}
+                                label="Hours"
+                            />
+                        </div>
+                    )}
                     <div className="card card-row-padding mb-30">
                         <table className="table-2 mb-4">
                             <thead>
@@ -106,7 +127,7 @@ export default function AdminLayer2() {
                                 </tr>
                             </thead>
                             <tbody className="flex flex-col gap-4 mt-4">
-                                {layer2_metrics.learning_insights?.map(
+                                {layer2_metrics.data.learning_insights?.map(
                                     (
                                         insight: LearningInsight,
                                         index: number

--- a/frontend/src/common.ts
+++ b/frontend/src/common.ts
@@ -328,17 +328,20 @@ export interface ServerResponseMany<T> extends ServerResponseBase {
 export type ServerResponse<T> = ServerResponseOne<T> | ServerResponseMany<T>;
 
 export interface LoginMetrics {
-    active_users: number;
-    total_logins: number;
-    logins_per_day: number;
-    percent_active: number;
-    percent_inactive: number;
-    total_residents: number;
-    total_admins: number;
-    facility: string;
-    new_residents_added: number;
-    new_admins_added: number;
-    peak_login_times: LoginActivity[];
+    data: {
+        active_users: number;
+        total_logins: number;
+        logins_per_day: number;
+        percent_active: number;
+        percent_inactive: number;
+        total_residents: number;
+        total_admins: number;
+        facility: string;
+        new_residents_added: number;
+        new_admins_added: number;
+        peak_login_times: LoginActivity[];
+    };
+    last_cache: string;
 }
 
 export interface LoginActivity {
@@ -476,10 +479,13 @@ export interface LearningInsight {
 }
 
 export interface AdminLayer2Join {
-    total_courses_offered: number;
-    total_students_enrolled: number;
-    total_hourly_activity: number;
-    learning_insights: LearningInsight[];
+    data: {
+        total_courses_offered: number;
+        total_students_enrolled: number;
+        total_hourly_activity: number;
+        learning_insights: LearningInsight[];
+    };
+    last_cache: string;
 }
 
 export interface EventCalendar {
@@ -710,9 +716,8 @@ export interface KiwixChannel {
 }
 
 export interface KiwixItem extends Library {
-    page_title: string; 
+    page_title: string;
 }
-
 
 export interface Option {
     key: number;


### PR DESCRIPTION
## Description of the change
This pull request adds a cache for the admin layer 2 dashboard/learning insights.  

- **Related issues**: Closes #685 


## Additional context
Had to add a little bit of redundant code to test if we are testing because NATS isn't running during testing. 


## Here is the timestamps!
![image](https://github.com/user-attachments/assets/f801a90b-c78d-4d09-a457-d19e3ac661ef)

![image](https://github.com/user-attachments/assets/62c510c3-2cb5-4d04-82fb-242ff7f0f013)
