### PR TITLE
fix: helpful link thumbnail update on change

### DIFF
--- a/backend/src/handlers/helpful_links_handler.go
+++ b/backend/src/handlers/helpful_links_handler.go
@@ -92,6 +92,7 @@ func (srv *Server) handleEditLink(w http.ResponseWriter, r *http.Request, log sL
 		return newInvalidIdServiceError(err, "Invalid id")
 	}
 	defer r.Body.Close()
+	link.ThumbnailUrl = srv.getFavicon(link.Url)
 	if err = srv.Db.EditLink(uint(id), link); err != nil {
 		return newDatabaseServiceError(err)
 	}


### PR DESCRIPTION
## Description of the change
This PR makes sure that we update the thumbnail url if a helpful link is updated. 

- **Related issues**: closes #702 
## Screenshot(s)
**Update helpful link video**
https://www.loom.com/share/e531914c5a8c42b3bacc8cb59686ab03?sid=070c6f2f-9e59-4a2d-8e29-0a7a1439bb3e

