### PR TITLE
fix: add css for fixing clipped text on the trending content when screen size is small

### DIFF
--- a/frontend/src/Components/LibraryCard.tsx
+++ b/frontend/src/Components/LibraryCard.tsx
@@ -92,7 +92,10 @@ export default function LibraryCard({
                             alt={`${library.title} thumbnail`}
                         />
                     </figure>
-                    <ClampedText as="h3" className="w-3/4 body my-auto mr-7">
+                    <ClampedText
+                        as="h3"
+                        className="w-3/4 flex-shrink-0 body my-auto mr-7"
+                    >
                         {library.title}
                     </ClampedText>
                 </div>


### PR DESCRIPTION
## Description of the change

Modified CSS on the LibraryCard.tsx to handle fixing the clipped text on the trending content when the screen size is small.

- **Related issues**: Link to Asana ticket: https://app.asana.com/1/1201607307149189/project/1209460078641109/task/1209485070839643?focus=true

## Screenshot(s)
[demo.webm](https://github.com/user-attachments/assets/c25c2367-ee4d-4b13-af2e-e5f0905c377e)