### PR TITLE
fix: add line of javascript to fix favoriting and unfavoriting a video card per #703

### DIFF
--- a/frontend/src/Components/VideoCard.tsx
+++ b/frontend/src/Components/VideoCard.tsx
@@ -82,7 +82,11 @@ export default function VideoCard({
                 <div
                     className="tooltip tooltip-top absolute right-2 top-2 w-6 h-6"
                     data-tip="Favorite video"
-                    onClick={() => void handleToggleAction('favorite')}
+                    onClick={(e) => {
+                        e.stopPropagation();
+                        void handleToggleAction('favorite');
+                    }
+                }
                 >
                     {bookmark}
                 </div>


### PR DESCRIPTION
## Description of the change

Added a call to stopPropagation() on the mouse event to stop the bubbling of the event up to the parent div element.

 **Related issues**: Closes #703

## Screenshot(s)
[FixedFavoriting.webm](https://github.com/user-attachments/assets/ba043599-7bd4-4846-bdcb-acb938a236e3)
