### PR TITLE
feat: add logic for displaying resident profile overview per #714

### DIFF
--- a/backend/migrations/00037_alter_open_content_activities.sql
+++ b/backend/migrations/00037_alter_open_content_activities.sql
@@ -1,0 +1,33 @@
+-- +goose Up
+-- +goose StatementBegin
+ALTER TABLE public.open_content_activities DROP CONSTRAINT unique_user_facility_library_url_timestamp;
+ALTER TABLE public.open_content_activities ADD CONSTRAINT unique_user_facility_library_url_timestamp UNIQUE (user_id, facility_id, open_content_provider_id, content_id, open_content_url_id, request_ts);
+ALTER TABLE public.open_content_activities 
+ADD COLUMN stop_ts TIMESTAMP(0) WITHOUT TIME ZONE NULL,
+ADD COLUMN duration INTERVAL GENERATED ALWAYS AS (stop_ts - request_ts) STORED;
+
+CREATE TABLE public.user_session_tracking (
+    id SERIAL NOT NULL,
+    user_id integer NOT NULL,
+    session_id character varying(255),
+    session_start_ts timestamp with time zone,
+    session_end_ts timestamp with time zone NULL,
+    session_duration INTERVAL GENERATED ALWAYS AS (session_end_ts - session_start_ts) STORED,
+
+    FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE
+);
+
+CREATE INDEX idx_user_session_tracking_user_id ON public.user_session_tracking USING btree (user_id);
+CREATE INDEX idx_user_session_tracking_user_session_start ON public.user_session_tracking USING btree (user_id, session_id, session_start_ts DESC);
+-- +goose StatementEnd
+
+-- +goose Down
+-- +goose StatementBegin
+ALTER TABLE public.open_content_activities DROP CONSTRAINT unique_user_facility_library_url_timestamp;
+ALTER TABLE public.open_content_activities ADD CONSTRAINT unique_user_facility_library_url_timestamp UNIQUE (user_id, facility_id, content_id, open_content_url_id, request_ts);
+ALTER TABLE public.open_content_activities 
+drop COLUMN duration,
+drop COLUMN stop_ts;
+
+DROP TABLE IF EXISTS public.user_session_tracking CASCADE;
+-- +goose StatementEnd

--- a/backend/src/database/libraries.go
+++ b/backend/src/database/libraries.go
@@ -106,7 +106,7 @@ func (db *DB) GetAllLibraries(args *models.QueryContext, visibility string) ([]L
 		}
 		tx = tx.Group("libraries.id, fvs.visibility_status").Order("favorite_count DESC")
 	default:
-		tx = tx.Order(args.OrderBy)
+		tx = tx.Order(args.OrderBy + " " + args.Order)
 	}
 	if !args.All {
 		tx = tx.Limit(args.PerPage).Offset(args.CalcOffset())

--- a/backend/src/database/open_content.go
+++ b/backend/src/database/open_content.go
@@ -402,7 +402,8 @@ func (db *DB) GetTopFiveLibrariesByUserID(userID int, args *models.QueryContext)
 		Joins(`join users u on u.id = oca.user_id
 				and u.id = ?`, userID).
 		Joins(`left outer join open_content_favorites ocf on ocf.open_content_provider_id = ocp.id
-				and ocf.content_id = lib.id`).
+				and ocf.content_id = lib.id
+				and ocf.facility_id IS NOT NULL`).
 		Joins(`left outer join facility_visibility_statuses fvs on fvs.open_content_provider_id = lib.open_content_provider_id
 			and fvs.content_id = lib.id
 			and fvs.facility_id = ?`, args.FacilityID).

--- a/backend/src/database/users.go
+++ b/backend/src/database/users.go
@@ -342,6 +342,8 @@ type LoginEngagementActivityWithUserInfo struct {
 func (db *DB) GetLoginEngagementActivity(userID int) (*LoginEngagementActivityWithUserInfo, error) {
 	var sessionEngagement []models.SessionEngagement
 
+	thirtyDaysAgo := time.Now().AddDate(0, 0, -30)
+
 	query := db.Table("user_session_tracking as ust").
 		Select(`ust.user_id,
 	ANY_VALUE(u.name_first) AS name_first,
@@ -351,7 +353,7 @@ func (db *DB) GetLoginEngagementActivity(userID int) (*LoginEngagementActivityWi
 	SUM(EXTRACT(EPOCH FROM ust.session_duration) / 3600) AS total_hours,
 	SUM(EXTRACT(EPOCH FROM ust.session_duration) / 60) AS total_minutes`).
 		Joins("JOIN users u ON ust.user_id = u.id").
-		Where("ust.user_id = ?", userID).
+		Where("ust.user_id = ? AND ust.session_start_ts >= ?", userID, thirtyDaysAgo).
 		Group("ust.user_id, time_interval").
 		Order("ust.user_id, time_interval")
 

--- a/backend/src/handlers/dashboard.go
+++ b/backend/src/handlers/dashboard.go
@@ -39,8 +39,8 @@ func (srv *Server) handleResidentProfile(w http.ResponseWriter, r *http.Request,
 	if err != nil {
 		return newDatabaseServiceError(err)
 	}
-
-	topLibraries, err := srv.Db.GetTopFiveLibrariesByUserID(userID)
+	args := srv.getQueryContext(r)
+	topLibraries, err := srv.Db.GetTopFiveLibrariesByUserID(userID, &args)
 	if err != nil {
 		return newDatabaseServiceError(err)
 	}

--- a/backend/src/handlers/login_flow.go
+++ b/backend/src/handlers/login_flow.go
@@ -144,7 +144,7 @@ func setLoginCookies(resp *http.Response, w http.ResponseWriter) {
 		http.SetCookie(w, &http.Cookie{
 			Name:     cookie.Name,
 			Value:    cookie.Value,
-			Expires:  time.Now().Add(24 * time.Hour),
+			Expires:  time.Now().Add(12 * time.Hour),
 			SameSite: http.SameSiteNoneMode,
 			HttpOnly: true,
 			Secure:   true,

--- a/backend/src/handlers/login_flow.go
+++ b/backend/src/handlers/login_flow.go
@@ -24,6 +24,7 @@ func (srv *Server) registerLoginFlowRoutes() []routeDef {
 }
 
 const (
+	SessionTimeout      = 12 * time.Hour
 	LoginEndpoint       = "/self-service/login"
 	LogoutEndpoint      = "/self-service/logout/browser"
 	ConsentPutEndpoint  = "/admin/oauth2/auth/requests/consent/accept"
@@ -144,7 +145,7 @@ func setLoginCookies(resp *http.Response, w http.ResponseWriter) {
 		http.SetCookie(w, &http.Cookie{
 			Name:     cookie.Name,
 			Value:    cookie.Value,
-			Expires:  time.Now().Add(12 * time.Hour),
+			Expires:  time.Now().Add(SessionTimeout),
 			SameSite: http.SameSiteNoneMode,
 			HttpOnly: true,
 			Secure:   true,
@@ -164,7 +165,7 @@ func (s *Server) handleOidcConsent(w http.ResponseWriter, r *http.Request, log s
 	defer r.Body.Close()
 	// get the user from the database
 	user, err := s.Db.GetUserByID(s.getUserID(r))
-	log.add("userId", s.getUserID(r))
+	log.add("user_id", s.getUserID(r))
 	if err != nil {
 		return newDatabaseServiceError(err)
 	}

--- a/backend/src/handlers/middleware.go
+++ b/backend/src/handlers/middleware.go
@@ -114,12 +114,8 @@ func (srv *Server) libraryProxyMiddleware(next http.Handler) http.Handler {
 				UserID:                user.UserID,
 				ContentID:             proxyParams.ID,
 			}
-			srv.Db.CreateContentActivity(urlString, &activity)
-			var bookmark models.OpenContentFavorite
-			if srv.Db.Model(&models.OpenContentFavorite{}).Where("user_id = ? AND content_id = ? AND open_content_url_id = ?", activity.UserID, activity.ContentID, activity.OpenContentUrlID).First(&bookmark).RowsAffected > 0 {
-				srv.wsClient.notifyUser(activity.UserID, []byte("true"))
-			} else {
-				srv.wsClient.notifyUser(activity.UserID, []byte("false"))
+			if !user.isAdmin() {
+				srv.createContentActivityAndNotifyWS(urlString, &activity)
 			}
 		}
 		ctx := context.WithValue(r.Context(), libraryKey, proxyParams)

--- a/backend/src/handlers/outcomes_handler_test.go
+++ b/backend/src/handlers/outcomes_handler_test.go
@@ -54,6 +54,12 @@ func getOutcomesByTypeAndOrdered(outcomeType, orderBy, order string) map[string]
 	}
 	args := getDefaultQueryCtx()
 	args.UserID = 4
+	if orderBy == "" {
+		orderBy = "created_at"
+	}
+	if order == "" {
+		order = "desc"
+	}
 	args.Order = order
 	args.OrderBy = orderBy
 	outcomes, err := server.Db.GetOutcomesForUser(&args, outType)

--- a/backend/src/handlers/utils.go
+++ b/backend/src/handlers/utils.go
@@ -72,9 +72,11 @@ func (srv *Server) getQueryContext(r *http.Request) models.QueryContext {
 			orderBy = orderBySplit[0]
 			order = orderBySplit[1]
 		}
+	} else {
+		orderBy = "created_at"
 	}
 	if order != "asc" && order != "desc" {
-		order = "asc"
+		order = "desc"
 	}
 	search := strings.TrimSpace(strings.ToLower(r.URL.Query().Get("search")))
 	tags := r.URL.Query()["tags"]

--- a/backend/src/handlers/utils.go
+++ b/backend/src/handlers/utils.go
@@ -72,8 +72,6 @@ func (srv *Server) getQueryContext(r *http.Request) models.QueryContext {
 			orderBy = orderBySplit[0]
 			order = orderBySplit[1]
 		}
-	} else {
-		orderBy = "created_at"
 	}
 	if order != "asc" && order != "desc" {
 		order = "desc"

--- a/backend/src/handlers/video_handler.go
+++ b/backend/src/handlers/video_handler.go
@@ -55,7 +55,9 @@ func (srv *Server) handleGetVideoById(w http.ResponseWriter, r *http.Request, lo
 		UserID:                user.UserID,
 		ContentID:             video.ID,
 	}
-	srv.Db.CreateContentActivity(videoViewerUrl, &activity)
+	if !user.isAdmin() {
+		srv.createContentActivityAndNotifyWS(videoViewerUrl, &activity)
+	}
 	return writeJsonResponse(w, http.StatusOK, video)
 }
 

--- a/backend/src/handlers/websockets.go
+++ b/backend/src/handlers/websockets.go
@@ -1,7 +1,9 @@
 package handlers
 
 import (
+	"UnlockEdv2/src/database"
 	"context"
+	"encoding/json"
 	"net/http"
 	"sync"
 	"time"
@@ -18,12 +20,45 @@ const (
 	bytesBuffer = 256
 )
 
+type WsEventType string
+
+const (
+	ClientHello   WsEventType = "client_hello"
+	ClientGoodbye WsEventType = "client_goodbye"
+	VisitEvent    WsEventType = "visits"
+	BookmarkEvent WsEventType = "bookmarks"
+)
+
+type MsgContent struct {
+	ActivityID int64  `json:"activity_id"`
+	Msg        string `json:"msg"`
+}
+
+type WsMsg struct {
+	EventType WsEventType `json:"event_type"`
+	UserID    uint        `json:"user_id"`
+	SessionID string      `json:"session_id"`
+	Msg       MsgContent  `json:"msg"`
+}
+
+func (ws *WsMsg) getClientKey() uint {
+	return ws.UserID
+}
+
 type WsClient struct {
-	Conn     *websocket.Conn
-	UserID   uint
-	ctx      context.Context
-	cancel   context.CancelFunc
-	sendChan chan []byte
+	Conn                  *websocket.Conn
+	UserID                uint
+	EventType             WsEventType
+	SessionID             string
+	OpenContentActivityID int64
+	ctx                   context.Context
+	cancel                context.CancelFunc
+	sendChan              chan []byte
+	mutex                 sync.Mutex
+}
+
+func (ws *WsClient) getClientKey() uint {
+	return ws.UserID
 }
 
 type ClientManager struct {
@@ -38,42 +73,62 @@ func newClientManager() *ClientManager {
 	}
 }
 
-func (cm *ClientManager) addClient(userId uint, client *WsClient) {
+func (cm *ClientManager) addClient(client *WsClient) {
 	cm.mutex.Lock()
 	defer cm.mutex.Unlock()
-	if cm.clients[userId] == nil {
-		cm.clients[userId] = client
-		log.Infof("Added client with user_id %d", userId)
+	clientKey := client.getClientKey()
+	if cm.clients[clientKey] == nil {
+		cm.clients[clientKey] = client
+		log.Infof("Added client with key/user_id %d", clientKey)
 	} else {
-		log.Warnf("Client already existed with user_id %d", userId)
+		log.Warnf("Client already existed with key/user_id %d", clientKey)
 	}
 }
 
-func (cm *ClientManager) removeClient(userId uint, client *WsClient, reason string) {
-	client.cancel()
-	err := client.Conn.Close(websocket.StatusNormalClosure, reason)
-	if err != nil {
-		log.Errorf("Failed to close connection: %v", err)
-	}
+func (cm *ClientManager) removeClient(client *WsClient, reason string) {
 	cm.mutex.Lock()
 	defer cm.mutex.Unlock()
-	if cm.clients[userId] != nil {
-		log.Infof("Removing client user_id %d", client.UserID)
-		delete(cm.clients, userId)
+	if client.Conn == nil {
+		log.Warn("Connection already closed, skipping removal.")
+		return
+	}
+	clientKey := client.getClientKey()
+	if cm.clients[clientKey] != nil {
+		log.Infof("Removing client key/user_id %d", clientKey)
+		err := client.Conn.Close(websocket.StatusNormalClosure, reason)
+		if err != nil {
+			log.Errorf("Failed to close connection: %v", err)
+		}
+		delete(cm.clients, clientKey)
+		client.Conn = nil
+		client.cancel()
 	}
 }
 
-func (cm *ClientManager) notifyUser(userId uint, message []byte) {
+func (cm *ClientManager) notifyUser(event WsMsg) {
+	clientKey := event.getClientKey()
 	cm.mutex.RLock()
-	defer cm.mutex.RUnlock()
-	if client, ok := cm.clients[userId]; ok {
-		client.send(message)
+	client, exists := cm.clients[clientKey]
+	cm.mutex.RUnlock()
+	if exists {
+		client.mutex.Lock()
+		defer client.mutex.Unlock()
+		client.send(event)
+		return
 	}
 }
 
-func (client *WsClient) send(message []byte) {
-	log.Infof("Sending message to user_id %d, message: %s", client.UserID, message)
-	client.sendChan <- message
+func (client *WsClient) send(event WsMsg) {
+	log.Infof("Sending message to user_id %d, message: %s, activityID: %d", client.UserID, event.Msg.Msg, event.Msg.ActivityID)
+	if event.Msg.ActivityID > 0 {
+		client.OpenContentActivityID = event.Msg.ActivityID
+	}
+	response, err := json.Marshal(event)
+	if err != nil {
+		log.Errorf("Failed to marshal event: %v", err)
+		return
+	}
+	client.sendChan <- response
 }
 
 func (client *WsClient) writePump() {
@@ -107,28 +162,71 @@ func (srv *Server) handleWebsocketConnection(w http.ResponseWriter, r *http.Requ
 		cancel:   cancel,
 		sendChan: make(chan []byte, bytesBuffer),
 	}
-	srv.wsClient.addClient(user.UserID, client)
+	srv.handleIfClientExists(client, "connected from a different device or tab")
+	srv.wsClient.addClient(client)
 	go client.writePump()
 	go srv.handleWsHeartbeat(client)
 	go srv.handleWsReader(ctx, client)
 	<-ctx.Done()
-	srv.wsClient.removeClient(user.UserID, client, "") //this removes client
+	srv.wsClient.removeClient(client, "")
 	return nil
+}
+
+func (cm *ClientManager) handleCleanup(db *database.DB, clientKey uint) {
+	cm.mutex.RLock()
+	defer cm.mutex.RUnlock()
+	client, ok := cm.clients[clientKey]
+	if !ok {
+		return
+	}
+	if client.SessionID != "" {
+		db.LogUserSessionEnded(client.UserID, client.SessionID)
+	}
+	if client.OpenContentActivityID > 0 {
+		db.UpdateOpenContentActivityStopTS(client.OpenContentActivityID)
+	}
+}
+
+func (srv *Server) handleIfClientExists(client *WsClient, reason string) {
+	clientKey := client.getClientKey()
+	existingClient, exists := srv.wsClient.clients[clientKey]
+	if exists {
+		log.Warnf("client exists for key/user_id %d. Closing connection.", clientKey)
+		srv.wsClient.handleCleanup(srv.Db, clientKey)
+		srv.wsClient.removeClient(existingClient, reason)
+	}
 }
 
 func (srv *Server) handleWsReader(ctx context.Context, client *WsClient) {
 	defer client.cancel()
 	for {
-		_, _, err := client.Conn.Read(ctx)
-		if err != nil {
+		_, msg, err := client.Conn.Read(ctx)
+		if err != nil { //if there was an error then we should attempt a clean up
 			if websocket.CloseStatus(err) == websocket.StatusNormalClosure ||
 				websocket.CloseStatus(err) == websocket.StatusGoingAway {
 				log.Info("WebSocket connection closed by client")
+				srv.handleIfClientExists(client, "websocket closed, unable to read message")
 			} else {
-				log.Errorf("Error reading from WebSocket: %v", err)
+				log.Warnf("Error reading from WebSocket, due to frontend closure")
 			}
-			srv.wsClient.removeClient(client.UserID, client, "reading from client failed")
+			srv.wsClient.removeClient(client, "websocket closed, unable to read message")
 			return
+		}
+		var event WsMsg
+		if err := json.Unmarshal(msg, &event); err != nil {
+			log.Warnf("Invalid message event from user %d: %v", client.UserID, err)
+			continue
+		}
+		switch event.EventType {
+		case VisitEvent:
+			srv.Db.UpdateOpenContentActivityStopTS(event.Msg.ActivityID)
+		case ClientGoodbye:
+			srv.Db.LogUserSessionEnded(event.UserID, event.SessionID)
+		case ClientHello:
+			client.SessionID = event.SessionID
+			srv.Db.LogUserSessionStarted(client.UserID, event.SessionID)
+		default:
+			log.Warnf("Invalid event type %s", event.EventType)
 		}
 	}
 }
@@ -141,9 +239,10 @@ func (srv *Server) handleWsHeartbeat(client *WsClient) {
 		case <-client.ctx.Done():
 			return
 		case <-ticker.C:
+			log.Info("sending ping...")
 			if err := client.Conn.Ping(client.ctx); err != nil {
 				log.Errorf("Failed to send ping: %v", err)
-				srv.wsClient.removeClient(client.UserID, client, "ping failed")
+				srv.wsClient.removeClient(client, "ping failed")
 				return
 			}
 		}

--- a/backend/src/models/logins.go
+++ b/backend/src/models/logins.go
@@ -37,22 +37,19 @@ func (UserSessionTracking) TableName() string { return "user_session_tracking" }
 
 type SessionEngagement struct {
 	UserId       int64   `json:"user_id"`
-	NameFirst    string  `json:"name_first"`
-	NameLast     string  `json:"name_last"`
-	Username     string  `json:"username"`
 	TimeInterval string  `json:"time_interval"`
 	TotalMinutes float64 `json:"total_minutes"`
 	TotalHours   float64 `json:"total_hours"`
 }
 
 type EngagementActivityMetrics struct {
-	UserID                   int64     `json:"user_id"`
-	TotalActiveDaysMonthly   int64     `json:"total_active_days_monthly"`
-	TotalHoursActiveMonthly  float64   `json:"total_hours_active_monthly"`
-	TotalHoursActiveWeekly   float64   `json:"total_hours_active_weekly"`
-	TotalMinutesActiveWeekly float64   `json:"total_minutes_active_weekly"`
-	TotalHoursEngaged        float64   `json:"total_hours_engaged"`
-	TotalMinutesEngaged      float64   `json:"total_minutes_engaged"`
-	FirstActiveDate          time.Time `json:"first_active_date"`
-	LastActiveDate           time.Time `json:"last_active_date"`
+	UserID                   int64      `json:"user_id"`
+	TotalActiveDaysMonthly   int64      `json:"total_active_days_monthly"`
+	TotalHoursActiveMonthly  float64    `json:"total_hours_active_monthly"`
+	TotalHoursActiveWeekly   float64    `json:"total_hours_active_weekly"`
+	TotalMinutesActiveWeekly float64    `json:"total_minutes_active_weekly"`
+	TotalHoursEngaged        float64    `json:"total_hours_engaged"`
+	TotalMinutesEngaged      float64    `json:"total_minutes_engaged"`
+	Joined                   time.Time  `json:"joined"`
+	LastActiveDate           *time.Time `json:"last_active_date"`
 }

--- a/backend/src/models/logins.go
+++ b/backend/src/models/logins.go
@@ -21,3 +21,38 @@ type LoginActivity struct {
 }
 
 func (LoginActivity) TableName() string { return "login_activity" }
+
+type UserSessionTracking struct {
+	ID              int64     `gorm:"primaryKey;autoIncrement" json:"id"`
+	UserID          uint      `gorm:"not null" json:"user_id"`
+	SessionID       string    `gorm:"size:255;not null" json:"session_id"`
+	SessionStartTS  time.Time `gorm:"default:CURRENT_TIMESTAMP" json:"session_start_ts"`
+	SessionEndTS    time.Time `gorm:"default:NULL" json:"session_end_ts"`
+	SessionDuration string    `gorm:"->;type:interval;generated always as (session_end_ts - session_start_ts) stored" json:"-"`
+
+	User *User `json:"user,omitempty" gorm:"foreignKey:UserID;constraint:OnDelete CASCADE"`
+}
+
+func (UserSessionTracking) TableName() string { return "user_session_tracking" }
+
+type SessionEngagement struct {
+	UserId       int64   `json:"user_id"`
+	NameFirst    string  `json:"name_first"`
+	NameLast     string  `json:"name_last"`
+	Username     string  `json:"username"`
+	TimeInterval string  `json:"time_interval"`
+	TotalMinutes float64 `json:"total_minutes"`
+	TotalHours   float64 `json:"total_hours"`
+}
+
+type EngagementActivityMetrics struct {
+	UserID                   int64     `json:"user_id"`
+	TotalActiveDaysMonthly   int64     `json:"total_active_days_monthly"`
+	TotalHoursActiveMonthly  float64   `json:"total_hours_active_monthly"`
+	TotalHoursActiveWeekly   float64   `json:"total_hours_active_weekly"`
+	TotalMinutesActiveWeekly float64   `json:"total_minutes_active_weekly"`
+	TotalHoursEngaged        float64   `json:"total_hours_engaged"`
+	TotalMinutesEngaged      float64   `json:"total_minutes_engaged"`
+	FirstActiveDate          time.Time `json:"first_active_date"`
+	LastActiveDate           time.Time `json:"last_active_date"`
+}

--- a/backend/src/models/open_content.go
+++ b/backend/src/models/open_content.go
@@ -22,12 +22,14 @@ type OpenContentProvider struct {
 }
 
 type OpenContentActivity struct {
+	ID                    int64     `gorm:"primaryKey" json:"id"`
 	OpenContentProviderID uint      `gorm:"not null" json:"open_content_provider_id"`
 	FacilityID            uint      `gorm:"not null" json:"facility_id"`
 	UserID                uint      `gorm:"not null" json:"user_id"`
 	ContentID             uint      `gorm:"not null" json:"content_id"`
 	OpenContentUrlID      uint      `gorm:"not null" json:"open_content_url_id"`
 	RequestTS             time.Time `gorm:"type:datetime;default:CURRENT_TIMESTAMP" json:"request_ts"`
+	StopTS                time.Time `gorm:"type:datetime;default:NULL" json:"stop_ts"`
 
 	User                *User                `gorm:"foreignKey:UserID" json:"-"`
 	OpenContentProvider *OpenContentProvider `gorm:"foreignKey:OpenContentProviderID;constraint:OnUpdate:CASCADE,OnDelete:SET NULL" json:"open_content_provider"`

--- a/frontend/src/Components/LibraryLayout.tsx
+++ b/frontend/src/Components/LibraryLayout.tsx
@@ -71,7 +71,7 @@ export default function LibaryLayout({
         error: librariesError,
         isLoading: librariesLoading
     } = useSWR<ServerResponseMany<Library>, AxiosError>(
-        `/api/libraries?page=${pageQuery}&per_page=${perPage}&order_by=created_at%20desc&visibility=${isAdministrator(user) && !adminWithStudentView() ? filterVisibilityAdmin : 'visible'}&search=${searchTerm}&${categoryQueryString}`
+        `/api/libraries?page=${pageQuery}&per_page=${perPage}&order_by=created_at&order=desc&visibility=${isAdministrator(user) && !adminWithStudentView() ? filterVisibilityAdmin : 'visible'}&search=${searchTerm}&${categoryQueryString}`
     );
 
     const librariesMeta = libraries?.meta ?? {

--- a/frontend/src/Components/OpenContentItemAccordion.tsx
+++ b/frontend/src/Components/OpenContentItemAccordion.tsx
@@ -5,7 +5,7 @@ import {
     BookOpenIcon,
     InformationCircleIcon
 } from '@heroicons/react/24/solid';
-import React, { useState } from 'react';
+import { useState } from 'react';
 import OpenContentCard from './cards/OpenContentCard';
 
 type OpenContentItemMap = Record<string, OpenContentItem[]>;
@@ -75,13 +75,15 @@ export default function OpenContentItemAccordion({
                     </button>
                     <div
                         className={`transition-[max-height] duration-400 ${
-                            activeKey === title ? 'overflow-visible max-h-[800px]' : 'max-h-0 overflow-hidden'
+                            activeKey === title
+                                ? 'overflow-visible max-h-[800px]'
+                                : 'max-h-0 overflow-hidden'
                         }`}
                     >
                         <div className="flex flex-col gap-4">
                             {contentItems.map((item) => (
                                 <OpenContentCard
-                                    key={item.content_id}
+                                    key={item.url}
                                     content={item}
                                 />
                             ))}

--- a/frontend/src/Components/OperationalInsightsCharts.tsx
+++ b/frontend/src/Components/OperationalInsightsCharts.tsx
@@ -183,10 +183,9 @@ const OperationalInsights = () => {
                                 >
                                     <EngagementRateGraph
                                         data={
-                                            metrics?.data
-                                                .user_engagement_times || []
+                                            metrics?.data.peak_login_times || []
                                         }
-                                        viewType="hourly"
+                                        viewType="peakLogin"
                                     />
                                 </ResponsiveContainer>
                             </div>

--- a/frontend/src/Components/OperationalInsightsCharts.tsx
+++ b/frontend/src/Components/OperationalInsightsCharts.tsx
@@ -182,9 +182,11 @@ const OperationalInsights = () => {
                                     debounce={500}
                                 >
                                     <EngagementRateGraph
-                                        peak_login_times={
-                                            metrics?.data.peak_login_times || []
+                                        data={
+                                            metrics?.data
+                                                .user_engagement_times || []
                                         }
+                                        viewType="hourly"
                                     />
                                 </ResponsiveContainer>
                             </div>

--- a/frontend/src/Components/StatsCard.tsx
+++ b/frontend/src/Components/StatsCard.tsx
@@ -5,12 +5,14 @@ interface StatsCardProps {
     number: string;
     label: string;
     tooltip?: string;
+    useToLocaleString?: boolean; //true will be the default bc component already existed with the formatNumber function operating on the number that is passed into the function
 }
 export default function StatsCard({
     title,
     number,
     label,
-    tooltip
+    tooltip,
+    useToLocaleString = true
 }: StatsCardProps) {
     const formatNumber = (num: string) => {
         return parseInt(num).toLocaleString('en-US');
@@ -31,7 +33,7 @@ export default function StatsCard({
                 )}
             </div>
             <p className="text-teal-3 text-4xl font-bold mt-4">
-                {formatNumber(number)}
+                {useToLocaleString ? formatNumber(number) : number}
                 <span className="text-teal-4 text-base font-bold ml-3">
                     {label[0].toUpperCase() + label.slice(1)}
                 </span>

--- a/frontend/src/Components/VideoEmbedViewer.tsx
+++ b/frontend/src/Components/VideoEmbedViewer.tsx
@@ -27,6 +27,9 @@ export default function VideoViewer() {
             }
         };
         void fetchVideoData();
+        return () => {
+            window.websocket?.notifyOpenContentActivity(true);
+        };
     }, [videoId]);
 
     const handleError = () => {

--- a/frontend/src/Components/cards/OpenContentCard.tsx
+++ b/frontend/src/Components/cards/OpenContentCard.tsx
@@ -15,7 +15,11 @@ export default function OpenContentCardRow({
             content.content_type === 'video'
                 ? `/viewer/videos/${content.content_id}`
                 : `/viewer/libraries/${content.content_id}`;
-        navigate(basePath);
+        const obj =
+            content.content_type === 'library'
+                ? { state: { url: content.url, title: content.title } }
+                : {};
+        navigate(basePath, obj);
     }
     return (
         <div

--- a/frontend/src/Layouts/AuthenticatedLayout.tsx
+++ b/frontend/src/Layouts/AuthenticatedLayout.tsx
@@ -4,6 +4,8 @@ import { useMatches, UIMatch, Outlet, useLoaderData } from 'react-router-dom';
 import PageNav from '@/Components/PageNav';
 import { Facility, RouteLabel } from '@/common';
 import { PageTitleProvider } from '@/Context/AuthLayoutPageTitleContext';
+import WebsocketSession from '@/session_ws';
+import { useAuth } from '@/useAuth';
 
 // Extend RouteMatch with custom RouteMeta
 interface CustomRouteMatch extends UIMatch {
@@ -11,6 +13,10 @@ interface CustomRouteMatch extends UIMatch {
 }
 
 export default function AuthenticatedLayout() {
+    const { user } = useAuth();
+    if (!window.websocket && user) {
+        window.websocket = new WebsocketSession(user);
+    }
     const matches = useMatches() as CustomRouteMatch[];
     const currentMatch = matches.find((match) => match?.handle?.title);
     const facilities = useLoaderData() as Facility[] | null;

--- a/frontend/src/Pages/ResidentProfile.tsx
+++ b/frontend/src/Pages/ResidentProfile.tsx
@@ -11,7 +11,7 @@ import StatsCard from '@/Components/StatsCard';
 import { UserCircleIcon } from '@heroicons/react/24/outline';
 import { useNavigate, useParams } from 'react-router-dom';
 
-const StudentProfile = () => {
+const ResidentProfile = () => {
     const { user_id } = useParams<{ user_id: string }>();
     const { data, error, isLoading } = useSWR<
         ServerResponseOne<ResidentEngagementProfile>,
@@ -144,7 +144,7 @@ const StudentProfile = () => {
                                                         ?.user_engagement_times ??
                                                     []
                                                 }
-                                                viewType="daily"
+                                                viewType="userEngagement"
                                             />
                                         </ResponsiveContainer>
                                     </div>
@@ -298,4 +298,4 @@ const StudentProfile = () => {
     );
 };
 
-export default StudentProfile;
+export default ResidentProfile;

--- a/frontend/src/Pages/ResidentProfile.tsx
+++ b/frontend/src/Pages/ResidentProfile.tsx
@@ -40,14 +40,6 @@ const ResidentProfile = () => {
 
     const weekLabel = isLessThanOneHour ? 'Minutes' : 'Hours';
 
-    const avgToolTip = isLessAvgThanOneHour
-        ? 'Average minutes logged in to UnlockedEd'
-        : 'Average hours logged in to UnlockedEd';
-
-    const weekToolTip = isLessThanOneHour
-        ? 'Total number of minutes resident was logged in to UnlockedEd this week'
-        : 'Total number of hours resident was logged in to UnlockedEd this week';
-
     const navigate = useNavigate();
     const handleShowLibraryClick = (id: number) => {
         navigate(`/viewer/libraries/${id}`);
@@ -63,9 +55,9 @@ const ResidentProfile = () => {
                         <div className="w-[300px] h-[240px] flex flex-col gap-4">
                             <div className="card p-4 overflow-hidden flex-1 h-full text-grey-4">
                                 <div className="justify-items-center">
-                                    <UserCircleIcon className="w-[64px] h-[64px]" />
+                                    <UserCircleIcon className="w-[80px] h-[80px]" />
                                 </div>
-                                <div className="">
+                                <div className="mt-auto">
                                     <div className="text-2xl text-center">
                                         {
                                             metrics?.session_engagement
@@ -76,7 +68,7 @@ const ResidentProfile = () => {
                                                 .user_info.name_last
                                         }
                                     </div>
-                                    <div className="text -base">
+                                    <div className="text-base">
                                         <div className="grid grid-cols-2">
                                             <p>Username</p>
                                             <div className="flex flex-row justify-between">
@@ -128,7 +120,7 @@ const ResidentProfile = () => {
                             <div className="card card-row-padding overflow-hidden">
                                 <h1 className="">
                                     {metrics?.session_engagement.user_info
-                                        .name_first + " 's recent Activity"}
+                                        .name_first + "'s Activity"}
                                 </h1>
                                 <div className=" items-stretch">
                                     <div className="w-full h-[240px] overflow-visible">
@@ -164,7 +156,7 @@ const ResidentProfile = () => {
                             useToLocaleString={false}
                         />
                         <StatsCard
-                            title="Avg Hours Per Week"
+                            title="Avg Time Per Week"
                             number={
                                 parseFloat(avgNumber) === 0
                                     ? '0'
@@ -173,11 +165,11 @@ const ResidentProfile = () => {
                                       : avgNumber
                             }
                             label={avgLabel}
-                            tooltip={avgToolTip}
+                            tooltip="Average time spent in UnlockEd per week"
                             useToLocaleString={false}
                         />
                         <StatsCard
-                            title="Total Hours This Week"
+                            title="Total Time This Week"
                             number={
                                 parseFloat(weekNumber) === 0
                                     ? '0'
@@ -186,7 +178,7 @@ const ResidentProfile = () => {
                                       : weekNumber
                             }
                             label={weekLabel}
-                            tooltip={weekToolTip}
+                            tooltip="Total time spent in UnlockEd this week"
                         />
                     </div>
                     {/* Tables */}

--- a/frontend/src/Pages/ResidentProfile.tsx
+++ b/frontend/src/Pages/ResidentProfile.tsx
@@ -115,7 +115,7 @@ const ResidentProfile = () => {
                             <div className="card card-row-padding overflow-hidden">
                                 <h1 className="">
                                     {metrics?.user.name_first +
-                                        "'s recent Activity"}
+                                        "'s Recent Activity"}
                                 </h1>
                                 <div className=" items-stretch">
                                     <div className="w-full h-[240px] overflow-visible">

--- a/frontend/src/Pages/ResidentProfile.tsx
+++ b/frontend/src/Pages/ResidentProfile.tsx
@@ -59,34 +59,24 @@ const ResidentProfile = () => {
                                 </div>
                                 <div className="mt-auto">
                                     <div className="text-2xl text-center">
-                                        {
-                                            metrics?.session_engagement
-                                                .user_info.name_first
-                                        }{' '}
-                                        {
-                                            metrics?.session_engagement
-                                                .user_info.name_last
-                                        }
+                                        {metrics?.user.name_first}{' '}
+                                        {metrics?.user.name_last}
                                     </div>
                                     <div className="text-base">
                                         <div className="grid grid-cols-2">
                                             <p>Username</p>
                                             <div className="flex flex-row justify-between">
                                                 <p>:</p>
-                                                {
-                                                    metrics?.session_engagement
-                                                        .user_info.username
-                                                }
+                                                {metrics.user.username}
                                             </div>
                                         </div>
                                         <div className="grid grid-cols-2">
                                             <p>Joined</p>
                                             <div className="flex flex-row justify-between">
                                                 <p>:</p>
-                                                {metrics?.activity_engagement
-                                                    ?.first_active_date
+                                                {metrics?.user.created_at
                                                     ? new Date(
-                                                          metrics.activity_engagement.first_active_date
+                                                          metrics.activity_engagement.joined
                                                       ).toLocaleDateString(
                                                           'en-US',
                                                           {
@@ -102,13 +92,17 @@ const ResidentProfile = () => {
                                             <p>Last Active</p>
                                             <div className="flex flex-row justify-between">
                                                 <p>:</p>
-                                                {new Date(
-                                                    metrics.activity_engagement.last_active_date
-                                                ).toLocaleDateString('en-US', {
-                                                    year: 'numeric',
-                                                    month: 'short',
-                                                    day: 'numeric'
-                                                })}
+                                                {metrics.activity_engagement
+                                                    .last_active_date
+                                                    ? new Date().toLocaleDateString(
+                                                          'en-US',
+                                                          {
+                                                              year: 'numeric',
+                                                              month: 'short',
+                                                              day: 'numeric'
+                                                          }
+                                                      )
+                                                    : 'N/A'}
                                             </div>
                                         </div>
                                     </div>
@@ -119,8 +113,8 @@ const ResidentProfile = () => {
                         <div className="flex-1 h-[240px] flex flex-col gap-4">
                             <div className="card card-row-padding overflow-hidden">
                                 <h1 className="">
-                                    {metrics?.session_engagement.user_info
-                                        .name_first + "'s Activity"}
+                                    {metrics?.user.name_first +
+                                        "'s recent Activity"}
                                 </h1>
                                 <div className=" items-stretch">
                                     <div className="w-full h-[240px] overflow-visible">
@@ -132,8 +126,7 @@ const ResidentProfile = () => {
                                         >
                                             <EngagementRateGraph
                                                 data={
-                                                    metrics?.session_engagement
-                                                        ?.user_engagement_times ??
+                                                    metrics?.session_engagement ??
                                                     []
                                                 }
                                                 viewType="userEngagement"

--- a/frontend/src/Pages/ResidentProfile.tsx
+++ b/frontend/src/Pages/ResidentProfile.tsx
@@ -10,6 +10,7 @@ import { ResponsiveContainer } from 'recharts';
 import StatsCard from '@/Components/StatsCard';
 import { UserCircleIcon } from '@heroicons/react/24/outline';
 import { useNavigate, useParams } from 'react-router-dom';
+import ClampedText from '@/Components/ClampedText';
 
 const ResidentProfile = () => {
     const { user_id } = useParams<{ user_id: string }>();
@@ -222,59 +223,43 @@ const ResidentProfile = () => {
                                     )}
                                 </tbody>
                             </table>
-                            <div className="border-t border-gray-300 mt-2"></div>
+                            <div className="border-t border-grey-300 mt-2"></div>
                             <p className="text-xs text-grey-4 italic">
-                                * Data is based on recent video performance and
-                                may not reflect all content.
+                                * Featured library
                             </p>
                         </div>
                         {/* <div></div> */}
                         <div className="card pt-2 px-3">
-                            <div className="text-teal-4 text-center text-lg font-semibold">
-                                Top 5 Recently Watched Videos
+                            <div className="text-teal-4 text-center text-lg font-semibold border-b border-b-grey-300">
+                                Recently Watched Videos
                             </div>
-                            <table className="table-2 mb-4">
-                                <thead>
-                                    <tr className="grid-col-2"></tr>
-                                </thead>
-                                <tbody className="grid-col-2">
-                                    {metrics.recent_videos.length > 0 ? (
-                                        metrics.recent_videos.map(
-                                            (
-                                                items: OpenContentResponse,
-                                                index: number
-                                            ) => {
-                                                return (
-                                                    <tr
-                                                        className="justify-items-center"
-                                                        key={index}
-                                                    >
-                                                        <td className="justify-self-end truncate w-full">
-                                                            <img
-                                                                className="h-8 mx-auto object-contain"
-                                                                src={
-                                                                    items.thumbnail_url ??
-                                                                    ''
-                                                                }
-                                                            />
-                                                            {items.title ??
-                                                                'Untitled'}
-                                                        </td>
-                                                    </tr>
-                                                );
-                                            }
-                                        )
-                                    ) : (
-                                        <tr className="justify-items-center">
-                                            <td className="justify-self-start">
-                                                No Videos Found
-                                            </td>
-                                            <td></td>
-                                            <td className="justify-self-end"></td>
-                                        </tr>
-                                    )}
-                                </tbody>
-                            </table>
+                            <div className="grid grid-cols-2 gap-4 mb-4 mt-4">
+                                {metrics.recent_videos.length > 0 ? (
+                                    metrics.recent_videos.map((item, index) => (
+                                        <div
+                                            key={index}
+                                            className="flex flex-col items-center"
+                                        >
+                                            <img
+                                                className="h-8 object-contain"
+                                                src={item.thumbnail_url ?? ''}
+                                                alt={item.title ?? 'Untitled'}
+                                            />
+                                            <ClampedText
+                                                className="text-xs"
+                                                as={'span'}
+                                                lines={2}
+                                            >
+                                                {item.title ?? 'Untitled'}
+                                            </ClampedText>
+                                        </div>
+                                    ))
+                                ) : (
+                                    <div className="col-span-2 text-center">
+                                        No Videos Found
+                                    </div>
+                                )}
+                            </div>
                         </div>
                     </div>
                 </>

--- a/frontend/src/Pages/StudentManagement.tsx
+++ b/frontend/src/Pages/StudentManagement.tsx
@@ -198,7 +198,7 @@ export default function StudentManagement() {
                                     return (
                                         <tr
                                             key={user.id}
-                                            className="card p-4 w-full grid-cols-4 justify-items-center cursor-pointer"
+                                            className="card p-4 w-full grid-cols-5 justify-items-center cursor-pointer"
                                             onClick={() =>
                                                 handleShowUserProfileClick(
                                                     user.id

--- a/frontend/src/Pages/StudentManagement.tsx
+++ b/frontend/src/Pages/StudentManagement.tsx
@@ -34,6 +34,7 @@ import {
     TextOnlyModal
 } from '@/Components/modals';
 import { useCheckResponse } from '@/Hooks/useCheckResponse';
+import { useNavigate } from 'react-router-dom';
 
 export default function StudentManagement() {
     const addUserModal = useRef<HTMLDialogElement>(null);
@@ -134,6 +135,13 @@ export default function StudentManagement() {
         setPageQuery(1);
         void mutate();
     };
+
+    const navigate = useNavigate();
+
+    const handleShowUserProfileClick = (id: number) => {
+        navigate(`/residents/${id}`);
+    };
+
     return (
         <div>
             <div className="flex flex-col space-y-6 overflow-x-auto rounded-lg p-4 px-5">
@@ -190,7 +198,12 @@ export default function StudentManagement() {
                                     return (
                                         <tr
                                             key={user.id}
-                                            className="card p-4 w-full grid-cols-5 justify-items-center"
+                                            className="card p-4 w-full grid-cols-4 justify-items-center cursor-pointer"
+                                            onClick={() =>
+                                                handleShowUserProfileClick(
+                                                    user.id
+                                                )
+                                            }
                                         >
                                             <td className="justify-self-start">
                                                 {user.name_first}{' '}
@@ -243,7 +256,8 @@ export default function StudentManagement() {
                                                         }
                                                         tooltipClassName="tooltip-left cursor-pointer"
                                                         icon={PencilSquareIcon}
-                                                        onClick={() => {
+                                                        onClick={(e) => {
+                                                            e?.stopPropagation();
                                                             setTargetUser({
                                                                 action: CRUDActions.Edit,
                                                                 target: user
@@ -262,7 +276,8 @@ export default function StudentManagement() {
                                                         icon={
                                                             ArrowPathRoundedSquareIcon
                                                         }
-                                                        onClick={() => {
+                                                        onClick={(e) => {
+                                                            e?.stopPropagation();
                                                             setTargetUser({
                                                                 action: CRUDActions.Reset,
                                                                 target: user
@@ -279,7 +294,8 @@ export default function StudentManagement() {
                                                         }
                                                         tooltipClassName="tooltip-left cursor-pointer"
                                                         icon={TrashIcon}
-                                                        onClick={() => {
+                                                        onClick={(e) => {
+                                                            e?.stopPropagation();
                                                             setTargetUser({
                                                                 action: CRUDActions.Delete,
                                                                 target: user

--- a/frontend/src/Pages/StudentProfile.tsx
+++ b/frontend/src/Pages/StudentProfile.tsx
@@ -33,22 +33,19 @@ const StudentProfile = () => {
               2
           );
 
-    const weekNumber = isLessThanOneHour ? (metrics?.activity_engagement.total_minutes_engaged ?? 0).toFixed(2) :
-        (metrics?.activity_engagement.total_hours_engaged ?? 0).toFixed(2);
-  
-    const avgLabel = isLessAvgThanOneHour
-        ? 'AVG Minutes PER Week'
-        : 'AVG Hours PER Week';
+    const weekNumber = isLessThanOneHour
+        ? (metrics?.activity_engagement.total_minutes_engaged ?? 0).toFixed(2)
+        : (metrics?.activity_engagement.total_hours_engaged ?? 0).toFixed(2);
 
-        const weekLabel = isLessThanOneHour
-        ? 'Total Minutes This Week'
-        : 'Total Hours This Week';
+    const avgLabel = isLessAvgThanOneHour ? 'Min' : 'Hrs';
+
+    const weekLabel = isLessThanOneHour ? 'Minutes' : 'Hours';
 
     const avgToolTip = isLessAvgThanOneHour
-        ? 'Average number of minutes resident is logged in to UnlockedEd'
-        : 'Average number of hours resident is logged in to UnlockedEd';
+        ? 'Average minutes logged in to UnlockedEd'
+        : 'Average hours logged in to UnlockedEd';
 
-        const weekToolTip = isLessThanOneHour
+    const weekToolTip = isLessThanOneHour
         ? 'Total number of minutes resident was logged in to UnlockedEd this week'
         : 'Total number of hours resident was logged in to UnlockedEd this week';
 
@@ -59,13 +56,13 @@ const StudentProfile = () => {
             {data && metrics && (
                 <>
                     <div className="flex flex-row gap-6 items-stretch">
-                        <div className="w-[270px] h-[240px] flex flex-col gap-4">
-                            <div className="card card-row-padding overflow-hidden text-med text-teal-4 flex-1 h-full">
+                        <div className="w-[300px] h-[240px] flex flex-col gap-4">
+                            <div className="card p-4 overflow-hidden flex-1 h-full text-grey-4">
                                 <div className="justify-items-center">
                                     <UserCircleIcon className="w-[64px] h-[64px]" />
                                 </div>
                                 <div className="">
-                                    <div className="text-md mt-2">
+                                    <div className="text-2xl text-center">
                                         {
                                             metrics?.session_engagement
                                                 .user_info.name_first
@@ -75,31 +72,49 @@ const StudentProfile = () => {
                                                 .user_info.name_last
                                         }
                                     </div>
-                                    <div className="text-sm mt-2">
-                                        <span className="font-semibold  justify-self-start">
-                                            Username
-                                        </span>
-                                        {' : '}
-                                        {
-                                            metrics?.session_engagement
-                                                .user_info.username
-                                        }
-                                    </div>
-                                    <div className="text-sm mt-2">
-                                        <span className="font-semibold">
-                                            Joined :
-                                        </span>{' '}
-                                        {new Date(
-                                            metrics.activity_engagement.first_active_date
-                                        ).toLocaleDateString('en-US')}
-                                    </div>
-                                    <div className="text-sm mt-2">
-                                        <span className="font-semibold">
-                                            Last Active :
-                                        </span>{' '}
-                                        {new Date(
-                                            metrics.activity_engagement.last_active_date
-                                        ).toLocaleDateString('en-US')}
+                                    <div className="text -base">
+                                        <div className="grid grid-cols-2">
+                                            <p>Username</p>
+                                            <div className="flex flex-row justify-between">
+                                                <p>:</p>
+                                                {
+                                                    metrics?.session_engagement
+                                                        .user_info.username
+                                                }
+                                            </div>
+                                        </div>
+                                        <div className="grid grid-cols-2">
+                                            <p>Joined</p>
+                                            <div className="flex flex-row justify-between">
+                                                <p>:</p>
+                                                {metrics?.activity_engagement
+                                                    ?.first_active_date
+                                                    ? new Date(
+                                                          metrics.activity_engagement.first_active_date
+                                                      ).toLocaleDateString(
+                                                          'en-US',
+                                                          {
+                                                              year: 'numeric',
+                                                              month: 'short',
+                                                              day: 'numeric'
+                                                          }
+                                                      )
+                                                    : 'No Date Available'}
+                                            </div>
+                                        </div>
+                                        <div className="grid grid-cols-2">
+                                            <p>Last Active</p>
+                                            <div className="flex flex-row justify-between">
+                                                <p>:</p>
+                                                {new Date(
+                                                    metrics.activity_engagement.last_active_date
+                                                ).toLocaleDateString('en-US', {
+                                                    year: 'numeric',
+                                                    month: 'short',
+                                                    day: 'numeric'
+                                                })}
+                                            </div>
+                                        </div>
                                     </div>
                                 </div>
                             </div>
@@ -141,20 +156,32 @@ const StudentProfile = () => {
                             number={metrics.activity_engagement.total_active_days_monthly.toFixed(
                                 0
                             )}
-                            label="Days Active This Month"
-                            tooltip="Total number of days resident has been active in UnlockedEd"
+                            label="Days"
+                            tooltip="Total days active in UnlockEd"
                             useToLocaleString={false}
                         />
                         <StatsCard
-                            title="Average Activity Time"
-                            number={avgNumber}
+                            title="Avg Hours Per Week"
+                            number={
+                                parseFloat(avgNumber) === 0
+                                    ? '0'
+                                    : parseFloat(avgNumber) < 1
+                                      ? '<1'
+                                      : avgNumber
+                            }
                             label={avgLabel}
                             tooltip={avgToolTip}
                             useToLocaleString={false}
                         />
                         <StatsCard
-                            title="Total Hours"
-                            number={weekNumber}
+                            title="Total Hours This Week"
+                            number={
+                                parseFloat(weekNumber) === 0
+                                    ? '0'
+                                    : parseFloat(weekNumber) < 1
+                                      ? '<1'
+                                      : weekNumber
+                            }
                             label={weekLabel}
                             tooltip={weekToolTip}
                         />
@@ -171,17 +198,20 @@ const StudentProfile = () => {
                                         <th className="justify-self-start">
                                             Library Name
                                         </th>
-                                        <th># Hours Watching</th>
+                                        <th># Hours</th>
                                         <th className="justify-self-end">
                                             Is Featured
                                         </th>
                                     </tr>
                                 </thead>
-                                <tbody className="flex flex-col gap-4 mt-4">
+                                <tbody className="grid-col-3">
                                     {metrics.top_libraries.map(
                                         (items: OpenContentResponse) => {
                                             return (
-                                                <tr key={items.content_id}>
+                                                <tr
+                                                    className="justify-items-center"
+                                                    key={items.content_id}
+                                                >
                                                     <td className="justify-self-start">
                                                         <img
                                                             className="h-8 mx-auto object-contain"
@@ -195,8 +225,13 @@ const StudentProfile = () => {
                                                             lines={1}
                                                             className="my-auto w-full body font-normal text-left"
                                                         >
-                                                            {items.title ??
-                                                                'Untitled'}
+                                                            {items.is_featured
+                                                                ? `* ${
+                                                                      items.title ??
+                                                                      'Untitled'
+                                                                  }`
+                                                                : items.title ??
+                                                                  'Untitled'}
                                                         </ClampedText>
                                                     </td>
                                                     <td>
@@ -238,7 +273,7 @@ const StudentProfile = () => {
                                         </th>
                                     </tr>
                                 </thead>
-                                <tbody className="flex flex-col gap-4 mt-4">
+                                <tbody className="grid-col-2">
                                     {metrics.recent_videos.length > 0 ? (
                                         metrics.recent_videos.map(
                                             (
@@ -246,7 +281,7 @@ const StudentProfile = () => {
                                                 index: number
                                             ) => {
                                                 return (
-                                                    <tr>
+                                                    <tr className="justify-items-center">
                                                         <td className="justify-self-end">
                                                             <img
                                                                 className="h-8 mx-auto object-contain"
@@ -266,7 +301,7 @@ const StudentProfile = () => {
                                             }
                                         )
                                     ) : (
-                                        <tr>
+                                        <tr className="justify-items-center">
                                             <td className="justify-self-start">
                                                 No Videos Found
                                             </td>

--- a/frontend/src/Pages/StudentProfile.tsx
+++ b/frontend/src/Pages/StudentProfile.tsx
@@ -1,0 +1,287 @@
+import useSWR from 'swr';
+import { AxiosError } from 'axios';
+import {
+    OpenContentResponse,
+    ResidentEngagementProfile,
+    ServerResponseOne
+} from '@/common';
+import EngagementRateGraph from '@/Components/EngagementRateGraph';
+import { ResponsiveContainer } from 'recharts';
+import StatsCard from '@/Components/StatsCard';
+import { UserCircleIcon } from '@heroicons/react/24/outline';
+import { useParams } from 'react-router-dom';
+import ClampedText from '@/Components/ClampedText';
+
+const StudentProfile = () => {
+    const { user_id } = useParams<{ user_id: string }>();
+    const { data, error, isLoading } = useSWR<
+        ServerResponseOne<ResidentEngagementProfile>,
+        AxiosError
+    >(`/api/users/${user_id}/profile`);
+    const metrics = data?.data;
+
+    const isLessAvgThanOneHour =
+        (metrics?.activity_engagement.total_hours_active_weekly ?? 0) < 1;
+    const isLessThanOneHour =
+        (metrics?.activity_engagement.total_hours_engaged ?? 0) < 1;
+
+    const avgNumber = isLessAvgThanOneHour
+        ? (
+              metrics?.activity_engagement.total_minutes_active_weekly ?? 0
+          ).toFixed(2)
+        : (metrics?.activity_engagement.total_hours_active_weekly ?? 0).toFixed(
+              2
+          );
+
+    const weekNumber = isLessThanOneHour ? (metrics?.activity_engagement.total_minutes_engaged ?? 0).toFixed(2) :
+        (metrics?.activity_engagement.total_hours_engaged ?? 0).toFixed(2);
+  
+    const avgLabel = isLessAvgThanOneHour
+        ? 'AVG Minutes PER Week'
+        : 'AVG Hours PER Week';
+
+        const weekLabel = isLessThanOneHour
+        ? 'Total Minutes This Week'
+        : 'Total Hours This Week';
+
+    const avgToolTip = isLessAvgThanOneHour
+        ? 'Average number of minutes resident is logged in to UnlockedEd'
+        : 'Average number of hours resident is logged in to UnlockedEd';
+
+        const weekToolTip = isLessThanOneHour
+        ? 'Total number of minutes resident was logged in to UnlockedEd this week'
+        : 'Total number of hours resident was logged in to UnlockedEd this week';
+
+    return (
+        <div className="overflow-x-hidden px-5 pb-4">
+            {error && <div>Error loading data</div>}
+            {!data || (isLoading && <div>Loading...</div>)}
+            {data && metrics && (
+                <>
+                    <div className="flex flex-row gap-6 items-stretch">
+                        <div className="w-[270px] h-[240px] flex flex-col gap-4">
+                            <div className="card card-row-padding overflow-hidden text-med text-teal-4 flex-1 h-full">
+                                <div className="justify-items-center">
+                                    <UserCircleIcon className="w-[64px] h-[64px]" />
+                                </div>
+                                <div className="">
+                                    <div className="text-md mt-2">
+                                        {
+                                            metrics?.session_engagement
+                                                .user_info.name_first
+                                        }{' '}
+                                        {
+                                            metrics?.session_engagement
+                                                .user_info.name_last
+                                        }
+                                    </div>
+                                    <div className="text-sm mt-2">
+                                        <span className="font-semibold  justify-self-start">
+                                            Username
+                                        </span>
+                                        {' : '}
+                                        {
+                                            metrics?.session_engagement
+                                                .user_info.username
+                                        }
+                                    </div>
+                                    <div className="text-sm mt-2">
+                                        <span className="font-semibold">
+                                            Joined :
+                                        </span>{' '}
+                                        {new Date(
+                                            metrics.activity_engagement.first_active_date
+                                        ).toLocaleDateString('en-US')}
+                                    </div>
+                                    <div className="text-sm mt-2">
+                                        <span className="font-semibold">
+                                            Last Active :
+                                        </span>{' '}
+                                        {new Date(
+                                            metrics.activity_engagement.last_active_date
+                                        ).toLocaleDateString('en-US')}
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                        {/* Chart */}
+                        <div className="flex-1 h-[240px] flex flex-col gap-4">
+                            <div className="card card-row-padding overflow-hidden">
+                                <h1 className="">
+                                    {' '}
+                                    {/* {metrics?.session_engagement.user_info.name_first +
+                                        " 's recent Activity"} */}
+                                </h1>
+                                <div className=" items-stretch">
+                                    <div className="h-[240px] overflow-visible">
+                                        <ResponsiveContainer
+                                            className="h-full p-7"
+                                            width="100%"
+                                            height="100%"
+                                            debounce={500}
+                                        >
+                                            <EngagementRateGraph
+                                                data={
+                                                    metrics?.session_engagement
+                                                        ?.user_engagement_times ??
+                                                    []
+                                                }
+                                                viewType="daily"
+                                            />
+                                        </ResponsiveContainer>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                    {/* Cards */}
+                    <div className="w-[1/2] grid grid-cols-3 gap-4 mb-6 mt-6">
+                        <StatsCard
+                            title="Days Active"
+                            number={metrics.activity_engagement.total_active_days_monthly.toFixed(
+                                0
+                            )}
+                            label="Days Active This Month"
+                            tooltip="Total number of days resident has been active in UnlockedEd"
+                            useToLocaleString={false}
+                        />
+                        <StatsCard
+                            title="Average Activity Time"
+                            number={avgNumber}
+                            label={avgLabel}
+                            tooltip={avgToolTip}
+                            useToLocaleString={false}
+                        />
+                        <StatsCard
+                            title="Total Hours"
+                            number={weekNumber}
+                            label={weekLabel}
+                            tooltip={weekToolTip}
+                        />
+                    </div>
+                    {/* Tables */}
+                    <div className="grid grid-cols-2 gap-3 mb-6 mt-6">
+                        <div className="card pt-2 px-3">
+                            <div className="text-teal-4 text-center text-lg font-semibold">
+                                Top 5 Most Viewed Libraries
+                            </div>
+                            <table className="table-2 mb-4">
+                                <thead>
+                                    <tr className="grid-col-3">
+                                        <th className="justify-self-start">
+                                            Library Name
+                                        </th>
+                                        <th># Hours Watching</th>
+                                        <th className="justify-self-end">
+                                            Is Featured
+                                        </th>
+                                    </tr>
+                                </thead>
+                                <tbody className="flex flex-col gap-4 mt-4">
+                                    {metrics.top_libraries.map(
+                                        (items: OpenContentResponse) => {
+                                            return (
+                                                <tr key={items.content_id}>
+                                                    <td className="justify-self-start">
+                                                        <img
+                                                            className="h-8 mx-auto object-contain"
+                                                            src={
+                                                                items.thumbnail_url ??
+                                                                ''
+                                                            }
+                                                        />
+                                                        <ClampedText
+                                                            as="h3"
+                                                            lines={1}
+                                                            className="my-auto w-full body font-normal text-left"
+                                                        >
+                                                            {items.title ??
+                                                                'Untitled'}
+                                                        </ClampedText>
+                                                    </td>
+                                                    <td>
+                                                        {items.total_hours.toFixed(
+                                                            2
+                                                        )}
+                                                    </td>
+                                                    <td className="justify-self-end">
+                                                        <input
+                                                            name={'is_featured'}
+                                                            type="checkbox"
+                                                            className="checkbox"
+                                                            checked={
+                                                                items.is_featured
+                                                            }
+                                                            readOnly
+                                                        />
+                                                    </td>
+                                                </tr>
+                                            );
+                                        }
+                                    )}
+                                </tbody>
+                            </table>
+                        </div>
+                        {/* <div></div> */}
+                        <div className="card pt-2 px-3">
+                            <div className="text-teal-4 text-center text-lg font-semibold">
+                                Top 5 Recently Watched Videos
+                            </div>
+                            <table className="table-2 mb-4">
+                                <thead>
+                                    <tr className="grid-col-2">
+                                        <th className="justify-self-end">
+                                            Title
+                                        </th>
+                                        <th className="justify-self-start">
+                                            Rank
+                                        </th>
+                                    </tr>
+                                </thead>
+                                <tbody className="flex flex-col gap-4 mt-4">
+                                    {metrics.recent_videos.length > 0 ? (
+                                        metrics.recent_videos.map(
+                                            (
+                                                items: OpenContentResponse,
+                                                index: number
+                                            ) => {
+                                                return (
+                                                    <tr>
+                                                        <td className="justify-self-end">
+                                                            <img
+                                                                className="h-8 mx-auto object-contain"
+                                                                src={
+                                                                    items.thumbnail_url ??
+                                                                    ''
+                                                                }
+                                                            />
+                                                        </td>
+                                                        {items.title ??
+                                                            'Untitled'}
+                                                        <td className="justify-self-start">
+                                                            {index + 1}
+                                                        </td>
+                                                    </tr>
+                                                );
+                                            }
+                                        )
+                                    ) : (
+                                        <tr>
+                                            <td className="justify-self-start">
+                                                No Videos Found
+                                            </td>
+                                            <td></td>
+                                            <td className="justify-self-end"></td>
+                                        </tr>
+                                    )}
+                                </tbody>
+                            </table>
+                        </div>
+                    </div>
+                </>
+            )}
+        </div>
+    );
+};
+
+export default StudentProfile;

--- a/frontend/src/Pages/StudentProfile.tsx
+++ b/frontend/src/Pages/StudentProfile.tsx
@@ -9,8 +9,7 @@ import EngagementRateGraph from '@/Components/EngagementRateGraph';
 import { ResponsiveContainer } from 'recharts';
 import StatsCard from '@/Components/StatsCard';
 import { UserCircleIcon } from '@heroicons/react/24/outline';
-import { useParams } from 'react-router-dom';
-import ClampedText from '@/Components/ClampedText';
+import { useNavigate, useParams } from 'react-router-dom';
 
 const StudentProfile = () => {
     const { user_id } = useParams<{ user_id: string }>();
@@ -48,6 +47,11 @@ const StudentProfile = () => {
     const weekToolTip = isLessThanOneHour
         ? 'Total number of minutes resident was logged in to UnlockedEd this week'
         : 'Total number of hours resident was logged in to UnlockedEd this week';
+
+    const navigate = useNavigate();
+    const handleShowLibraryClick = (id: number) => {
+        navigate(`/viewer/libraries/${id}`);
+    };
 
     return (
         <div className="overflow-x-hidden px-5 pb-4">
@@ -123,14 +127,13 @@ const StudentProfile = () => {
                         <div className="flex-1 h-[240px] flex flex-col gap-4">
                             <div className="card card-row-padding overflow-hidden">
                                 <h1 className="">
-                                    {' '}
-                                    {/* {metrics?.session_engagement.user_info.name_first +
-                                        " 's recent Activity"} */}
+                                    {metrics?.session_engagement.user_info
+                                        .name_first + " 's recent Activity"}
                                 </h1>
                                 <div className=" items-stretch">
-                                    <div className="h-[240px] overflow-visible">
+                                    <div className="w-full h-[240px] overflow-visible">
                                         <ResponsiveContainer
-                                            className="h-full p-7"
+                                            className="w-full h-full overflow-visible pb-10"
                                             width="100%"
                                             height="100%"
                                             debounce={500}
@@ -194,61 +197,39 @@ const StudentProfile = () => {
                             </div>
                             <table className="table-2 mb-4">
                                 <thead>
-                                    <tr className="grid-col-3">
+                                    <tr className="grid-col-2">
                                         <th className="justify-self-start">
                                             Library Name
                                         </th>
                                         <th># Hours</th>
-                                        <th className="justify-self-end">
-                                            Is Featured
-                                        </th>
                                     </tr>
                                 </thead>
-                                <tbody className="grid-col-3">
+                                <tbody className="">
                                     {metrics.top_libraries.map(
                                         (items: OpenContentResponse) => {
                                             return (
                                                 <tr
-                                                    className="justify-items-center"
+                                                    className="justify-items-center cursor-pointer"
                                                     key={items.content_id}
+                                                    onClick={() =>
+                                                        handleShowLibraryClick(
+                                                            items.content_id
+                                                        )
+                                                    }
                                                 >
                                                     <td className="justify-self-start">
-                                                        <img
-                                                            className="h-8 mx-auto object-contain"
-                                                            src={
-                                                                items.thumbnail_url ??
-                                                                ''
-                                                            }
-                                                        />
-                                                        <ClampedText
-                                                            as="h3"
-                                                            lines={1}
-                                                            className="my-auto w-full body font-normal text-left"
-                                                        >
-                                                            {items.is_featured
-                                                                ? `* ${
-                                                                      items.title ??
-                                                                      'Untitled'
-                                                                  }`
-                                                                : items.title ??
-                                                                  'Untitled'}
-                                                        </ClampedText>
+                                                        {items.is_featured
+                                                            ? `* ${
+                                                                  items.title ??
+                                                                  'Untitled'
+                                                              }`
+                                                            : items.title ??
+                                                              'Untitled'}
                                                     </td>
-                                                    <td>
+                                                    <td className="justify-self-end">
                                                         {items.total_hours.toFixed(
                                                             2
                                                         )}
-                                                    </td>
-                                                    <td className="justify-self-end">
-                                                        <input
-                                                            name={'is_featured'}
-                                                            type="checkbox"
-                                                            className="checkbox"
-                                                            checked={
-                                                                items.is_featured
-                                                            }
-                                                            readOnly
-                                                        />
                                                     </td>
                                                 </tr>
                                             );
@@ -256,6 +237,11 @@ const StudentProfile = () => {
                                     )}
                                 </tbody>
                             </table>
+                            <div className="border-t border-gray-300 mt-2"></div>
+                            <p className="text-xs text-grey-4 italic">
+                                * Data is based on recent video performance and
+                                may not reflect all content.
+                            </p>
                         </div>
                         {/* <div></div> */}
                         <div className="card pt-2 px-3">
@@ -264,14 +250,7 @@ const StudentProfile = () => {
                             </div>
                             <table className="table-2 mb-4">
                                 <thead>
-                                    <tr className="grid-col-2">
-                                        <th className="justify-self-end">
-                                            Title
-                                        </th>
-                                        <th className="justify-self-start">
-                                            Rank
-                                        </th>
-                                    </tr>
+                                    <tr className="grid-col-2"></tr>
                                 </thead>
                                 <tbody className="grid-col-2">
                                     {metrics.recent_videos.length > 0 ? (
@@ -281,8 +260,11 @@ const StudentProfile = () => {
                                                 index: number
                                             ) => {
                                                 return (
-                                                    <tr className="justify-items-center">
-                                                        <td className="justify-self-end">
+                                                    <tr
+                                                        className="justify-items-center"
+                                                        key={index}
+                                                    >
+                                                        <td className="justify-self-end truncate w-full">
                                                             <img
                                                                 className="h-8 mx-auto object-contain"
                                                                 src={
@@ -290,11 +272,8 @@ const StudentProfile = () => {
                                                                     ''
                                                                 }
                                                             />
-                                                        </td>
-                                                        {items.title ??
-                                                            'Untitled'}
-                                                        <td className="justify-self-start">
-                                                            {index + 1}
+                                                            {items.title ??
+                                                                'Untitled'}
                                                         </td>
                                                     </tr>
                                                 );

--- a/frontend/src/Routes/App.tsx
+++ b/frontend/src/Routes/App.tsx
@@ -18,7 +18,7 @@ import Welcome from '@/Pages/Welcome';
 import Login from '@/Pages/Auth/Login';
 import UnauthorizedNotFound from '@/Pages/Unauthorized';
 import { getProviderPlatforms } from '@/routeLoaders';
-import StudentProfile from '@/Pages/StudentProfile';
+import ResidentProfile from '@/Pages/ResidentProfile';
 
 const deptAdminRoutes = DeclareAuthenticatedRoutes(
     [
@@ -95,7 +95,7 @@ const adminRoutes = DeclareAuthenticatedRoutes(
         },
         {
             path: 'residents/:user_id',
-            element: <StudentProfile />,
+            element: <ResidentProfile />,
             handle: {
                 title: 'Resident Profile',
                 path: ['residents']

--- a/frontend/src/Routes/App.tsx
+++ b/frontend/src/Routes/App.tsx
@@ -18,6 +18,7 @@ import Welcome from '@/Pages/Welcome';
 import Login from '@/Pages/Auth/Login';
 import UnauthorizedNotFound from '@/Pages/Unauthorized';
 import { getProviderPlatforms } from '@/routeLoaders';
+import StudentProfile from '@/Pages/StudentProfile';
 
 const deptAdminRoutes = DeclareAuthenticatedRoutes(
     [
@@ -90,6 +91,14 @@ const adminRoutes = DeclareAuthenticatedRoutes(
             errorElement: <Error />,
             handle: {
                 title: 'Residents'
+            }
+        },
+        {
+            path: 'residents/:user_id',
+            element: <StudentProfile />,
+            handle: {
+                title: 'Resident Profile',
+                path: ['residents']
             }
         }
     ],

--- a/frontend/src/common.ts
+++ b/frontend/src/common.ts
@@ -342,7 +342,7 @@ export interface LoginMetrics {
         facility: string;
         new_residents_added: number;
         new_admins_added: number;
-        user_engagement_times: UserEngagementTimes[];
+        peak_login_times: LoginActivity[];
     };
     last_cache: string;
 }

--- a/frontend/src/common.ts
+++ b/frontend/src/common.ts
@@ -12,6 +12,7 @@ export enum FeatureAccess {
     ProgramAccess = 'program_management'
 }
 export const INIT_KRATOS_LOGIN_FLOW = '/self-service/login/browser';
+
 export interface User {
     id: number;
     name_first: string;
@@ -20,6 +21,7 @@ export interface User {
     role: UserRole;
     email: string;
     password_reset?: boolean;
+    session_id: string;
     created_at: string;
     updated_at: string;
     facility_name?: string;
@@ -340,7 +342,7 @@ export interface LoginMetrics {
         facility: string;
         new_residents_added: number;
         new_admins_added: number;
-        peak_login_times: LoginActivity[];
+        user_engagement_times: UserEngagementTimes[];
     };
     last_cache: string;
 }
@@ -731,4 +733,63 @@ export interface SearchResultItem extends OpenContentItem {
 export interface Option {
     key: number;
     value: string;
+}
+
+export enum WsEventType {
+    ClientHello = 'client_hello',
+    ClientGoodbye = 'client_goodbye',
+    Pong = 'pong',
+    VisitEvent = 'visits',
+    BookmarkEvent = 'bookmarks'
+}
+
+export interface OcActivityUpdate {
+    activity_id: number;
+}
+
+export interface WsMsg {
+    event_type: WsEventType;
+    msg: MsgContent;
+    user_id: number;
+    session_id?: string;
+}
+
+export interface MsgContent {
+    activity_id: number;
+    msg: string;
+}
+
+export interface UserEngagementTimes {
+    time_interval: string;
+    total_hours: number;
+    facility_id: number;
+}
+
+export interface SessionEngagementActivityWithUserInfo {
+    user_info: User;
+    user_engagement_times: UserEngagementTimes[];
+}
+
+export interface EngagementActivityMetrics {
+    user_id: number;
+    total_active_days_monthly: number;
+    total_hours_active_monthly: number;
+    total_hours_active_weekly: number;
+    total_minutes_active_weekly: number;
+    total_hours_engaged: number;
+    total_minutes_engaged: number;
+    first_active_date: string;
+    last_active_date: string;
+}
+export interface OpenContentResponse extends OpenContentItem {
+    is_featured: boolean;
+    total_hours: number;
+    total_minutes: number;
+}
+
+export interface ResidentEngagementProfile {
+    session_engagement: SessionEngagementActivityWithUserInfo;
+    activity_engagement: EngagementActivityMetrics;
+    top_libraries: OpenContentResponse[];
+    recent_videos: OpenContentResponse[];
 }

--- a/frontend/src/common.ts
+++ b/frontend/src/common.ts
@@ -765,11 +765,6 @@ export interface UserEngagementTimes {
     facility_id: number;
 }
 
-export interface SessionEngagementActivityWithUserInfo {
-    user_info: User;
-    user_engagement_times: UserEngagementTimes[];
-}
-
 export interface EngagementActivityMetrics {
     user_id: number;
     total_active_days_monthly: number;
@@ -778,7 +773,7 @@ export interface EngagementActivityMetrics {
     total_minutes_active_weekly: number;
     total_hours_engaged: number;
     total_minutes_engaged: number;
-    first_active_date: string;
+    joined: string;
     last_active_date: string;
 }
 export interface OpenContentResponse extends OpenContentItem {
@@ -788,7 +783,8 @@ export interface OpenContentResponse extends OpenContentItem {
 }
 
 export interface ResidentEngagementProfile {
-    session_engagement: SessionEngagementActivityWithUserInfo;
+    user: User;
+    session_engagement: UserEngagementTimes[];
     activity_engagement: EngagementActivityMetrics;
     top_libraries: OpenContentResponse[];
     recent_videos: OpenContentResponse[];

--- a/frontend/src/session_ws.ts
+++ b/frontend/src/session_ws.ts
@@ -1,0 +1,187 @@
+import { WsMsg, WsEventType, OcActivityUpdate, User } from './common';
+
+export class WebsocketSession {
+    private socket: WebSocket | null = null;
+    private currentActivityId = 0;
+    private readonly session_id: string;
+    private readonly userId: number;
+    private readonly reconnectInterval: number = 5000; // 5 seconds delay before retrying
+    private currentMsgHandler: (msg: Partial<WsMsg>) => void = () => {
+        return;
+    };
+
+    constructor(user: User) {
+        this.userId = user.id;
+        this.session_id = user.session_id;
+        this.addWindowListeners();
+    }
+
+    // adds event listeners to re-establish the connection
+    private addWindowListeners(): void {
+        window.addEventListener('focus', this.handleFocusChange);
+        window.addEventListener(
+            'visibilitychange',
+            this.handleVisibilityChange
+        );
+        window.addEventListener('logoutEvent', this.handleLogout);
+    }
+
+    private removeWindowListeners(): void {
+        window.removeEventListener('focus', this.handleFocusChange);
+        window.removeEventListener(
+            'visibilitychange',
+            this.handleVisibilityChange
+        );
+        window.removeEventListener('logoutEvent', this.handleLogout);
+    }
+
+    private handleFocusChange = (): void => {
+        if (this.socket && document.hidden){
+            this.tearDownConnection(false);
+        }else if (!this.socket) {
+            this.createConnection();
+        }
+    };
+
+    private handleVisibilityChange = (): void => {
+        if (!document.hidden && !this.socket) {
+            this.createConnection();
+        } else if (document.hidden && this.socket){
+            this.tearDownConnection(false);
+        }
+    };
+
+    private handleLogout = (): void => {
+        this.tearDownConnection(true);
+    };
+
+    // public API to connect or reconnect the websocket
+    public connect(): void {
+        this.createConnection();
+    }
+
+    // creates the websocket connection and sets up its event handlers
+    private createConnection(): void {
+        if (this.socket) return; // already exists
+        const webSocketUrl = `/api/ws/listen`;
+        this.socket = new WebSocket(webSocketUrl);
+
+        this.socket.onopen = () => {
+            // send an initial message with session details for client hello
+            const message: WsMsg = {
+                event_type: WsEventType.ClientHello,
+                msg: {
+                    msg: 'client_hello',
+                    activity_id: 0
+                },
+                user_id: this.userId,
+                session_id: this.session_id
+            };
+            this.sendMessage(message);
+        };
+
+        this.socket.onmessage = (event: MessageEvent<string>) => {
+            const msg = this.defaultMsgHandler(event);
+            this.currentMsgHandler(msg);
+        };
+
+        this.socket.onclose = (event: CloseEvent) => {
+            console.warn('WebSocket closed:', event.reason);
+            this.socket = null;
+            setTimeout(() => {
+                if (!document.hidden){
+                    this.createConnection();
+                }
+            }, this.reconnectInterval);
+        };
+
+        this.socket.onerror = (error: Event) => {
+            console.error('WebSocket error:', error);
+        };
+    }
+
+    public notifyOpenContentActivity(cleanup?: boolean): void {
+        if (this.socket && this.socket.readyState === WebSocket.OPEN) {
+            const msg: WsMsg = {
+                event_type: WsEventType.VisitEvent,
+                msg: {
+                    activity_id: this.currentActivityId,
+                    msg: ''
+                },
+                user_id: this.userId,
+                session_id: this.session_id
+            };
+            this.socket.send(JSON.stringify(msg));
+        } else {
+            this.connect();
+        }
+        if (cleanup) {
+            this.currentActivityId = 0;
+        }
+    }
+
+    // public API to send messages to the backend.
+    public sendMessage(msg: WsMsg): void {
+        if (this.socket && this.socket.readyState === WebSocket.OPEN) {
+            this.socket.send(JSON.stringify(msg));
+        } else {
+            console.warn('WebSocket is not open. Message not sent:');
+        }
+    }
+
+    public tearDownConnection(removeListeners: boolean): void {
+        if (this.socket) {
+            const sessionMessage: WsMsg = {
+                event_type: WsEventType.ClientGoodbye,
+                user_id: this.userId,
+                session_id: this.session_id,
+                msg: { activity_id: this.currentActivityId, msg: '' }
+            };
+            this.sendMessage(sessionMessage);
+            this.socket.close();
+            this.socket = null;
+        }
+        if (removeListeners) {
+            this.removeWindowListeners();
+        }
+    }
+
+    public setMsgHandler(handler: (msg: Partial<WsMsg>) => void): void {
+        this.currentMsgHandler = handler;
+    }
+
+    public resetMsgHandler(): void {
+        this.currentMsgHandler = () => {
+            return;
+        };
+    }
+
+    private defaultMsgHandler(event: MessageEvent<string>): Partial<WsMsg> {
+        try {
+            const data = JSON.parse(event.data) as Partial<WsMsg>;
+            // if an activity_id is received, end any prior activity and update the id.
+            if (data.event_type !== undefined) {
+                if (data.event_type === WsEventType.VisitEvent) {
+                    if (this.currentActivityId !== 0) {
+                        this.notifyOpenContentActivity();
+                    }
+                    this.currentActivityId = (
+                        data.msg as OcActivityUpdate
+                    ).activity_id;
+                }
+            }
+            return data;
+        } catch (error) {
+            console.error('Error parsing WebSocket message:', error);
+        }
+        return {} as Partial<WsMsg>;
+    }
+}
+
+declare global {
+    interface Window {
+        websocket?: WebsocketSession;
+    }
+}
+
+export default WebsocketSession;

--- a/frontend/src/useAuth.ts
+++ b/frontend/src/useAuth.ts
@@ -163,6 +163,7 @@ export async function handleLogout(): Promise<void> {
                 (resp.data as AuthResponse).redirect_to
             );
             if (logout.status === 200) {
+                window.dispatchEvent(new Event("logoutEvent"));
                 const logoutResp = logout.data as AuthResponse;
                 window.location.replace(
                     logoutResp.logout_url ?? INIT_KRATOS_LOGIN_FLOW


### PR DESCRIPTION
## Description of the change

Implemented logic to track the total time a user spends within UnlockEd. WebSocket integration added to both frontend and backend for real time user tracking.

### Added tracking for:
- Time spent viewing libraries.
- Time spent on individual pages within a library.
- Time spent watching videos.

### Resident Profile Screen:
- Developed a Resident Profile screen to display user engagement metrics.

### Database updates:
- Added stop_ts and duration columns to the open_content_activities table.
- Added a constraint to open_content_activities.
- Created a new table, user_session_tracking, to log user session activity.

- **Related issues**: Link to asana:  https://app.asana.com/0/1209460078641109/1209457884707524

NOTE: Added logic to the local dev seeder for seeding the database with data for use within the Resident Profile screen.

## Screenshot(s)

[ResProfile.webm](https://github.com/user-attachments/assets/8bb8096b-52c6-4e53-8d41-14e0e8299a85)