### PR TITLE
feat: add doc number to profile overview and search

### DIFF
--- a/backend/migrations/00043_add_doc_to_users.sql
+++ b/backend/migrations/00043_add_doc_to_users.sql
@@ -1,9 +1,0 @@
--- +goose Up
--- +goose StatementBegin
-ALTER TABLE public.users ADD COLUMN doc_id VARCHAR(32);
--- +goose StatementEnd
-
--- +goose Down
--- +goose StatementBegin
-ALTER TABLE public.users DROP COLUMN doc_id;
--- +goose StatementEnd

--- a/backend/migrations/00043_add_doc_to_users.sql
+++ b/backend/migrations/00043_add_doc_to_users.sql
@@ -1,0 +1,9 @@
+-- +goose Up
+-- +goose StatementBegin
+ALTER TABLE public.users ADD COLUMN doc_id VARCHAR(32);
+-- +goose StatementEnd
+
+-- +goose Down
+-- +goose StatementBegin
+ALTER TABLE public.users DROP COLUMN doc_id;
+-- +goose StatementEnd

--- a/backend/src/handlers/auth.go
+++ b/backend/src/handlers/auth.go
@@ -32,6 +32,7 @@ type (
 		KratosID      string                 `json:"kratos_id"`
 		FeatureAccess []models.FeatureAccess `json:"feature_access"`
 		SessionID     string                 `json:"session_id"`
+		DOC_ID        string                 `json:"doc_id"`
 	}
 )
 
@@ -165,6 +166,7 @@ func (srv *Server) handleCheckAuth(w http.ResponseWriter, r *http.Request, log s
 	traits["created_at"] = user.CreatedAt
 	traits["name_first"] = user.NameFirst
 	traits["name_last"] = user.NameLast
+	traits["doc_id"] = user.DOC_ID
 	if traits["feature_access"] == nil || len(srv.features) == 0 {
 		traits["feature_access"] = []models.FeatureAccess{}
 	}

--- a/backend/src/handlers/auth.go
+++ b/backend/src/handlers/auth.go
@@ -32,7 +32,7 @@ type (
 		KratosID      string                 `json:"kratos_id"`
 		FeatureAccess []models.FeatureAccess `json:"feature_access"`
 		SessionID     string                 `json:"session_id"`
-		DOC_ID        string                 `json:"doc_id"`
+		DocID         string                 `json:"doc_id"`
 	}
 )
 
@@ -56,6 +56,7 @@ func (claims *Claims) getTraits() map[string]any {
 		"password_reset": claims.PasswordReset,
 		"facility_name":  claims.FacilityName,
 		"feature_access": claims.FeatureAccess,
+		"doc_id":         claims.DocID,
 	}
 }
 
@@ -166,7 +167,6 @@ func (srv *Server) handleCheckAuth(w http.ResponseWriter, r *http.Request, log s
 	traits["created_at"] = user.CreatedAt
 	traits["name_first"] = user.NameFirst
 	traits["name_last"] = user.NameLast
-	traits["doc_id"] = user.DOC_ID
 	if traits["feature_access"] == nil || len(srv.features) == 0 {
 		traits["feature_access"] = []models.FeatureAccess{}
 	}

--- a/backend/src/handlers/user_handler.go
+++ b/backend/src/handlers/user_handler.go
@@ -217,8 +217,8 @@ func (srv *Server) handleUpdateUser(w http.ResponseWriter, r *http.Request, log 
 		// usernames are immutable
 		return newBadRequestServiceError(errors.New("username cannot be updated"), "username")
 	}
-	if user.DOC_ID == "" && toUpdate.DOC_ID != "" {
-		user.DOC_ID = toUpdate.DOC_ID
+	if user.DocID == "" && toUpdate.DocID != "" {
+		user.DocID = toUpdate.DocID
 	}
 	invalidUser := validateUser(&user)
 	if invalidUser != "" {

--- a/backend/src/handlers/user_handler.go
+++ b/backend/src/handlers/user_handler.go
@@ -217,6 +217,9 @@ func (srv *Server) handleUpdateUser(w http.ResponseWriter, r *http.Request, log 
 		// usernames are immutable
 		return newBadRequestServiceError(errors.New("username cannot be updated"), "username")
 	}
+	if user.DOC_ID == "" && toUpdate.DOC_ID != "" {
+		user.DOC_ID = toUpdate.DOC_ID
+	}
 	invalidUser := validateUser(&user)
 	if invalidUser != "" {
 		return newBadRequestServiceError(errors.New("invalid username"), invalidUser)

--- a/backend/src/models/resource.go
+++ b/backend/src/models/resource.go
@@ -102,5 +102,8 @@ func (q QueryContext) OrderClause() string {
 }
 
 func (q QueryContext) SearchQuery() string {
+	if q.Search == "" {
+		return ""
+	}
 	return "%" + q.Search + "%"
 }

--- a/backend/src/models/users.go
+++ b/backend/src/models/users.go
@@ -39,6 +39,7 @@ type User struct {
 	Role       UserRole `gorm:"size:64;default:student" json:"role" validate:"oneof=student system_admin facility_admin department_admin"`
 	KratosID   string   `gorm:"size:255" json:"kratos_id"`
 	FacilityID uint     `json:"facility_id"`
+	DOC_ID     string   `json:"doc_id" gorm:"column:doc_id;size:25"`
 
 	/* foreign keys */
 	Mappings             []ProviderUserMapping `json:"mappings,omitempty" gorm:"foreignKey:UserID;constraint:OnDelete CASCADE"`

--- a/backend/src/models/users.go
+++ b/backend/src/models/users.go
@@ -39,7 +39,7 @@ type User struct {
 	Role       UserRole `gorm:"size:64;default:student" json:"role" validate:"oneof=student system_admin facility_admin department_admin"`
 	KratosID   string   `gorm:"size:255" json:"kratos_id"`
 	FacilityID uint     `json:"facility_id"`
-	DOC_ID     string   `json:"doc_id" gorm:"column:doc_id;size:25"`
+	DocID      string   `json:"doc_id" gorm:"column:doc_id;size:25"`
 
 	/* foreign keys */
 	Mappings             []ProviderUserMapping `json:"mappings,omitempty" gorm:"foreignKey:UserID;constraint:OnDelete CASCADE"`

--- a/frontend/src/Components/modals/index.ts
+++ b/frontend/src/Components/modals/index.ts
@@ -242,6 +242,13 @@ export const getUserInputs = (
                     'Username can only contain letters and numbers without spaces'
             },
             disabled: action === CRUDActions.Edit
+        },
+        {
+            type: FormInputTypes.Text,
+            label: 'Department Of Corrections ID',
+            interfaceRef: 'doc_id',
+            required: false,
+            length: 25
         }
     ];
     if (AdminRoles.includes(userRole)) {

--- a/frontend/src/Components/modals/index.ts
+++ b/frontend/src/Components/modals/index.ts
@@ -245,9 +245,9 @@ export const getUserInputs = (
         },
         {
             type: FormInputTypes.Text,
-            label: 'Department Of Corrections ID',
+            label: 'Department of Corrections ID',
             interfaceRef: 'doc_id',
-            required: false,
+            required: true,
             length: 25
         }
     ];

--- a/frontend/src/Pages/ResidentProfile.tsx
+++ b/frontend/src/Pages/ResidentProfile.tsx
@@ -72,6 +72,14 @@ const ResidentProfile = () => {
                                             </div>
                                         </div>
                                         <div className="grid grid-cols-2">
+                                            <p>DOC ID</p>
+                                            <div className="flex flex-row justify-between">
+                                                <p>:</p>
+                                                {metrics.user.doc_id}
+                                            </div>
+                                        </div>
+
+                                        <div className="grid grid-cols-2">
                                             <p>Joined</p>
                                             <div className="flex flex-row justify-between">
                                                 <p>:</p>

--- a/frontend/src/Pages/StudentManagement.tsx
+++ b/frontend/src/Pages/StudentManagement.tsx
@@ -179,9 +179,10 @@ export default function StudentManagement() {
                 <div className="relative w-full" style={{ overflowX: 'clip' }}>
                     <table className="table-2 mb-4">
                         <thead>
-                            <tr className="grid grid-cols-5 px-4">
+                            <tr className="grid grid-cols-6 px-4">
                                 <th className="justify-self-start">Name</th>
                                 <th>Username</th>
+                                <th>DOC ID</th>
                                 <th>Last Updated</th>
                                 <th>Created At</th>
                                 <th className="justify-self-end pr-4">
@@ -198,7 +199,7 @@ export default function StudentManagement() {
                                     return (
                                         <tr
                                             key={user.id}
-                                            className="card p-4 w-full grid-cols-5 justify-items-center cursor-pointer"
+                                            className="card p-4 w-full grid-cols-6 justify-items-center cursor-pointer"
                                             onClick={() =>
                                                 handleShowUserProfileClick(
                                                     user.id
@@ -210,6 +211,7 @@ export default function StudentManagement() {
                                                 {user.name_last}
                                             </td>
                                             <td>{user.username}</td>
+                                            <td>{user.doc_id}</td>
                                             <td>
                                                 <div
                                                     className="tooltip"

--- a/frontend/src/common.ts
+++ b/frontend/src/common.ts
@@ -18,6 +18,7 @@ export interface User {
     name_first: string;
     name_last: string;
     username: string;
+    doc_id: string;
     role: UserRole;
     email: string;
     password_reset?: boolean;


### PR DESCRIPTION
## Description of the change

This pull request: 

- 	Adds the ability for an admin to add the users DOC number during creation
- 	Adds the ability for an admin to search for the user with their DOC number
- 	Adds the residents DOC number to the profile overview page

- **Related issues**: Closes id 38 

## Screenshot(s)

![image](https://github.com/user-attachments/assets/9a746ebf-10c4-460c-b0f1-f78d74c9ecc9)
![image](https://github.com/user-attachments/assets/780626bb-10a5-4b70-94c3-d5404beb0658)
![image](https://github.com/user-attachments/assets/2c20699b-76e7-47de-ad2d-403fade289ec)

## Asana 
https://app.asana.com/0/1209460078641109/1209485070839620/f