### PR TITLE
fix: add method to retrieve all english language libraries to avoid kiwix mutiple language error

### DIFF
--- a/backend/src/handlers/libraries_handler.go
+++ b/backend/src/handlers/libraries_handler.go
@@ -1,7 +1,6 @@
 package handlers
 
 import (
-	"UnlockEdv2/src/database"
 	"UnlockEdv2/src/models"
 	"encoding/json"
 	"encoding/xml"
@@ -101,18 +100,9 @@ func (srv *Server) handleSearchOpenContent(w http.ResponseWriter, r *http.Reques
 		return writePaginatedResponse(w, http.StatusOK, channels, paginationData)
 	}
 	if len(libraryIDs) > 0 {
-		libraries, err = srv.Db.GetLibrariesByIDs(libraryIDs)
+		libraries, err = srv.Db.GetLibrariesByIDsAndLang(libraryIDs, "eng")
 	} else {
-		queryCtx.Search = ""
-		queryCtx.All = true
-		var librariesResp []database.LibraryResponse
-		librariesResp, err = srv.Db.GetAllLibraries(&queryCtx, "visible")
-		libraries = make([]models.Library, 0, len(librariesResp))
-		if err == nil {
-			for _, library := range librariesResp {
-				libraries = append(libraries, library.Library)
-			}
-		}
+		libraries, err = srv.Db.GetAllLibrariesByLang(&queryCtx, "eng")
 	}
 	if err != nil {
 		log.add("library_ids", libraryIDs)


### PR DESCRIPTION
## Description of the change

Added a new method within the database layer for retrieving all english language libraries and modified handler to call this method. 

### Description of issue it fixes:  
When doing a search through all libraries it throws an exception because kiwix only allows you to search through libraries of one language type (eng) only. This was already being handled when a user selects, via checkboxes, which library they want to search through. It filters for 'eng' type libraries only. 

The error message you receive when you search through libraries of all language types is:   
- "Two or more books in different languages would participate in search, which may lead to confusing results."