### PR TITLE
refactor: add request context to all db calls using queryCtx

### DIFF
--- a/backend/src/database/courses.go
+++ b/backend/src/database/courses.go
@@ -16,7 +16,7 @@ func (db *DB) GetCourses(args *models.QueryContext) ([]models.Course, error) {
 	content := make([]models.Course, 0, args.PerPage)
 	total := int64(0)
 	if args.Search != "" {
-		search := "%" + args.Search + "%"
+		search := args.SearchQuery()
 		tx := db.Model(&models.Course{}).
 			Where("LOWER(courses.name) LIKE ?", search).
 			Or("LOWER(courses.alt_name) LIKE ?", search).

--- a/backend/src/database/program_sections.go
+++ b/backend/src/database/program_sections.go
@@ -4,7 +4,7 @@ import "UnlockEdv2/src/models"
 
 func (db *DB) GetSectionsForProgram(id int, args *models.QueryContext) ([]models.ProgramSection, error) {
 	content := []models.ProgramSection{}
-	if err := db.Find(&content, "program_id = ?", id).Preload("Events").Count(&args.Total).Error; err != nil {
+	if err := db.WithContext(args.Ctx).Find(&content, "program_id = ?", id).Preload("Events").Count(&args.Total).Error; err != nil {
 		return nil, newNotFoundDBError(err, "programs")
 	}
 	return content, nil
@@ -20,9 +20,9 @@ func (db *DB) GetSectionByID(id int) (*models.ProgramSection, error) {
 
 func (db *DB) GetSectionsForFacility(args *models.QueryContext) ([]models.ProgramSection, error) {
 	content := []models.ProgramSection{}
-	tx := db.Find(&content, "facility_id = ?", args.FacilityID)
+	tx := db.WithContext(args.Ctx).Find(&content, "facility_id = ?", args.FacilityID)
 	if args.Search != "" {
-		tx = tx.Where("name LIKE ?", "%"+args.Search+"%")
+		tx = tx.Where("LOWER(name) LIKE ?", args.SearchQuery())
 	}
 	if err := tx.Count(&args.Total).Limit(args.PerPage).Offset(args.CalcOffset()).Error; err != nil {
 		return nil, newGetRecordsDBError(err, "program sections")

--- a/backend/src/handlers/proxy_handler.go
+++ b/backend/src/handlers/proxy_handler.go
@@ -95,12 +95,12 @@ func (srv *Server) handleRedirectVideosLocal(w http.ResponseWriter, r *http.Requ
 }
 
 func (srv *Server) handleRedirectVideosS3(w http.ResponseWriter, r *http.Request) {
-	logrus.Infof("Redirecting to S3 for video %s", r.URL.Path)
 	video := r.Context().Value(videoKey).(*models.Video)
 	if srv.dev || video == nil || srv.s3Bucket == "" {
 		srv.handleRedirectVideosLocal(w, r, video)
 		return
 	}
+	logrus.Tracef("Redirecting to S3 for video %s", r.URL.Path)
 	presignParams := &s3.GetObjectInput{
 		Bucket: aws.String(srv.s3Bucket),
 		Key:    aws.String(video.GetS3KeyMp4()),
@@ -109,7 +109,7 @@ func (srv *Server) handleRedirectVideosS3(w http.ResponseWriter, r *http.Request
 		opts.Expires = getTimeoutFromDuration(video.Duration)
 	})
 	if err != nil {
-		logrus.Printf("Error generating presigned URL: %v", err)
+		logrus.Errorf("Error generating presigned URL: %v", err)
 		srv.errorResponse(w, http.StatusInternalServerError, "Error generating presigned URL")
 		return
 	}

--- a/backend/src/handlers/utils.go
+++ b/backend/src/handlers/utils.go
@@ -75,7 +75,7 @@ func (srv *Server) getQueryContext(r *http.Request) models.QueryContext {
 	page, perPage := srv.getPaginationInfo(r)
 	orderBy := strings.ToLower(r.URL.Query().Get("order_by"))
 	order := strings.ToLower(r.URL.Query().Get("order"))
-	if order == "" && orderBy != "" {
+	if orderBy != "" && order == "" {
 		orderBySplit := strings.Fields(orderBy)
 		if len(orderBySplit) > 1 {
 			orderBy = orderBySplit[0]

--- a/backend/src/models/resource.go
+++ b/backend/src/models/resource.go
@@ -94,5 +94,13 @@ func (q QueryContext) CalcOffset() int {
 }
 
 func (q QueryContext) OrderClause() string {
-	return fmt.Sprintf("%s %s", q.OrderBy, q.Order)
+	val := fmt.Sprintf("%s %s", q.OrderBy, q.Order)
+	if val == " " {
+		return "created_at desc"
+	}
+	return val
+}
+
+func (q QueryContext) SearchQuery() string {
+	return "%" + q.Search + "%"
 }


### PR DESCRIPTION
this adds a couple convenience methods for the `QueryContext` struct that is slowly being integrated into all of our queries.

`SearchQuery()` + `OrderClause()` that just removes the need to do `"%' + args.Search + "%"` and `args.Order + " " args.OrderBy`

Also this passes the request context into the database calls, ensuring to cancel the context if the request times out.
