### PR TITLE
fix: change order by of libraries within the knowledge center to be by title ascending per asana task 40

### DIFF
--- a/backend/src/handlers/utils.go
+++ b/backend/src/handlers/utils.go
@@ -83,6 +83,9 @@ func (srv *Server) getQueryContext(r *http.Request) models.QueryContext {
 			order = orderBySplit[1]
 		}
 	}
+	if orderBy == "" {
+		orderBy = "created_at"
+	}
 	if order != "asc" && order != "desc" {
 		order = "desc"
 	}

--- a/frontend/src/Components/LibraryLayout.tsx
+++ b/frontend/src/Components/LibraryLayout.tsx
@@ -71,7 +71,7 @@ export default function LibaryLayout({
         error: librariesError,
         isLoading: librariesLoading
     } = useSWR<ServerResponseMany<Library>, AxiosError>(
-        `/api/libraries?page=${pageQuery}&per_page=${perPage}&order_by=created_at&order=desc&visibility=${isAdministrator(user) && !adminWithStudentView() ? filterVisibilityAdmin : 'visible'}&search=${searchTerm}&${categoryQueryString}`
+        `/api/libraries?page=${pageQuery}&per_page=${perPage}&order_by=title&order=asc&visibility=${isAdministrator(user) && !adminWithStudentView() ? filterVisibilityAdmin : 'visible'}&search=${searchTerm}&${categoryQueryString}`
     );
 
     const librariesMeta = libraries?.meta ?? {


### PR DESCRIPTION
## Description of the change

Within the LibraryLayout.tsx (in Knowledge Center)
- Modified the ordering parameters found within the request url used to retrieve libraries. The ordering parameters were changed from created_at/desc TO title/asc.

- **Related issues**: Link to issue on asana task: https://app.asana.com/1/1201607307149189/project/1209460078641109/task/1209485908694611?focus=true