### PR TITLE
fix: fix order by add created at

### DIFF
--- a/frontend/src/Pages/AdminManagement.tsx
+++ b/frontend/src/Pages/AdminManagement.tsx
@@ -168,8 +168,8 @@ export default function AdminManagement() {
                             enumType={{
                                 'Name (A-Z)': 'name_last asc',
                                 'Name (Z-A)': 'name_last desc',
-                                'Account Created &#8595; ': 'created_at desc',
-                                'Account Created &#8593; ': 'created_at asc'
+                                'Account Created (Newest) ': 'created_at desc',
+                                'Account Created (Oldest) ': 'created_at asc'
                             }}
                         />
                     </div>
@@ -187,10 +187,11 @@ export default function AdminManagement() {
                 <div className="relative w-full" style={{ overflowX: 'clip' }}>
                     <table className="table-2 mb-4">
                         <thead>
-                            <tr className="grid-cols-4 px-4">
+                            <tr className="grid grid-cols-5 px-4">
                                 <th className="justify-self-start">Name</th>
                                 <th>Username</th>
                                 <th>Last Updated</th>
+                                <th>Created At</th>
                                 <th className="justify-self-end pr-4">
                                     Actions
                                 </th>
@@ -201,10 +202,11 @@ export default function AdminManagement() {
                                 !error &&
                                 userData.map((user: User) => {
                                     const updatedAt = new Date(user.updated_at);
+                                    const createdAt = new Date(user.created_at);
                                     return (
                                         <tr
                                             key={user.id}
-                                            className="card p-4 w-full grid-cols-4 justify-items-center"
+                                            className="card p-4 w-full grid-cols-5 justify-items-center"
                                         >
                                             <td className="justify-self-start">
                                                 {user.name_first}{' '}
@@ -219,6 +221,25 @@ export default function AdminManagement() {
                                                     <a className="flex justify-start cursor-pointer">
                                                         <span>
                                                             {updatedAt.toLocaleDateString(
+                                                                'en-US',
+                                                                {
+                                                                    year: 'numeric',
+                                                                    month: 'short',
+                                                                    day: 'numeric'
+                                                                }
+                                                            )}
+                                                        </span>
+                                                    </a>
+                                                </div>
+                                            </td>
+                                            <td>
+                                                <div
+                                                    className="tooltip"
+                                                    data-tip="Account Creation"
+                                                >
+                                                    <a className="flex justify-start cursor-pointer">
+                                                        <span>
+                                                            {createdAt.toLocaleDateString(
                                                                 'en-US',
                                                                 {
                                                                     year: 'numeric',

--- a/frontend/src/Pages/StudentManagement.tsx
+++ b/frontend/src/Pages/StudentManagement.tsx
@@ -146,8 +146,8 @@ export default function StudentManagement() {
                             enumType={{
                                 'Name (A-Z)': 'name_last asc',
                                 'Name (Z-A)': 'name_last desc',
-                                'Account Created &#8595; ': 'created_at desc',
-                                'Account Created &#8593; ': 'created_at asc'
+                                'Account Created (Newest) ': 'created_at desc',
+                                'Account Created  (Oldest)': 'created_at asc'
                             }}
                         />
                     </div>
@@ -168,10 +168,11 @@ export default function StudentManagement() {
                 <div className="relative w-full" style={{ overflowX: 'clip' }}>
                     <table className="table-2 mb-4">
                         <thead>
-                            <tr className="grid-cols-4 px-4">
+                            <tr className="grid grid-cols-5 px-4">
                                 <th className="justify-self-start">Name</th>
                                 <th>Username</th>
                                 <th>Last Updated</th>
+                                <th>Created At</th>
                                 <th className="justify-self-end pr-4">
                                     Actions
                                 </th>
@@ -182,10 +183,11 @@ export default function StudentManagement() {
                                 !error &&
                                 userData.map((user: User) => {
                                     const updatedAt = new Date(user.updated_at);
+                                    const createdAt = new Date(user.created_at);
                                     return (
                                         <tr
                                             key={user.id}
-                                            className="card p-4 w-full grid-cols-4 justify-items-center"
+                                            className="card p-4 w-full grid-cols-5 justify-items-center"
                                         >
                                             <td className="justify-self-start">
                                                 {user.name_first}{' '}
@@ -200,6 +202,25 @@ export default function StudentManagement() {
                                                     <a className="flex justify-start cursor-pointer">
                                                         <span>
                                                             {updatedAt.toLocaleDateString(
+                                                                'en-US',
+                                                                {
+                                                                    year: 'numeric',
+                                                                    month: 'short',
+                                                                    day: 'numeric'
+                                                                }
+                                                            )}
+                                                        </span>
+                                                    </a>
+                                                </div>
+                                            </td>
+                                            <td>
+                                                <div
+                                                    className="tooltip"
+                                                    data-tip="Account Creation"
+                                                >
+                                                    <a className="flex justify-start cursor-pointer">
+                                                        <span>
+                                                            {createdAt.toLocaleDateString(
                                                                 'en-US',
                                                                 {
                                                                     year: 'numeric',


### PR DESCRIPTION
## Description of the change
This PR fixes the Admin and Student management page order by drop downs. It fixes the previous Arrow icons, removing them, and adding "Newest" and "Oldest". This PR also adds the Created At column to show the user when the account was created. 

- **Related issues**: Closes #711 

## Screenshot(s)
![image](https://github.com/user-attachments/assets/80bcaaf6-307c-4d70-8de8-c1bc9db466b0)
![image](https://github.com/user-attachments/assets/e20ac958-4ee7-4237-bfdc-77cbc569c625)
![image](https://github.com/user-attachments/assets/7f4f4300-5b1c-4f5a-af0a-708df4c9bce1)
![image](https://github.com/user-attachments/assets/c96131b6-907f-456b-92d1-15a5ea19b89a)
 


## Additional context
Created At column was added as a result/conversation with Josh after I had grabbed the ticket. 