### PR TITLE
fix: add/edit user fixes

### DIFF
--- a/frontend/src/Components/modals/AddUserModal.tsx
+++ b/frontend/src/Components/modals/AddUserModal.tsx
@@ -1,5 +1,5 @@
 import { forwardRef, useState } from 'react';
-import { CRUDActions, CRUDModalProps, FormInputTypes, getUserInputs } from '.';
+import { CRUDActions, CRUDModalProps, getUserInputs } from '.';
 import { FieldValues, SubmitHandler } from 'react-hook-form';
 import { NewUserResponse, ProviderPlatform, User, UserRole } from '@/common';
 import API from '@/api/api';
@@ -79,22 +79,7 @@ export const AddUserModal = forwardRef(function (
     return (
         <FormModal
             title={'Add User'}
-            inputs={[
-                ...getUserInputs(CRUDActions.Add),
-                ...(userRole === UserRole.Student
-                    ? [
-                          {
-                              type: FormInputTypes.MultiSelectDropdown,
-                              label: 'Also create new account for user in:',
-                              interfaceRef: 'platforms',
-                              required: false,
-                              options: providerPlatforms
-                                  ? providerPlatforms
-                                  : []
-                          }
-                      ]
-                    : [])
-            ]}
+            inputs={getUserInputs(userRole, CRUDActions.Add, providerPlatforms)}
             onSubmit={addUser}
             error={formError}
             ref={addUserModal}

--- a/frontend/src/Components/modals/EditUserModal.tsx
+++ b/frontend/src/Components/modals/EditUserModal.tsx
@@ -13,6 +13,7 @@ export const EditUserModal = forwardRef(function (
         mutate: mutate,
         refModal: editUserModal
     });
+    if (!target) return null;
     const editUser: SubmitHandler<FieldValues> = async (data) => {
         const resp = await API.patch(`users/${target?.id}`, data);
         checkResponse(
@@ -24,7 +25,7 @@ export const EditUserModal = forwardRef(function (
     return (
         <FormModal
             title={'Edit User'}
-            inputs={getUserInputs(CRUDActions.Edit)}
+            inputs={getUserInputs(target.role, CRUDActions.Edit)}
             defaultValues={target}
             onSubmit={editUser}
             ref={editUserModal}

--- a/frontend/src/Components/modals/index.ts
+++ b/frontend/src/Components/modals/index.ts
@@ -4,11 +4,13 @@ import {
     ProviderPlatformType,
     ServerResponseMany,
     ServerResponseOne,
-    Timezones
+    Timezones,
+    UserRole
 } from '@/common';
 import { KeyedMutator } from 'swr';
 import { Validate } from 'react-hook-form';
 import React from 'react';
+import { AdminRoles } from '@/useAuth';
 
 export enum TextModalType {
     Confirm,
@@ -207,9 +209,11 @@ export const checkOnlyLettersAndNumbers: Validate<string, string | boolean> = (
     return true;
 };
 export const getUserInputs = (
-    action: CRUDActions
+    userRole: UserRole,
+    action: CRUDActions,
+    providerPlatforms?: ProviderPlatform[]
 ): InputWithOptions<ProviderPlatform>[] => {
-    return [
+    const inputs: InputWithOptions<ProviderPlatform>[] = [
         {
             type: FormInputTypes.Text,
             label: 'First Name',
@@ -238,15 +242,32 @@ export const getUserInputs = (
                     'Username can only contain letters and numbers without spaces'
             },
             disabled: action === CRUDActions.Edit
-        },
-        {
+        }
+    ];
+    if (AdminRoles.includes(userRole)) {
+        inputs.push({
             type: FormInputTypes.Text,
             label: 'Email (optional)',
             interfaceRef: 'email',
             required: false,
-            length: 50
-        }
-    ];
+            length: 50,
+            disabled: false
+        });
+    }
+    if (
+        userRole === UserRole.Student &&
+        providerPlatforms &&
+        providerPlatforms.length > 0
+    ) {
+        inputs.push({
+            type: FormInputTypes.MultiSelectDropdown,
+            label: 'Also create new account for user in:',
+            interfaceRef: 'platforms',
+            required: false,
+            options: providerPlatforms
+        });
+    }
+    return inputs;
 };
 export { AddUserModal } from './AddUserModal';
 export { EditUserModal } from './EditUserModal';

--- a/frontend/src/routeLoaders.ts
+++ b/frontend/src/routeLoaders.ts
@@ -141,5 +141,5 @@ export const getProviderPlatforms: LoaderFunction = async () => {
     if (response.success) {
         return json({ providerPlatforms: response.data as ProviderPlatform[] });
     }
-    return json<null>(null);
+    return json({ providerPlatforms: [] });
 };


### PR DESCRIPTION
## Description of the change

Fixes a few bugs with the add/edit resident and admin modals, including:
- only renders provider platforms when there are provider platforms to render
- fixes bug where residents and admin wouldn't load if connected learning level was not turned on
- removes email from the resident add/edit user modals.

## Screenshot(s)
<img width="1502" alt="Screenshot 2025-03-03 at 3 40 33 PM" src="https://github.com/user-attachments/assets/3f2a4fce-84d2-43b1-bf48-5088dcdad430" />
<img width="1501" alt="Screenshot 2025-03-03 at 3 40 48 PM" src="https://github.com/user-attachments/assets/9de9e7e9-fb3e-45f4-9e74-24d13f38677c" />
<img width="1504" alt="Screenshot 2025-03-03 at 3 41 05 PM" src="https://github.com/user-attachments/assets/d1642b12-1c4a-4ae3-b212-707304606b82" />
<img width="1502" alt="Screenshot 2025-03-03 at 3 41 21 PM" src="https://github.com/user-attachments/assets/5d0231bc-0d9a-463b-b48c-bb91b89e7615" />
