### PR TITLE
feat: add proper tab separation change trending content to home

### DIFF
--- a/frontend/src/Components/Navbar.tsx
+++ b/frontend/src/Components/Navbar.tsx
@@ -17,8 +17,7 @@ import {
     RectangleStackIcon,
     CogIcon,
     LightBulbIcon,
-    RocketLaunchIcon,
-    ArrowTrendingUpIcon
+    RocketLaunchIcon
 } from '@heroicons/react/24/solid';
 import {
     handleLogout,
@@ -210,7 +209,7 @@ export default function Navbar({
                                 ) && (
                                     <>
                                         <li>
-                                            <Link to="/home">
+                                            <Link to="/temp-home">
                                                 <ULIComponent icon={HomeIcon} />
                                                 Home
                                             </Link>
@@ -223,11 +222,9 @@ export default function Navbar({
                             ) && (
                                 <>
                                     <li>
-                                        <Link to="/trending-content">
-                                            <ULIComponent
-                                                icon={ArrowTrendingUpIcon}
-                                            />
-                                            Trending Content
+                                        <Link to="/home">
+                                            <ULIComponent icon={HomeIcon} />
+                                            Home
                                         </Link>
                                     </li>
                                     <li>

--- a/frontend/src/Components/TabView.tsx
+++ b/frontend/src/Components/TabView.tsx
@@ -22,7 +22,7 @@ export default function TabView({
                         className={`focus:outline-none py-3 px-8 ${
                             isActive
                                 ? 'font-bold text-teal-4 border-b-2 border-teal-4'
-                                : 'hover:scale-105 hover:text-teal-3 hover:drop-shadow hover:border-b-2 hover:border-teal-3'
+                                : 'hover:text-teal-3 hover:drop-shadow hover:border-b-2 hover:border-teal-3'
                         }`}
                     >
                         {tabName}

--- a/frontend/src/Components/TabView.tsx
+++ b/frontend/src/Components/TabView.tsx
@@ -10,19 +10,20 @@ export default function TabView({
     setActiveTab: (tab: Tab) => void;
 }) {
     return (
-        <div className="flex flex-row gap-16 w-100 border-b-2 border-grey-2 py-3">
-            {tabs.map((tab: Tab, index: number) => {
+        <div className="flex flex-row w-100 border-b-2 border-grey-2">
+            {tabs.map((tab, index) => {
                 const tabName =
                     tab.name.charAt(0).toUpperCase() + tab.name.slice(1);
+                const isActive = activeTab.value === tab.value;
                 return (
                     <button
-                        className={
-                            activeTab.value == tab.value
-                                ? 'text-teal-4 font-bold drop-shadow'
-                                : ''
-                        }
-                        onClick={() => setActiveTab(tab)}
                         key={index}
+                        onClick={() => setActiveTab(tab)}
+                        className={`focus:outline-none py-3 px-8 ${
+                            isActive
+                                ? 'font-bold text-teal-4 border-b-2 border-teal-4'
+                                : 'hover:scale-105 hover:text-teal-3 hover:drop-shadow hover:border-b-2 hover:border-teal-3'
+                        }`}
                     >
                         {tabName}
                     </button>

--- a/frontend/src/Pages/ResidentHome.tsx
+++ b/frontend/src/Pages/ResidentHome.tsx
@@ -16,7 +16,7 @@ import useSWR from 'swr';
 import { AxiosError } from 'axios';
 import OpenContentItemAccordion from '@/Components/OpenContentItemAccordion';
 
-export default function StudentLayer1() {
+export default function ResidentHome() {
     const navigate = useNavigate();
     const { topUserContent, topFacilityContent } = useLoaderData() as {
         topUserContent: OpenContentItem[];

--- a/frontend/src/Pages/StudentLayer0.tsx
+++ b/frontend/src/Pages/StudentLayer0.tsx
@@ -11,7 +11,13 @@ export default function StudentLayer0() {
                 alt="UnlockEd Logo"
                 className="w-125px h-125px"
             />
-            <div className="card card-row-padding"></div>
+            <div title="Error" />
+            <div className="text-center">
+                <div className="mb-4 font-medium text-xl text-red-600">
+                    Please contact your administrator to get access to
+                    application features
+                </div>
+            </div>
         </div>
     );
 }

--- a/frontend/src/Routes/App.tsx
+++ b/frontend/src/Routes/App.tsx
@@ -109,7 +109,7 @@ const nonAdminLoggedInRoutes = DeclareAuthenticatedRoutes([
         }
     },
     {
-        path: 'home',
+        path: 'temp-home',
         element: <StudentLayer0 />,
         handle: {
             title: 'UnlockEd'

--- a/frontend/src/Routes/KnowledgeCenterRoutes.tsx
+++ b/frontend/src/Routes/KnowledgeCenterRoutes.tsx
@@ -19,7 +19,7 @@ import LibraryViewer from '@/Pages/LibraryViewer';
 import VideoViewer from '@/Components/VideoEmbedViewer';
 import VideoContent from '@/Components/VideoContent';
 import OpenContent from '@/Pages/OpenContent';
-import StudentLayer1 from '@/Pages/StudentLayer1';
+import ResidentHome from '@/Pages/ResidentHome';
 
 export const KnowledgeCenterAdminRoutes: RouteObject =
     DeclareAuthenticatedRoutes(
@@ -73,11 +73,11 @@ export const KnowledgeCenterAdminRoutes: RouteObject =
 export const KnowledgeCenterRoutes: RouteObject = DeclareAuthenticatedRoutes(
     [
         {
-            path: 'trending-content',
-            element: <StudentLayer1 />,
+            path: 'home',
+            element: <ResidentHome />,
             loader: getStudentLevel1Data,
             handle: {
-                title: 'Trending Content'
+                title: 'Home'
             }
         },
         {

--- a/frontend/src/useAuth.ts
+++ b/frontend/src/useAuth.ts
@@ -192,10 +192,10 @@ const getAdminLink = (user: User): string => {
 
 const getResidentLink = (user: User): string => {
     if (user.feature_access.includes(FeatureAccess.OpenContentAccess)) {
-        return '/trending-content';
+        return '/home';
     }
     if (user.feature_access.includes(FeatureAccess.ProviderAccess)) {
         return '/learning-path';
     }
-    return '/home';
+    return '/temp-home';
 };


### PR DESCRIPTION
## Description of the change
This pull request adds more tab separation in our "TabView" so that on the parts of the application that uses tabs there is more intuitive tab navigation. It also changes StudentLayer0 (which is essentially if the user has 0 features enabled) to "/temp-home" and added a "Contact your administrators" dialogue to help assist them in why they're at that page. Also, StudentLayer1 (trending content) was changed to "ResidentHome", and also assigned the "/home" route. 

- **Related issues**: Closes 32 and 57 in Asana

## Screenshot(s)
![image](https://github.com/user-attachments/assets/05c7dbf1-fade-47c2-9a32-eac7d5c2f25b)
![image](https://github.com/user-attachments/assets/0445b6be-7f2b-4b6a-b6b0-63e014cf5d78)
![image](https://github.com/user-attachments/assets/bb6ff49c-3631-48b8-ace3-30ebcb569535)
![image](https://github.com/user-attachments/assets/747238ef-794d-43a8-9704-b76d257f63cb)
**This is now the StudentLayer0 when no features are available**
![image](https://github.com/user-attachments/assets/ff3ffee8-243f-4a70-9b62-31748663c89a)


