### PR TITLE
fix: wrong col count for helpful links

### DIFF
--- a/frontend/src/Components/dashboard/ExpandableCardGrid.tsx
+++ b/frontend/src/Components/dashboard/ExpandableCardGrid.tsx
@@ -8,17 +8,18 @@ export default function ExpandableCardGrid<T>({
     children,
     emptyStateText,
     emptyStateLink,
-    title
+    title,
+    cols = 4
 }: {
     items: T[];
     children: (item: T) => React.ReactNode; // Child function to render each item
     emptyStateText?: string;
     emptyStateLink?: string;
     title?: string;
+    cols?: number;
 }) {
     const { user } = useAuth();
     const [expanded, setExpanded] = useState<boolean>(false);
-    const cols = user?.role == UserRole.Student ? 3 : 4;
     const slice = expanded ? items.length : cols;
     const isAdmin =
         user?.role === UserRole.Admin || user?.role === UserRole.SystemAdmin;

--- a/frontend/src/Pages/StudentLayer1.tsx
+++ b/frontend/src/Pages/StudentLayer1.tsx
@@ -4,7 +4,8 @@ import {
     UserRole,
     ServerResponseOne,
     HelpfulLinkAndSort,
-    ServerResponseMany
+    ServerResponseMany,
+    HelpfulLink
 } from '@/common';
 import HelpfulLinkCard from '@/Components/cards/HelpfulLinkCard';
 import LibraryCard from '@/Components/LibraryCard';
@@ -87,8 +88,9 @@ export default function StudentLayer1() {
                 <ExpandableCardGrid
                     items={featured?.data ?? []}
                     title="Featured Content"
+                    cols={3}
                 >
-                    {(item) => (
+                    {(item: Library) => (
                         <LibraryCard
                             key={item.id}
                             library={item}
@@ -116,8 +118,9 @@ export default function StudentLayer1() {
                     items={helpfulLinks?.data.helpful_links ?? []}
                     emptyStateText="Add helpful links to share"
                     emptyStateLink="knowledge-center/helpful-links"
+                    cols={4}
                 >
-                    {(link) => (
+                    {(link: HelpfulLink) => (
                         <HelpfulLinkCard
                             key={link.id}
                             link={link}


### PR DESCRIPTION
## Description of the change

When introducing the `ExpandableCardGrid` I made a mistake and didn't apply the four-column layout for the helpful links. This fix adds a cols prop to the grid and sets the Featured content at 3 cols and Helpful links at 4 cols.


## Screenshot(s)

![image](https://github.com/user-attachments/assets/9898643a-82b8-47de-8474-0dfab254b42a)
