### PR TITLE
fix: fix helpful link thumbnail issue

### DIFF
--- a/backend/src/handlers/helpful_links_handler.go
+++ b/backend/src/handlers/helpful_links_handler.go
@@ -4,6 +4,7 @@ import (
 	"UnlockEdv2/src/database"
 	"UnlockEdv2/src/models"
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"net/url"
 	"strconv"
@@ -172,14 +173,10 @@ func (srv *Server) handleFavoriteLink(w http.ResponseWriter, r *http.Request, lo
 
 func (srv *Server) getFavicon(link string) string {
 	logrus.Printf("Getting favicon for link %s", link)
-	baseUrl, err := url.Parse(link)
-	if err != nil {
+	parsed, err := url.Parse(link)
+	if err != nil || parsed.Hostname() == "" {
 		return "/ul-logo.png"
 	}
-	maybeIcon := baseUrl.Scheme + "://" + baseUrl.Host + "/favicon.ico"
-	resp, err := srv.Client.Head(maybeIcon)
-	if err != nil || resp.StatusCode != http.StatusOK {
-		return "/ul-logo.png"
-	}
-	return maybeIcon
+	domain := parsed.Hostname()
+	return fmt.Sprintf("https://www.google.com/s2/favicons?domain=%s&sz=64", domain)
 }


### PR DESCRIPTION
## Description of the change
Thumbnails on helpful link's weren't being rendered properly because at times the response status code would actually be 200, but there still would be no favicon. We fix this by checking whether or not the actual content-length of the response is 0 or less, and if it is, assign the ULL logo. 

- **Related issues**: Closes #725 

## Screenshot(s)

**Reference the few links copied from staging that weren't working**
![image](https://github.com/user-attachments/assets/f152aa9f-ad5a-48fd-bdc7-23c4987ed17c)


