### PR TITLE
refactor: change add student to add resident, change url length

### DIFF
--- a/frontend/src/Components/forms/AddLinkForm.tsx
+++ b/frontend/src/Components/forms/AddLinkForm.tsx
@@ -54,7 +54,7 @@ export default function AddLinkForm({
                     label="Title"
                     interfaceRef="title"
                     required
-                    length={25}
+                    length={255}
                     errors={errors}
                     register={register}
                 />

--- a/frontend/src/Pages/StudentManagement.tsx
+++ b/frontend/src/Pages/StudentManagement.tsx
@@ -154,14 +154,14 @@ export default function StudentManagement() {
 
                     <div
                         className="tooltip tooltip-left"
-                        data-tip="Add Student"
+                        data-tip="Add Resident"
                     >
                         <button
                             className="button "
                             onClick={() => addUserModal.current?.showModal()}
                         >
                             <PlusCircleIcon className="w-4 my-auto" />
-                            Add Student
+                            Add Resident
                         </button>
                     </div>
                 </div>
@@ -235,7 +235,9 @@ export default function StudentManagement() {
                                             <td className="justify-self-end">
                                                 <div className="flex space-x-4">
                                                     <ULIComponent
-                                                        dataTip={'Edit Student'}
+                                                        dataTip={
+                                                            'Edit Resident'
+                                                        }
                                                         tooltipClassName="tooltip-left cursor-pointer"
                                                         icon={PencilSquareIcon}
                                                         onClick={() => {
@@ -260,7 +262,7 @@ export default function StudentManagement() {
 
                                                     <ULIComponent
                                                         dataTip={
-                                                            'Delete Student'
+                                                            'Delete Resident'
                                                         }
                                                         tooltipClassName="tooltip-left cursor-pointer"
                                                         icon={TrashIcon}
@@ -303,7 +305,7 @@ export default function StudentManagement() {
             <Modal
                 ref={addUserModal}
                 type={ModalType.Add}
-                item="Student"
+                item="Resident"
                 form={
                     <AddUserForm
                         onSuccess={onAddUserSuccess}
@@ -314,7 +316,7 @@ export default function StudentManagement() {
             <Modal
                 ref={editUserModal}
                 type={ModalType.Edit}
-                item="Student"
+                item="Resident"
                 form={
                     targetUser ? (
                         <EditUserForm
@@ -329,7 +331,7 @@ export default function StudentManagement() {
             <Modal
                 ref={deleteUserModal}
                 type={ModalType.Confirm}
-                item="Delete Student"
+                item="Delete Resident"
                 form={
                     <DeleteForm
                         item="User"


### PR DESCRIPTION
## Description of the change

This increases the allowed length of the URL for helpful_links, after some research I have found that the most common character count for URL's is between 80-100 characters long, given that the actual url is not displayed and the user explicitly names the url. In the database we limit the URL to 255 characters so the URL character limit has been updated to be 255 characters. Secondly, the "Add Students" button has been changed to "Add Residents" and in the form. 

- **Related issues**: Closes #707 Closes #709 

## Screenshot(s)
![image](https://github.com/user-attachments/assets/d56fab6c-353b-4db8-9f11-344a806fc0db)
![image](https://github.com/user-attachments/assets/6450a794-db51-4a11-82c1-52558effef82)
**Helpful Link URL -> Description field is the URL for character count length reference**
![image](https://github.com/user-attachments/assets/b9186467-3d4e-426a-a96e-c5f8a5713a13)
![image](https://github.com/user-attachments/assets/c9c1a013-af98-4cf6-95bd-44285a61705f)
