### PR TITLE
fix: removed horizontal and vertical scrollbars

### DIFF
--- a/frontend/src/Components/FacilityCard.tsx
+++ b/frontend/src/Components/FacilityCard.tsx
@@ -30,6 +30,7 @@ export default function FacilityCard({
                     onClick={() => {
                         openDeleteFacility(facility);
                     }}
+                    tooltipClassName="tooltip-left"
                 />
             </td>
         </tr>

--- a/frontend/src/Components/LibraryCard.tsx
+++ b/frontend/src/Components/LibraryCard.tsx
@@ -107,6 +107,7 @@ export default function LibraryCard({
                                     icon={MagnifyingGlassIcon}
                                     iconClassName="!w-5 !h-5"
                                     dataTip={`Search ${library.title}`}
+                                    tooltipClassName="tooltip-left"
                                 />
                             </div>
                         )}
@@ -131,6 +132,7 @@ export default function LibraryCard({
                                         ? 'Feature Library'
                                         : 'Favorite Library'
                                 }
+                                tooltipClassName="tooltip-left"
                             />
                         )}
                     </div>

--- a/frontend/src/Components/modals/FormModal.tsx
+++ b/frontend/src/Components/modals/FormModal.tsx
@@ -65,7 +65,7 @@ export const FormModal = forwardRef(function FormModal<T extends FieldValues>(
     }, []);
 
     return (
-        <dialog ref={ref} className="modal relative" onClose={() => reset()}>
+        <dialog ref={ref} className="modal" onClose={() => reset()}>
             <div className="modal-box">
                 <CloseX close={() => void reset()} />
                 <div className="flex flex-col">

--- a/frontend/src/Components/modals/TextOnlyModal.tsx
+++ b/frontend/src/Components/modals/TextOnlyModal.tsx
@@ -21,7 +21,7 @@ export const TextOnlyModal = forwardRef(function TextModal(
     ref: React.ForwardedRef<HTMLDialogElement>
 ) {
     return (
-        <dialog ref={ref} className="modal relative">
+        <dialog ref={ref} className="modal">
             <div className="modal-box">
                 <CloseX close={onClose} />
                 <div className="flex flex-col gap-6">

--- a/frontend/src/Pages/HelpfulLinksManagement.tsx
+++ b/frontend/src/Pages/HelpfulLinksManagement.tsx
@@ -64,8 +64,8 @@ export default function HelpfulLinksManagement() {
         }
         checkResponseForDelete(
             response.success,
-            'Error deleting facility',
-            'Facility successfully deleted'
+            'Error deleting link',
+            'Link successfully deleted'
         );
         closeDeleteLink();
     }


### PR DESCRIPTION
## Description of the change

We had unnecessary scrollbars (horizontal and vertical) that appeared on pages that included modals and tooltips that went off screen. This PR makes the following change:
* Removes the `relative` class from the modals. It didn't appear to be necessary.
* Changes the tooltip position on the Library Card for the Library Card and on the Facilities page to push to the left.

Resident:
Knowledge Center → Libraries — excess horizontal
Knowledge Center → Helpful Links — excess horizontal

Admin:
Knowledge Center Management → Libraries — excess horizontal
Knowledge Center Management → Videos — excess vertical
Knowledge Center Management → Helpful Links — excess vertical
Resident Management → excess vertical
Admin Management → excess vertical
Facility Management — excess horizontal, excess vertical

## Screenshot(s)

![image](https://github.com/user-attachments/assets/0d8af10c-ab48-493d-8702-b108ad74a771)


## Additional context

DaisyUI isn't intelligent enough to automatically clip tooltips or to push them away from the boundary of the container. This solution isn't ideal (since the tooltip overlaps on the icon to the left of it).


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1209699141721791