### PR TITLE
fix: remove admin ability to alter data in student view

### DIFF
--- a/frontend/src/Components/FavoriteCard.tsx
+++ b/frontend/src/Components/FavoriteCard.tsx
@@ -69,6 +69,10 @@ const FavoriteCard: React.FC<FavoriteCardProps> = ({
         }
         const response = await API.put(endpoint, payload);
         if (adminWithStudentView()) {
+            toaster(
+                "You're in preview mode. Changes cannot be made.",
+                ToastState.null
+            );
             return;
         }
         if (response.success) {

--- a/frontend/src/Components/FavoriteCard.tsx
+++ b/frontend/src/Components/FavoriteCard.tsx
@@ -1,9 +1,11 @@
-import { useNavigate } from 'react-router-dom';
+import { useLocation, useNavigate } from 'react-router-dom';
 import { StarIcon as SolidStar } from '@heroicons/react/24/solid';
 import { KeyedMutator } from 'swr';
 import { ToastState, ServerResponseMany, OpenContentItem } from '@/common';
 import API from '@/api/api';
 import { useToast } from '@/Context/ToastCtx';
+
+import { isAdministrator, useAuth } from '@/useAuth';
 
 interface FavoriteCardProps {
     favorite: OpenContentItem;
@@ -20,6 +22,11 @@ const FavoriteCard: React.FC<FavoriteCardProps> = ({
 }) => {
     const navigate = useNavigate();
     const { toaster } = useToast();
+    const route = useLocation();
+    const { user } = useAuth();
+    const adminWithStudentView = (): boolean => {
+        return !route.pathname.includes('management') && isAdministrator(user);
+    };
 
     const handleCardClick = () => {
         if (!favorite.visibility_status) {
@@ -61,6 +68,9 @@ const FavoriteCard: React.FC<FavoriteCardProps> = ({
             }
         }
         const response = await API.put(endpoint, payload);
+        if (adminWithStudentView()) {
+            return;
+        }
         if (response.success) {
             toaster(`Removed from favorites`, ToastState.success);
             await mutate();

--- a/frontend/src/Components/LibraryCard.tsx
+++ b/frontend/src/Components/LibraryCard.tsx
@@ -42,6 +42,10 @@ export default function LibraryCard({
         if (!mutate) return;
         if (e) e.stopPropagation();
         if (adminWithStudentView()) {
+            toaster(
+                "You're in preview mode. Changes cannot be made.",
+                ToastState.null
+            );
             return;
         }
         const actionString =

--- a/frontend/src/Components/LibraryCard.tsx
+++ b/frontend/src/Components/LibraryCard.tsx
@@ -4,7 +4,7 @@ import { Library, ToastState, UserRole } from '@/common';
 import API from '@/api/api';
 import { useLocation, useNavigate } from 'react-router-dom';
 import { useToast } from '@/Context/ToastCtx';
-import { AdminRoles } from '@/useAuth';
+import { useAuth, AdminRoles, isAdministrator } from '@/useAuth';
 import ULIComponent from '@/Components/ULIComponent';
 import { StarIcon, FlagIcon } from '@heroicons/react/24/solid';
 import {
@@ -29,7 +29,11 @@ export default function LibraryCard({
     const [visible, setVisible] = useState<boolean>(library.visibility_status);
     const [favorite, setFavorite] = useState<boolean>(library.is_favorited);
     const navigate = useNavigate();
+    const { user } = useAuth();
     const route = useLocation();
+    const adminWithStudentView = (): boolean => {
+        return !route.pathname.includes('management') && isAdministrator(user);
+    };
 
     async function handleToggleAction(
         action: 'favorite' | 'toggle',
@@ -37,6 +41,9 @@ export default function LibraryCard({
     ) {
         if (!mutate) return;
         if (e) e.stopPropagation();
+        if (adminWithStudentView()) {
+            return;
+        }
         const actionString =
             action == 'favorite'
                 ? favorite

--- a/frontend/src/Components/VideoCard.tsx
+++ b/frontend/src/Components/VideoCard.tsx
@@ -42,6 +42,10 @@ export default function VideoCard({
 
     const handleToggleAction = async (action: 'favorite' | 'visibility') => {
         if (adminWithStudentView() && action === 'favorite') {
+            toaster(
+                "You're in preview mode. Changes cannot be made.",
+                ToastState.null
+            );
             return;
         }
         const response = await API.put<null, object>(

--- a/frontend/src/Components/VideoCard.tsx
+++ b/frontend/src/Components/VideoCard.tsx
@@ -10,11 +10,11 @@ import {
 } from '@/common';
 import API from '@/api/api';
 import { KeyedMutator } from 'swr';
-import { useNavigate } from 'react-router-dom';
+import { useLocation, useNavigate } from 'react-router-dom';
 import { useToast } from '@/Context/ToastCtx';
 import { StarIcon } from '@heroicons/react/24/solid';
 import { StarIcon as StarIconOutline } from '@heroicons/react/24/outline';
-import { AdminRoles } from '@/useAuth';
+import { AdminRoles, useAuth, isAdministrator } from '@/useAuth';
 import ClampedText from './ClampedText';
 
 export default function VideoCard({
@@ -34,8 +34,16 @@ export default function VideoCard({
     const [favorite, setFavorite] = useState<boolean>(video.is_favorited);
     const navigate = useNavigate();
     const { toaster } = useToast();
+    const route = useLocation();
+    const { user } = useAuth();
+    const adminWithStudentView = (): boolean => {
+        return !route.pathname.includes('management') && isAdministrator(user);
+    };
 
     const handleToggleAction = async (action: 'favorite' | 'visibility') => {
+        if (adminWithStudentView() && action === 'favorite') {
+            return;
+        }
         const response = await API.put<null, object>(
             `videos/${video.id}/${action}`,
             {}
@@ -48,6 +56,7 @@ export default function VideoCard({
                 : visible
                   ? 'is now hidden'
                   : 'is now visible';
+
         if (response.success) {
             toaster(`Video ${actionString}`, ToastState.success);
             await mutate();

--- a/frontend/src/Components/cards/HelpfulLinkCard.tsx
+++ b/frontend/src/Components/cards/HelpfulLinkCard.tsx
@@ -10,11 +10,12 @@ import VisibleHiddenToggle from '../VisibleHiddenToggle';
 import { useState } from 'react';
 import ULIComponent from '../ULIComponent';
 import { PencilSquareIcon, TrashIcon } from '@heroicons/react/24/outline';
-import { AdminRoles } from '@/useAuth';
+import { useAuth, isAdministrator, AdminRoles } from '@/useAuth';
 import { useToast } from '@/Context/ToastCtx';
 import { StarIcon } from '@heroicons/react/24/solid';
 import { StarIcon as StarIconOutline } from '@heroicons/react/24/outline';
 import ClampedText from '../ClampedText';
+import { useLocation } from 'react-router-dom';
 
 export default function HelpfulLinkCard({
     link,
@@ -34,12 +35,21 @@ export default function HelpfulLinkCard({
     const [visible, setVisible] = useState<boolean>(link.visibility_status);
     const [favorite, setFavorite] = useState<boolean>(link.is_favorited);
     const { toaster } = useToast();
+    const { user } = useAuth();
+    const route = useLocation();
+
+    const adminWithStudentView = (): boolean => {
+        return !route.pathname.includes('management') && isAdministrator(user);
+    };
 
     const handleToggleAction = async (
         action: 'favorite' | 'toggle',
         e?: React.MouseEvent
     ) => {
         if (e) e.stopPropagation();
+        if (adminWithStudentView()) {
+            return;
+        }
         const response = await API.put<null, object>(
             `helpful-links/${action}/${link.id}`,
             {}

--- a/frontend/src/Components/cards/HelpfulLinkCard.tsx
+++ b/frontend/src/Components/cards/HelpfulLinkCard.tsx
@@ -48,6 +48,10 @@ export default function HelpfulLinkCard({
     ) => {
         if (e) e.stopPropagation();
         if (adminWithStudentView()) {
+            toaster(
+                "You're in preview mode. Changes cannot be made.",
+                ToastState.null
+            );
             return;
         }
         const response = await API.put<null, object>(


### PR DESCRIPTION
## Description of the change
This PR removes the ability of admins to favorite while in preview mode on Libraries, Helpful Links, and Videos. 

- **Related issues**: Closes #771 

## Screenshot(s)
https://www.loom.com/share/1b6986f253a04f1fbebea7477f5f103e?sid=fde981af-4d93-4ee2-aaec-866eaa29bb6f



---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1209457884707537