### PR TITLE
Fix pass reset permissions and video thumbnail issues

### DIFF
--- a/frontend/src/Components/FavoriteCard.tsx
+++ b/frontend/src/Components/FavoriteCard.tsx
@@ -47,6 +47,15 @@ const FavoriteCard: React.FC<FavoriteCardProps> = ({
         }
     };
 
+    function getThumbnailUrl(oc: OpenContentItem): string {
+        switch (oc.content_type) {
+            case 'video':
+                return `/api/photos/${oc.external_id}.jpg`;
+            default:
+                return oc.thumbnail_url ?? '/ul-logo.png';
+        }
+    }
+
     const handleUnfavorite = async () => {
         let endpoint = '';
         let payload = {};
@@ -106,7 +115,7 @@ const FavoriteCard: React.FC<FavoriteCardProps> = ({
                 </div>
             )}
             <img
-                src={favorite.thumbnail_url ?? '/ul-logo.png'}
+                src={getThumbnailUrl(favorite)}
                 alt={favorite.title}
                 className="h-16 mx-auto object-contain"
             />

--- a/frontend/src/Components/VideoCard.tsx
+++ b/frontend/src/Components/VideoCard.tsx
@@ -106,8 +106,8 @@ export default function VideoCard({
             <div className="flex flex-col p-4 gap-2 border-b-2">
                 <figure className="w-1/2 mx-auto bg-cover">
                     <img
-                        src={video?.thumbnail_url ?? '/youtube.png'}
-                        alt={`${video.title} thumbnail`}
+                        src={`/api/photos/${video.external_id}.jpg`}
+                        alt={`/youtube.png`}
                     />
                 </figure>
                 <ClampedText as="h3" className="body text-center h-10 my-auto">

--- a/frontend/src/Components/cards/OpenContentCard.tsx
+++ b/frontend/src/Components/cards/OpenContentCard.tsx
@@ -35,6 +35,14 @@ export default function OpenContentCardRow({
                 : {};
         navigate(basePath, obj);
     }
+    function getThumbnailUrl(oc: OpenContentItem): string {
+        switch (oc.content_type) {
+            case 'video':
+                return `/api/photos/${oc.external_id}.jpg`;
+            default:
+                return oc.thumbnail_url ?? '/ul-logo.png';
+        }
+    }
     return (
         <div
             className={`card ${content.visibility_status == null || content.visibility_status ? 'cursor-pointer' : 'bg-grey-2 cursor-not-allowed'} flex flex-row w-full gap-3 px-4 py-2 tooltip`}
@@ -47,7 +55,7 @@ export default function OpenContentCardRow({
             <div>
                 <img
                     className="h-8 mx-auto object-contain"
-                    src={content.thumbnail_url ?? ''}
+                    src={getThumbnailUrl(content)}
                 ></img>
             </div>
             <ClampedText

--- a/provider-middleware/video_dl.go
+++ b/provider-middleware/video_dl.go
@@ -136,9 +136,10 @@ func (yt *VideoService) putAllCurrentVideoMetadata(ctx context.Context) error {
 			return err
 		}
 		input := &s3.PutObjectInput{
-			Bucket: aws.String(yt.bucketName),
-			Body:   bytes.NewReader(videoBytes),
-			Key:    aws.String(video.GetS3KeyJson()),
+			Bucket:      aws.String(yt.bucketName),
+			Body:        bytes.NewReader(videoBytes),
+			Key:         aws.String(video.GetS3KeyJson()),
+			IfNoneMatch: aws.String(video.GetS3KeyJson()),
 		}
 		resp, err := yt.s3Svc.PutObject(ctx, input)
 		if err != nil {


### PR DESCRIPTION
the Video thumbnails kept resetting for some reason. since we are storing them on the backend as `external_id.jpg`, we can just read them from the backend in the same format.

this also prevents any admin from `curl`ing a post request to reset any other admin's password 