### PR TITLE
feat: add section status modification and archiving

### DIFF
--- a/backend/src/database/program_sections.go
+++ b/backend/src/database/program_sections.go
@@ -59,8 +59,7 @@ func (db *DB) GetProgramSectionDetailsByID(id int, args *models.QueryContext) ([
 	if err := query.Count(&args.Total).Error; err != nil {
 		return nil, newGetRecordsDBError(err, "programs")
 	}
-	query.Order("ps.start_dt desc")
-	if err := query.Limit(args.PerPage).Offset(args.CalcOffset()).Find(&sectionDetails).Error; err != nil {
+	if err := query.Limit(args.PerPage).Offset(args.CalcOffset()).Order(args.OrderClause()).Find(&sectionDetails).Error; err != nil {
 		return nil, newGetRecordsDBError(err, "programs")
 	}
 	return sectionDetails, nil

--- a/backend/src/handlers/programs_handler.go
+++ b/backend/src/handlers/programs_handler.go
@@ -16,7 +16,6 @@ func (srv *Server) registerProgramsRoutes() []routeDef {
 		{"DELETE /api/programs/{id}", srv.handleDeleteProgram, true, axx},
 		{"PATCH /api/programs/{id}", srv.handleUpdateProgram, true, axx},
 		{"PUT /api/programs/{id}/save", srv.handleFavoriteProgram, false, axx},
-		{"GET /api/programs/{id}/overview", srv.handleShowProgamOverview, true, axx},
 	}
 }
 
@@ -54,30 +53,6 @@ func (srv *Server) handleShowProgram(w http.ResponseWriter, r *http.Request, log
 type ProgramOverviewResponse struct {
 	models.Program
 	SectionDetails []models.ProgramSectionDetail `json:"section_details"`
-}
-
-func (srv *Server) handleShowProgamOverview(w http.ResponseWriter, r *http.Request, log sLog) error {
-	args := srv.getQueryContext(r)
-	id, err := strconv.Atoi(r.PathValue("id"))
-	if err != nil {
-		return newInvalidIdServiceError(err, "program ID")
-	}
-	program, err := srv.Db.GetProgramByID(id)
-	log.add("program_id", id)
-	if err != nil {
-		return newDatabaseServiceError(err)
-	}
-	sectionDetails, err := srv.Db.GetProgramSectionDetailsByID(id, &args)
-	if err != nil {
-		return newDatabaseServiceError(err)
-	}
-	response := make([]ProgramOverviewResponse, 0, 1)
-	overview := ProgramOverviewResponse{
-		Program:        *program,
-		SectionDetails: sectionDetails,
-	}
-	response = append(response, overview)
-	return writePaginatedResponse(w, http.StatusOK, response, args.IntoMeta())
 }
 
 type ProgramForm struct {

--- a/backend/src/handlers/sections_handler.go
+++ b/backend/src/handlers/sections_handler.go
@@ -24,7 +24,7 @@ func (srv *Server) handleGetSectionsForProgram(w http.ResponseWriter, r *http.Re
 		return newInvalidIdServiceError(err, "program ID")
 	}
 	args := srv.getQueryContext(r)
-	sections, err := srv.Db.GetSectionsForProgram(id, &args)
+	sections, err := srv.Db.GetProgramSectionDetailsByID(id, &args)
 	if err != nil {
 		log.add("program_id", id)
 		return newDatabaseServiceError(err)

--- a/backend/src/handlers/sections_handler_test.go
+++ b/backend/src/handlers/sections_handler_test.go
@@ -39,7 +39,7 @@ func TestHandleGetSectionsForProgram(t *testing.T) {
 					Page:    1,
 					PerPage: 10,
 				}
-				sections, err := server.Db.GetSectionsForProgram(int(id), &args)
+				sections, err := server.Db.GetProgramSectionDetailsByID(int(id), &args)
 				if err != nil {
 					t.Errorf("failed to get sections for program from db, error is %v", err)
 				}
@@ -282,7 +282,7 @@ func getSectionId() map[string]any {
 	if err != nil {
 		form["err"] = err
 	}
-	sections, err := server.Db.GetSectionsForProgram(int(programs[rand.Intn(len(programs))].ID), &args)
+	sections, err := server.Db.GetProgramSectionDetailsByID(int(programs[rand.Intn(len(programs))].ID), &args)
 	if err != nil {
 		form["err"] = err
 	}

--- a/backend/src/handlers/sections_handler_test.go
+++ b/backend/src/handlers/sections_handler_test.go
@@ -22,15 +22,15 @@ func TestHandleGetSectionsForProgram(t *testing.T) {
 	}
 	for _, test := range httpTests {
 		t.Run(test.testName, func(t *testing.T) {
-			progamIdMap := test.mapKeyValues
-			if progamIdMap["err"] != nil {
-				t.Fatalf("unable to get program id from db, error is %v", progamIdMap["err"])
+			programIdMap := test.mapKeyValues
+			if programIdMap["err"] != nil {
+				t.Fatalf("unable to get program id from db, error is %v", programIdMap["err"])
 			}
 			req, err := http.NewRequest(http.MethodGet, "/api/programs/{id}/sections", nil)
 			if err != nil {
 				t.Fatalf("unable to create new request, error is %v", err)
 			}
-			id := progamIdMap["id"].(uint)
+			id := programIdMap["id"].(uint)
 			req.SetPathValue("id", fmt.Sprintf("%d", id))
 			handler := getHandlerByRole(server.handleGetSectionsForProgram, test.role)
 			rr := executeRequest(t, req, handler, test)
@@ -43,7 +43,7 @@ func TestHandleGetSectionsForProgram(t *testing.T) {
 				if err != nil {
 					t.Errorf("failed to get sections for program from db, error is %v", err)
 				}
-				data := models.PaginatedResource[models.ProgramSection]{}
+				data := models.PaginatedResource[models.ProgramSectionDetail]{}
 				received := rr.Body.String()
 				if err = json.Unmarshal([]byte(received), &data); err != nil {
 					t.Errorf("failed to unmarshal resource, error is %v", err)
@@ -52,7 +52,7 @@ func TestHandleGetSectionsForProgram(t *testing.T) {
 					t.Errorf("handler returned unexpected total returned: got %v want %v", data.Meta.Total, args.Total)
 				}
 				for _, section := range sections {
-					if !slices.ContainsFunc(data.Data, func(sec models.ProgramSection) bool {
+					if !slices.ContainsFunc(data.Data, func(sec models.ProgramSectionDetail) bool {
 						return sec.ID == section.ID
 					}) {
 						t.Error("sections for program not found, out of sync")

--- a/backend/src/handlers/sections_handler_test.go
+++ b/backend/src/handlers/sections_handler_test.go
@@ -36,8 +36,9 @@ func TestHandleGetSectionsForProgram(t *testing.T) {
 			rr := executeRequest(t, req, handler, test)
 			if test.expectedStatusCode == http.StatusOK {
 				args := models.QueryContext{
-					Page:    1,
-					PerPage: 10,
+					Page:       1,
+					PerPage:    10,
+					FacilityID: 1,
 				}
 				sections, err := server.Db.GetProgramSectionDetailsByID(int(id), &args)
 				if err != nil {

--- a/backend/src/models/program_sections.go
+++ b/backend/src/models/program_sections.go
@@ -34,7 +34,7 @@ type ProgramSection struct {
 	CreditHours    *int64        `json:"credit_hours"`
 
 	Program  *Program              `json:"program" gorm:"foreignKey:ProgramID;references:ID"`
-	Facility *Facility             `json:"-" gorm:"foreignKey:FacilityID;references:ID"`
+	Facility *Facility             `json:"facility" gorm:"foreignKey:FacilityID;references:ID"`
 	Events   []ProgramSectionEvent `json:"events" gorm:"foreignKey:SectionID;references:ID"`
 }
 

--- a/backend/src/models/program_sections.go
+++ b/backend/src/models/program_sections.go
@@ -57,12 +57,7 @@ type ProgramSectionEnrollment struct {
 func (ProgramSectionEnrollment) TableName() string { return "program_section_enrollments" }
 
 type ProgramSectionDetail struct {
-	ID             int64      `json:"id"`
-	FacilityName   string     `json:"facility_name"`
-	InstructorName string     `json:"instructor_name"`
-	StartDt        time.Time  `json:"start_dt"`
-	Duration       string     `json:"duration"`
-	Capacity       string     `json:"capacity"`
-	Enrolled       int        `json:"enrolled"`
-	EndDt          *time.Time `json:"end_dt"`
+	ProgramSection
+	FacilityName string `json:"facility_name"`
+	Enrolled     int    `json:"enrolled"`
 }

--- a/frontend/src/Components/SectionStatus.tsx
+++ b/frontend/src/Components/SectionStatus.tsx
@@ -19,11 +19,20 @@ import {
 } from '@/common';
 import { KeyedMutator } from 'swr';
 
+export function isArchived(section: Section) {
+    if (
+        section.archived_at === null ||
+        section.archived_at === '0001-01-01T00:00:00Z'
+    )
+        return false;
+    return true;
+}
+
 function SelectedSectionStatusPill({
     archived,
     status
 }: {
-    archived: string | null;
+    archived: boolean;
     status: SelectedSectionStatus;
 }) {
     let icon, background;
@@ -58,11 +67,7 @@ function SelectedSectionStatusPill({
         >
             <ULIComponent icon={icon} />
             <span>{status}</span>
-            {archived === null || archived === '0001-01-01T00:00:00Z' ? (
-                <ULIComponent icon={ChevronDownIcon} />
-            ) : (
-                <div></div>
-            )}
+            {archived ? <div></div> : <ULIComponent icon={ChevronDownIcon} />}
         </div>
     );
 }
@@ -82,15 +87,11 @@ export default function SectionStatus({
     const [selectedModifyOption, setSelectedModifyOption] =
         useState<SectionStatusOptions>();
 
-    const notArchived =
-        section.archived_at === null ||
-        section.archived_at === '0001-01-01T00:00:00Z';
-
     function openSelectionModal(
         e: React.MouseEvent<HTMLDivElement, MouseEvent>,
         option: SectionStatusOptions
     ) {
-        if (!notArchived) return;
+        if (isArchived(section)) return;
         setDropdownOpen(false);
         setSelectedModifyOption(option);
         e.stopPropagation();
@@ -105,7 +106,7 @@ export default function SectionStatus({
             <div
                 className="relative"
                 onClick={(e) => {
-                    if (!notArchived) return;
+                    if (isArchived(section)) return;
                     setDropdownOpen(!dropdownOpen);
                     e.stopPropagation();
                 }}
@@ -117,7 +118,7 @@ export default function SectionStatus({
                 tabIndex={0}
             >
                 <SelectedSectionStatusPill
-                    archived={section.archived_at}
+                    archived={isArchived(section)}
                     status={selectedStatus}
                 />
                 {dropdownOpen && (

--- a/frontend/src/Components/SectionStatus.tsx
+++ b/frontend/src/Components/SectionStatus.tsx
@@ -1,0 +1,159 @@
+import { useEffect, useRef, useState } from 'react';
+import ULIComponent from './ULIComponent';
+import {
+    CheckCircleIcon,
+    ChevronDownIcon,
+    ClockIcon,
+    PauseCircleIcon,
+    PresentationChartLineIcon,
+    XCircleIcon
+} from '@heroicons/react/24/outline';
+import ModifySectionModal from './modals/ModifySectionModal';
+import { showModal } from './modals';
+import {
+    Section,
+    SectionStatusMap,
+    SectionStatusOptions,
+    SelectedSectionStatus,
+    ServerResponseMany
+} from '@/common';
+import { KeyedMutator } from 'swr';
+
+function SelectedSectionStatusPill({
+    archived,
+    status
+}: {
+    archived: string | null;
+    status: SelectedSectionStatus;
+}) {
+    let icon, background;
+
+    switch (status) {
+        case SelectedSectionStatus.Completed:
+            icon = CheckCircleIcon;
+            background = 'bg-[#DDFFCD] text-[#408D1C]';
+            break;
+        case SelectedSectionStatus.Canceled:
+            icon = XCircleIcon;
+            background = 'bg-[#FFDFDF] text-[#CA0000]';
+            break;
+        case SelectedSectionStatus.Paused:
+            icon = PauseCircleIcon;
+            background = 'bg-grey-2 text-body-text';
+            break;
+        case SelectedSectionStatus.Scheduled:
+            icon = ClockIcon;
+            background = 'bg-[#FFF3D4] text-[#ECAA00]';
+            break;
+        case SelectedSectionStatus.Active:
+            icon = PresentationChartLineIcon;
+            background = 'bg-[#B0DFDA] text-[#002E2A]';
+    }
+
+    if (!icon || !background) return;
+
+    return (
+        <div
+            className={`inline-flex items-center gap-1 catalog-pill mx-0 w-full justify-between ${background}`}
+        >
+            <ULIComponent icon={icon} />
+            <span>{status}</span>
+            {archived === null || archived === '0001-01-01T00:00:00Z' ? (
+                <ULIComponent icon={ChevronDownIcon} />
+            ) : (
+                <div></div>
+            )}
+        </div>
+    );
+}
+
+export default function SectionStatus({
+    section,
+    status,
+    mutateSections
+}: {
+    section: Section;
+    status: SelectedSectionStatus;
+    mutateSections: KeyedMutator<ServerResponseMany<Section>>;
+}) {
+    const [dropdownOpen, setDropdownOpen] = useState(false);
+    const [selectedStatus, setSelectedStatus] = useState(status);
+    const modifySectionRef = useRef<HTMLDialogElement>(null);
+    const [selectedModifyOption, setSelectedModifyOption] =
+        useState<SectionStatusOptions>();
+
+    const notArchived =
+        section.archived_at === null ||
+        section.archived_at === '0001-01-01T00:00:00Z';
+
+    function openSelectionModal(
+        e: React.MouseEvent<HTMLDivElement, MouseEvent>,
+        option: SectionStatusOptions
+    ) {
+        if (!notArchived) return;
+        setDropdownOpen(false);
+        setSelectedModifyOption(option);
+        e.stopPropagation();
+    }
+
+    useEffect(() => {
+        showModal(modifySectionRef);
+    }, [selectedModifyOption]);
+
+    return (
+        <>
+            <div
+                className="relative"
+                onClick={(e) => {
+                    if (!notArchived) return;
+                    setDropdownOpen(!dropdownOpen);
+                    e.stopPropagation();
+                }}
+                onBlur={(e) => {
+                    if (!e.currentTarget.contains(e.relatedTarget as Node)) {
+                        setDropdownOpen(false);
+                    }
+                }}
+                tabIndex={0}
+            >
+                <SelectedSectionStatusPill
+                    archived={section.archived_at}
+                    status={selectedStatus}
+                />
+                {dropdownOpen && (
+                    <ul
+                        className="absolute left-0 bg-inner-background rounded-box shadow-lg p-2 overflow-y-auto z-10 w-full"
+                        tabIndex={0}
+                    >
+                        {Object.values(SectionStatusOptions).map((option) => {
+                            if (SectionStatusMap[option] === selectedStatus)
+                                return null;
+
+                            return (
+                                <li key={option} className="w-full">
+                                    <div
+                                        className="flex items-center space-x-2 px-2 py-1 hover:bg-grey-2 rounded cursor-pointer"
+                                        onClick={(e) =>
+                                            openSelectionModal(e, option)
+                                        }
+                                    >
+                                        <span className="text-sm">
+                                            {option}
+                                        </span>
+                                    </div>
+                                </li>
+                            );
+                        })}
+                    </ul>
+                )}
+            </div>
+            <ModifySectionModal
+                ref={modifySectionRef}
+                action={selectedModifyOption}
+                section={section}
+                mutate={mutateSections}
+                setSelectedStatus={setSelectedStatus}
+            />
+        </>
+    );
+}

--- a/frontend/src/Components/inputs/CancelSubmitRow.tsx
+++ b/frontend/src/Components/inputs/CancelSubmitRow.tsx
@@ -6,11 +6,13 @@ import { DeleteButton } from './DeleteButton';
 export function CancelSubmitRow({
     type,
     onCancel,
-    onSubmit
+    onSubmit,
+    action
 }: {
     type: TextModalType;
     onCancel: () => void;
     onSubmit: () => void;
+    action?: string;
 }) {
     return (
         <form method="dialog" className="flex flex-row justify-between">
@@ -18,7 +20,10 @@ export function CancelSubmitRow({
             {type === TextModalType.Delete ? (
                 <DeleteButton onClick={onSubmit} />
             ) : type === TextModalType.Confirm ? (
-                <ConfirmButton onClick={onSubmit} />
+                <ConfirmButton
+                    onClick={onSubmit}
+                    action={action ?? 'Confirm'}
+                />
             ) : null}
         </form>
     );

--- a/frontend/src/Components/inputs/ConfirmButton.tsx
+++ b/frontend/src/Components/inputs/ConfirmButton.tsx
@@ -1,7 +1,13 @@
-export function ConfirmButton({ onClick }: { onClick: () => void }) {
+export function ConfirmButton({
+    action,
+    onClick
+}: {
+    action: string;
+    onClick: () => void;
+}) {
     return (
         <button className="btn btn-primary" onClick={onClick}>
-            Confirm
+            {action.charAt(0).toUpperCase() + action.slice(1)}
         </button>
     );
 }

--- a/frontend/src/Components/modals/ModifySectionModal.tsx
+++ b/frontend/src/Components/modals/ModifySectionModal.tsx
@@ -1,0 +1,99 @@
+import { TextOnlyModal } from './TextOnlyModal';
+import { closeModal, TextModalType } from '.';
+import { forwardRef } from 'react';
+import API from '@/api/api';
+import { useCheckResponse } from '@/Hooks/useCheckResponse';
+import { KeyedMutator } from 'swr';
+import {
+    Section,
+    SectionStatusMap,
+    SectionStatusOptions,
+    SelectedSectionStatus,
+    ServerResponseMany
+} from '@/common';
+
+export const StatusMessagesMap = {
+    [SectionStatusOptions.Complete]: {
+        title: 'Mark as Complete',
+        text: (status: string) =>
+            `Mark this ${status.toLocaleLowerCase()} section as complete?`
+    },
+    [SectionStatusOptions.Pause]: {
+        title: 'Pause Section',
+        text: (status: string) =>
+            `Are you sure you would like to pause this ${status.toLocaleLowerCase()} section?`
+    },
+    [SectionStatusOptions.Cancel]: {
+        title: 'Cancel Section',
+        text: (status: string) =>
+            `Are you sure you would like to cancel this ${status.toLocaleLowerCase()} section?`
+    },
+    [SectionStatusOptions.Schedule]: {
+        title: 'Mark as Scheduled',
+        text: (status: string) =>
+            `Mark this ${status.toLocaleLowerCase()} section as scheduled?`
+    },
+    [SectionStatusOptions.Active]: {
+        title: 'Mark as Active',
+        text: (status: string) =>
+            `Mark this ${status.toLocaleLowerCase()} section as active?`
+    }
+};
+
+const ModifySectionModal = forwardRef(function (
+    {
+        action,
+        section,
+        mutate,
+        setSelectedStatus
+    }: {
+        action: SectionStatusOptions | undefined;
+        section: Section;
+        mutate: KeyedMutator<ServerResponseMany<Section>>;
+        setSelectedStatus: React.Dispatch<
+            React.SetStateAction<SelectedSectionStatus>
+        >;
+    },
+    ref: React.ForwardedRef<HTMLDialogElement>
+) {
+    const checkResponse = useCheckResponse({
+        mutate: mutate,
+        refModal: ref
+    });
+    if (action === undefined) return;
+    const { title, text } = StatusMessagesMap[action] || {};
+    if (title === undefined || text === undefined) return;
+
+    async function onConfirm() {
+        const updatedStatus = SectionStatusMap[action!];
+        setSelectedStatus(updatedStatus);
+
+        const resp = await API.patch(`program-sections?id=${section.id}`, {
+            status: updatedStatus
+        });
+
+        checkResponse(
+            resp.success,
+            'Unable to update section',
+            'Section updated successfully'
+        );
+        return;
+    }
+    function close() {
+        closeModal(ref);
+    }
+    return (
+        <div onClick={(e) => e.stopPropagation()}>
+            <TextOnlyModal
+                ref={ref}
+                type={TextModalType.Confirm}
+                title={title}
+                text={text(section.status) ?? ''}
+                onSubmit={() => void onConfirm()}
+                onClose={close}
+            />
+        </div>
+    );
+});
+
+export default ModifySectionModal;

--- a/frontend/src/Components/modals/ModifySectionModal.tsx
+++ b/frontend/src/Components/modals/ModifySectionModal.tsx
@@ -16,27 +16,27 @@ export const StatusMessagesMap = {
     [SectionStatusOptions.Complete]: {
         title: 'Mark as Complete',
         text: (status: string) =>
-            `Mark this ${status.toLocaleLowerCase()} section as complete?`
+            `Mark this ${status.toLocaleLowerCase()} class as complete?`
     },
     [SectionStatusOptions.Pause]: {
         title: 'Pause Section',
         text: (status: string) =>
-            `Are you sure you would like to pause this ${status.toLocaleLowerCase()} section?`
+            `Are you sure you would like to pause this ${status.toLocaleLowerCase()} class?`
     },
     [SectionStatusOptions.Cancel]: {
         title: 'Cancel Section',
         text: (status: string) =>
-            `Are you sure you would like to cancel this ${status.toLocaleLowerCase()} section?`
+            `Are you sure you would like to cancel this ${status.toLocaleLowerCase()} class?`
     },
     [SectionStatusOptions.Schedule]: {
         title: 'Mark as Scheduled',
         text: (status: string) =>
-            `Mark this ${status.toLocaleLowerCase()} section as scheduled?`
+            `Mark this ${status.toLocaleLowerCase()} class as scheduled?`
     },
     [SectionStatusOptions.Active]: {
         title: 'Mark as Active',
         text: (status: string) =>
-            `Mark this ${status.toLocaleLowerCase()} section as active?`
+            `Mark this ${status.toLocaleLowerCase()} class as active?`
     }
 };
 
@@ -66,11 +66,11 @@ const ModifySectionModal = forwardRef(function (
 
     async function onConfirm() {
         const updatedStatus = SectionStatusMap[action!];
-        setSelectedStatus(updatedStatus);
 
         const resp = await API.patch(`program-sections?id=${section.id}`, {
-            status: updatedStatus
+            section_status: updatedStatus
         });
+        if (resp.success) setSelectedStatus(updatedStatus);
 
         checkResponse(
             resp.success,
@@ -88,7 +88,7 @@ const ModifySectionModal = forwardRef(function (
                 ref={ref}
                 type={TextModalType.Confirm}
                 title={title}
-                text={text(section.status) ?? ''}
+                text={text(section.section_status) ?? ''}
                 onSubmit={() => void onConfirm()}
                 onClose={close}
             />

--- a/frontend/src/Components/modals/TextOnlyModal.tsx
+++ b/frontend/src/Components/modals/TextOnlyModal.tsx
@@ -5,7 +5,7 @@ import { TextModalType } from '.';
 interface TextModalProps {
     type: TextModalType;
     title: string;
-    text: string;
+    text: string | ReactNode;
     onSubmit: () => void;
     onClose: () => void;
 }
@@ -28,7 +28,7 @@ export const TextOnlyModal = forwardRef(function TextModal(
                     <span className={`text-3xl font-semibold text-neutral`}>
                         {title}
                     </span>
-                    <p>{text}</p>
+                    {typeof text === 'string' ? <p>{text}</p> : text}
                     {type === TextModalType.Information ? (
                         <>{children}</>
                     ) : (
@@ -36,6 +36,7 @@ export const TextOnlyModal = forwardRef(function TextModal(
                             type={type}
                             onCancel={onClose}
                             onSubmit={onSubmit}
+                            action={title}
                         />
                     )}
                 </div>

--- a/frontend/src/Pages/ProgramOverviewDashboard.tsx
+++ b/frontend/src/Pages/ProgramOverviewDashboard.tsx
@@ -31,7 +31,7 @@ export default function ProgramOverview() {
     const [perPage, setPerPage] = useState(20);
     const [selectedSections, setSelectedSections] = useState<number[]>([]);
     const [searchTerm, setSearchTerm] = useState<string>('');
-    const [sortQuery, setSortQuery] = useState<string>('name_last asc');
+    const [sortQuery, setSortQuery] = useState<string>('ps.start_dt asc');
     const [includeArchived, setIncludeArchived] = useState(false);
     const archiveSectionsRef = useRef<HTMLDialogElement>(null);
     const [unableToArchiveSections, setUnableToArchiveSections] = useState<
@@ -53,7 +53,7 @@ export default function ProgramOverview() {
         error: sectionsError,
         mutate: mutateSections
     } = useSWR<ServerResponseMany<Section>, AxiosError>(
-        `/api/programs/${id}/sections?page=${page}&per_page=${perPage}`
+        `/api/programs/${id}/sections?page=${page}&per_page=${perPage}&order_by=${sortQuery}`
     );
 
     const sections = sectionsResp?.data;
@@ -198,12 +198,10 @@ export default function ProgramOverview() {
                         label="order by"
                         setState={setSortQuery}
                         enumType={{
-                            'Facility (A-Z)': 'facility_name asc',
-                            'Facility (Z-A)': 'facility_name desc',
-                            'Enrollment Count (Most)': 'enrollment desc',
-                            'Enrollment Count (Least)': 'enrollment asc',
-                            'Start Date (Earliest)': 'start_date asc',
-                            'Start Date (Latest)': 'start_date desc'
+                            'Enrollment Count (Most)': 'enrolled desc',
+                            'Enrollment Count (Least)': 'enrolled asc',
+                            'Start Date (Earliest)': 'ps.start_dt asc',
+                            'Start Date (Latest)': 'ps.start_dt desc'
                         }}
                     />
                     <div className="flex items-center">

--- a/frontend/src/common.ts
+++ b/frontend/src/common.ts
@@ -673,10 +673,10 @@ export interface Section {
     instructor_name: string;
     start_dt: string;
     end_dt: string;
-    status: SelectedSectionStatus;
+    section_status: SelectedSectionStatus;
     enrolled: number;
     capacity: number;
-    archived_at: string | null; // double check how this is returned, and if it would be null or undefined
+    archived_at: string | null;
 }
 
 export enum SelectedSectionStatus {

--- a/frontend/src/common.ts
+++ b/frontend/src/common.ts
@@ -665,20 +665,43 @@ export interface Program {
     facilities: Facility[];
 }
 
-export interface ProgramSectionDetail {
+export interface Section {
     id: number;
-    instructor_name: string;
+    program_id: number;
+    facility_id: number;
     facility_name: string;
-    start_dt: Date;
-    end_dt: Date;
-    capacity: number;
+    instructor_name: string;
+    start_dt: string;
+    end_dt: string;
+    status: SelectedSectionStatus;
     enrolled: number;
+    capacity: number;
+    archived_at: string | null; // double check how this is returned, and if it would be null or undefined
 }
 
-export interface ProgramDashboard extends Program {
-    section_details: ProgramSectionDetail[];
-    meta: PaginationMeta;
+export enum SelectedSectionStatus {
+    Scheduled = 'Scheduled',
+    Active = 'Active',
+    Paused = 'Paused',
+    Completed = 'Completed',
+    Canceled = 'Cancelled'
 }
+
+export enum SectionStatusOptions {
+    Complete = 'Complete',
+    Pause = 'Pause',
+    Cancel = 'Cancel',
+    Schedule = 'Schedule',
+    Active = 'Active'
+}
+
+export const SectionStatusMap = {
+    [SectionStatusOptions.Complete]: SelectedSectionStatus.Completed,
+    [SectionStatusOptions.Pause]: SelectedSectionStatus.Paused,
+    [SectionStatusOptions.Cancel]: SelectedSectionStatus.Canceled,
+    [SectionStatusOptions.Schedule]: SelectedSectionStatus.Scheduled,
+    [SectionStatusOptions.Active]: SelectedSectionStatus.Active
+};
 
 export interface ProgramTag {
     id: string;


### PR DESCRIPTION
## Description of the change

Admins are now able to manually update the status of the sections, which are displayed inside the program from the program management page. Some notes to consider before merging this PR are below.

- **Related issues**: [Change section status](https://app.asana.com/0/1209460078641109/1209693986941448/f)


## Screenshot(s)
Brief video of the functionality:

https://github.com/user-attachments/assets/c8b21519-fc66-40cc-bbae-1bce70d5dc0c

Furthermore, if the section is not allowed to be archived due to having students and either being in the ACTIVE or SCHEDULED states, the following will appear when they attempt to archive the section. This will NOT allow the invalid section to be archived, but will archive the valid section.
<img width="601" alt="Screenshot 2025-03-24 at 7 51 54 PM" src="https://github.com/user-attachments/assets/5475b012-d43d-4ecb-844e-abe35c8859a9" />



## Additional context
### Migration updates I'd like to make 
There are a few changes that might require a migration (if we feel significant enough), including the following:
- Archive column on create should be NULL rather than the zero timestamp it is now ('0001-01-01T00:00:00Z'). I have it handling for the zero timestamp case, but I don't think its preferred
- we currently do not have an end_dt on in the table. Should this be added? Was this planning on being calculated? Should I remove it from the UI for now?
- in the enum for section_status, we have it as "Cancelled" rather than "Canceled" (two L's vs one). American english commonly uses one L, but since the migration had 2 L's I updated the frontend to handle for that. Should we update to one L or keep it as 2?
- I am currently waiting on enrollment for section. This is why all sections show 0 enrollment, and why all sections at this moment can be archived. This ticket does handle the case where enrollment > 0 and status is active or scheduled (and does not allow the user to archive the section), but the variables might need to be updated on this page when that happens.

### To test
You can run the following query to add some sections into the DB:
```
INSERT INTO program_sections (id, program_id, facility_id, instructor_name, start_dt, status, capacity, archived_at) VALUES
(21, 2, 1, 'Linus Torvalds', '2021-07-01', 'Cancelled', 15, NULL),
(22, 2, 1, 'Alex Trebek', '2021-08-01', 'Active', 14, NULL),
(23, 2, 1, 'Mark Smith', '2021-09-01', 'Paused', 16, NULL),
(24, 2, 2, 'Ada Lovelace', '2021-10-01', 'Scheduled', 20, NULL),
(25, 2, 3, 'Grace Hopper', '2021-11-01', 'Completed', 25, '2021-12-01')
```
You then have to check your DB to see what program has the ID of 2. In my experience it has been AA/NA, but it might vary. Just check the ids on the `program_sections` table.

### Misc
I would like to remove the `delete` api for sections as we have established sections will not be deleted, and instead are archived, however, this is difficult when running the sections handler test, since it creates programs, updates them, and then cleans it up by deleting them. Would we like to keep that endpoint for solely this reason, or is there an alternative solution?