### PR TITLE
fix: login/auth issue for stale or invalid flow ids

### DIFF
--- a/backend/src/handlers/login_flow.go
+++ b/backend/src/handlers/login_flow.go
@@ -268,8 +268,12 @@ func (srv *Server) handleRefreshAuth(w http.ResponseWriter, r *http.Request, log
 	if err != nil {
 		return newCreateRequestServiceError(err)
 	}
+	redirectTo, ok := consentResponse["redirect_to"].(string)
+	if !ok {
+		return newBadRequestServiceError(errors.New("hydra auth refresh failed"), "Bad Request")
+	}
 	return writeJsonResponse(w, http.StatusOK, map[string]string{
-		"redirect_to": consentResponse["redirect_to"].(string),
+		"redirect_to": redirectTo,
 	})
 }
 

--- a/frontend/src/Components/forms/ConsentForm.tsx
+++ b/frontend/src/Components/forms/ConsentForm.tsx
@@ -1,5 +1,6 @@
 import API from '@/api/api';
 import { AuthResponse } from '@/common';
+import { AUTHCALLBACK } from '@/useAuth';
 import { useNavigate } from 'react-router-dom';
 
 interface ConsentForm {
@@ -27,10 +28,10 @@ export default function ConsentForm() {
             window.location.href = location;
             return;
         }
-        window.location.href = '/authcallback';
+        window.location.href = AUTHCALLBACK;
     };
     const deny = () => {
-        window.location.href = '/authcallback';
+        window.location.href = AUTHCALLBACK;
     };
     return (
         <div className="bg-base-100 shadow-lg rounded-lg p-8 mb-4 flex flex-col my-2 max-w-screen-xl mx-auto">

--- a/frontend/src/Components/forms/LoginForm.tsx
+++ b/frontend/src/Components/forms/LoginForm.tsx
@@ -1,10 +1,16 @@
-import { useLoaderData, Form, useNavigation } from 'react-router-dom';
+import {
+    useLoaderData,
+    Form,
+    useNavigation,
+    useNavigate
+} from 'react-router-dom';
 import { TextInput } from '@/Components/inputs/TextInput';
 import InputError from '@/Components/inputs/InputError';
 import { AuthFlow, AuthResponse, ServerResponseOne } from '@/common';
 import { SubmitHandler, useForm } from 'react-hook-form';
 import API from '@/api/api';
 import { useEffect, useState } from 'react';
+import { AUTHCALLBACK } from '@/useAuth';
 
 interface Inputs {
     identifier: string;
@@ -17,6 +23,7 @@ interface Inputs {
 export default function LoginForm() {
     const loaderData = useLoaderData() as AuthFlow;
     const navigation = useNavigation();
+    const navigate = useNavigate();
     const processing = navigation.state === 'submitting';
     const [user, setUser] = useState<string | undefined>(undefined);
     const [errorMessage, setErrorMessage] = useState(false);
@@ -43,6 +50,11 @@ export default function LoginForm() {
     };
     useEffect(() => {
         if (loaderData.redirect_to) {
+            if (loaderData.redirect_to === AUTHCALLBACK) {
+                // use internal navigation if possible
+                navigate(AUTHCALLBACK);
+                return;
+            }
             window.location.href = loaderData.redirect_to;
             return;
         }

--- a/frontend/src/Components/forms/LoginForm.tsx
+++ b/frontend/src/Components/forms/LoginForm.tsx
@@ -1,16 +1,10 @@
-import {
-    useLoaderData,
-    Form,
-    useNavigation,
-    useNavigate
-} from 'react-router-dom';
+import { useLoaderData, Form, useNavigation } from 'react-router-dom';
 import { TextInput } from '@/Components/inputs/TextInput';
 import InputError from '@/Components/inputs/InputError';
 import { AuthFlow, AuthResponse, ServerResponseOne } from '@/common';
 import { SubmitHandler, useForm } from 'react-hook-form';
 import API from '@/api/api';
 import { useEffect, useState } from 'react';
-import { AUTHCALLBACK } from '@/useAuth';
 
 interface Inputs {
     identifier: string;
@@ -23,7 +17,6 @@ interface Inputs {
 export default function LoginForm() {
     const loaderData = useLoaderData() as AuthFlow;
     const navigation = useNavigation();
-    const navigate = useNavigate();
     const processing = navigation.state === 'submitting';
     const [user, setUser] = useState<string | undefined>(undefined);
     const [errorMessage, setErrorMessage] = useState(false);
@@ -50,18 +43,13 @@ export default function LoginForm() {
     };
     useEffect(() => {
         if (loaderData.redirect_to) {
-            if (loaderData.redirect_to === AUTHCALLBACK) {
-                // use internal navigation if possible
-                navigate(AUTHCALLBACK);
-                return;
-            }
             window.location.href = loaderData.redirect_to;
             return;
         }
         if (loaderData.identifier) {
             setUser(loaderData.identifier);
         }
-    });
+    }, [loaderData]);
     return (
         <Form
             method="post"

--- a/frontend/src/Pages/Error.tsx
+++ b/frontend/src/Pages/Error.tsx
@@ -1,3 +1,7 @@
+import { AUTHCALLBACK } from '@/useAuth';
+import { useNavigate } from 'react-router-dom';
+
+const navigate = useNavigate();
 export default function Error() {
     return (
         <>
@@ -10,7 +14,7 @@ export default function Error() {
                 <button
                     className="btn btn-primary btn-outline"
                     onClick={() => {
-                        window.location.href = '/authcallback';
+                        navigate(AUTHCALLBACK);
                     }}
                 >
                     Home Page

--- a/frontend/src/Pages/Error.tsx
+++ b/frontend/src/Pages/Error.tsx
@@ -1,7 +1,5 @@
 import { AUTHCALLBACK } from '@/useAuth';
-import { useNavigate } from 'react-router-dom';
 
-const navigate = useNavigate();
 export default function Error() {
     return (
         <>
@@ -14,7 +12,7 @@ export default function Error() {
                 <button
                     className="btn btn-primary btn-outline"
                     onClick={() => {
-                        navigate(AUTHCALLBACK);
+                        window.location.href = AUTHCALLBACK;
                     }}
                 >
                     Home Page

--- a/frontend/src/Pages/Welcome.tsx
+++ b/frontend/src/Pages/Welcome.tsx
@@ -3,6 +3,7 @@ import Brand from '../Components/Brand';
 import { INIT_KRATOS_LOGIN_FLOW, ServerResponse, User } from '@/common';
 import API from '@/api/api';
 import { Link } from 'react-router-dom';
+import { AUTHCALLBACK } from '@/useAuth';
 
 export default function Welcome() {
     const [imgSrc, setImgSrc] = useState('unlockedv1Sm.webp');
@@ -39,7 +40,7 @@ export default function Welcome() {
                             </li>
                         ) : (
                             <li>
-                                <Link to={'/authcallback'}>Dashboard</Link>
+                                <Link to={AUTHCALLBACK}>Dashboard</Link>
                             </li>
                         )}
                     </ul>

--- a/frontend/src/app.tsx
+++ b/frontend/src/app.tsx
@@ -27,6 +27,7 @@ import Programs from './Pages/Programs.tsx';
 import LibraryLayout from './Components/LibraryLayout';
 import VideoManagement from './Pages/VideoManagement';
 import {
+    AUTHCALLBACK,
     checkDefaultFacility,
     checkExistingFlow,
     checkRole,
@@ -90,10 +91,10 @@ function ProtectedRoute({
 }) {
     const { user } = useAuth();
     if (!user) {
-        return <Navigate to={`${INIT_KRATOS_LOGIN_FLOW}`} />;
+        return <Navigate to={INIT_KRATOS_LOGIN_FLOW} />;
     }
     if (!allowedFeatures.every((feat) => hasFeature(user, feat))) {
-        return <Navigate to="/authcallback" />;
+        return <Navigate to={AUTHCALLBACK} />;
     }
     return <Outlet />;
 }

--- a/frontend/src/common.ts
+++ b/frontend/src/common.ts
@@ -100,8 +100,8 @@ export interface OryFlow {
     expires_at: string;
     id: string;
     issued_at: string;
-    oauth2_login_challenge: string;
-    oauth2_login_request: Oauth2LoginRequest;
+    oauth2_login_challenge?: string;
+    oauth2_login_request?: Oauth2LoginRequest;
     organization_id: string;
     refresh: boolean;
     request_url: string;


### PR DESCRIPTION
#754 

previously it would check the flow, and because the user is logged in, it would assume that it's a user trying to oauth into the platform, and send a request to the backend with the auth flow to `/api/auth/refresh`, which would then `502` because it's relying on a parameter that isn't present.

This checks for a user already logged in and if an oauth2 challenge isn't found, it will simply redirect them to `/authcallback`, if the `flow_id` isn't valid, then it redirects them to `/self-service/login/browser` to get a new `flow_id` 