### PR TITLE
fix: fix history navigation

### DIFF
--- a/frontend/src/Components/VideoContent.tsx
+++ b/frontend/src/Components/VideoContent.tsx
@@ -18,13 +18,12 @@ import { LibrarySearchBar } from './inputs';
 import LibrarySearchResultsModal from './LibrarySearchResultsModal';
 import ToggleView from '@/Components/ToggleView';
 import { useSessionViewType } from '@/Hooks/sessionView';
+import { useUrlPagination } from '@/Hooks/paginationUrlSync';
 
 export default function VideoContent() {
     const { user } = useAuth();
     const [searchTerm, setSearchTerm] = useState('');
     const searchQuery = useDebounceValue(searchTerm, 300);
-    const [perPage, setPerPage] = useState(12);
-    const [pageQuery, setPageQuery] = useState(1);
     const [sortQuery, setSortQuery] = useState('created_at DESC');
     const route = useLocation();
     const modalRef = useRef<HTMLDialogElement>(null);
@@ -32,6 +31,14 @@ export default function VideoContent() {
         null
     );
     const [activeView, setActiveView] = useSessionViewType('videoView');
+
+    const {
+        page: pageQuery,
+        perPage,
+        setPage: setPageQuery,
+        setPerPage
+    } = useUrlPagination(1, 20);
+
     const adminWithStudentView = (): boolean => {
         return !route.pathname.includes('management') && isAdministrator(user);
     };
@@ -67,11 +74,6 @@ export default function VideoContent() {
     if (!user) {
         return null;
     }
-    const handleSetPerPage = (val: number) => {
-        setPerPage(val);
-        setPageQuery(1);
-        void mutate();
-    };
 
     return (
         <>
@@ -126,7 +128,7 @@ export default function VideoContent() {
                     <Pagination
                         meta={meta}
                         setPage={setPageQuery}
-                        setPerPage={handleSetPerPage}
+                        setPerPage={setPerPage}
                     />
                 </div>
             )}

--- a/frontend/src/Hooks/paginationUrlSync.tsx
+++ b/frontend/src/Hooks/paginationUrlSync.tsx
@@ -1,0 +1,29 @@
+import { useSearchParams } from 'react-router-dom';
+
+export function useUrlPagination(defaultPage = 1, defaultPerPage = 20) {
+    const [searchParams, setSearchParams] = useSearchParams();
+
+    const page = parseInt(
+        searchParams.get('page') ?? defaultPage.toString(),
+        10
+    );
+    const perPage = parseInt(
+        searchParams.get('per_page') ?? defaultPerPage.toString(),
+        10
+    );
+
+    const setPage = (newPage: number, options?: { replace?: boolean }) => {
+        const params = new URLSearchParams(searchParams);
+        params.set('page', newPage.toString());
+        setSearchParams(params, { replace: options?.replace ?? false });
+    };
+
+    const setPerPage = (newPerPage: number) => {
+        const params = new URLSearchParams(searchParams);
+        params.set('per_page', newPerPage.toString());
+        params.set('page', '1');
+        setSearchParams(params, { replace: false });
+    };
+
+    return { page, perPage, setPage, setPerPage };
+}

--- a/frontend/src/Pages/AdminManagement.tsx
+++ b/frontend/src/Pages/AdminManagement.tsx
@@ -35,6 +35,7 @@ import {
 } from '@/Components/modals';
 import { useCheckResponse } from '@/Hooks/useCheckResponse';
 import { useAuth, isSysAdmin, isDeptAdmin, isFacilityAdmin } from '@/useAuth';
+import { useUrlPagination } from '@/Hooks/paginationUrlSync';
 
 const canEdit = (currentUser: User, targetUser: User): boolean => {
     return (
@@ -60,10 +61,15 @@ export default function AdminManagement() {
     const [tempPassword, setTempPassword] = useState<string>('');
     const [searchTerm, setSearchTerm] = useState('');
     const searchQuery = useDebounceValue(searchTerm, 300);
-    const [perPage, setPerPage] = useState(10);
-    const [pageQuery, setPageQuery] = useState(1);
+
     const [sortQuery, setSortQuery] = useState('created_at DESC');
     const { toaster } = useToast();
+    const {
+        page: pageQuery,
+        perPage,
+        setPage: setPageQuery,
+        setPerPage
+    } = useUrlPagination(1, 20);
 
     const { user } = useAuth();
     const newAdminRole: UserRole = isSysAdmin(user!)
@@ -110,12 +116,6 @@ export default function AdminManagement() {
     const handleChange = (newSearch: string) => {
         setSearchTerm(newSearch);
         setPageQuery(1);
-    };
-
-    const handleSetPerPage = (val: number) => {
-        setPerPage(val);
-        setPageQuery(1);
-        void mutate();
     };
 
     function handleCancelModal(ref: ForwardedRef<HTMLDialogElement>) {
@@ -337,7 +337,7 @@ export default function AdminManagement() {
                                 <Pagination
                                     meta={meta}
                                     setPage={setPageQuery}
-                                    setPerPage={handleSetPerPage}
+                                    setPerPage={setPerPage}
                                 />
                             )}
                     </div>

--- a/frontend/src/Pages/FacilityManagement.tsx
+++ b/frontend/src/Pages/FacilityManagement.tsx
@@ -18,6 +18,7 @@ import {
     TextOnlyModal
 } from '@/Components/modals';
 import { useCheckResponse } from '@/Hooks/useCheckResponse';
+import { useUrlPagination } from '@/Hooks/paginationUrlSync';
 
 export default function FacilityManagement() {
     const addFacilityModal = useRef<HTMLDialogElement>(null);
@@ -27,8 +28,12 @@ export default function FacilityManagement() {
     const [targetFacility, setTargetFacility] =
         useState<TargetItem<Facility> | null>(null);
 
-    const [perPage, setPerPage] = useState(10);
-    const [pageQuery, setPageQuery] = useState(1);
+    const {
+        page: pageQuery,
+        perPage,
+        setPage: setPageQuery,
+        setPerPage
+    } = useUrlPagination(1, 20);
 
     const {
         data: facility,
@@ -58,12 +63,6 @@ export default function FacilityManagement() {
             showModal(ref);
         }
     }, [targetFacility]);
-
-    const handleSetPerPage = (val: number) => {
-        setPerPage(val);
-        setPageQuery(1);
-        void mutate();
-    };
 
     const deleteFacility = async () => {
         if (targetFacility?.target.id == 1) {
@@ -149,7 +148,7 @@ export default function FacilityManagement() {
                         <Pagination
                             meta={facility?.meta}
                             setPage={setPageQuery}
-                            setPerPage={handleSetPerPage}
+                            setPerPage={setPerPage}
                         />
                     )}
             </div>

--- a/frontend/src/Pages/Favorites.tsx
+++ b/frontend/src/Pages/Favorites.tsx
@@ -15,13 +15,18 @@ import FavoriteCard from '@/Components/FavoriteCard';
 import { isAdministrator, useAuth } from '@/useAuth';
 import ToggleView from '@/Components/ToggleView';
 import { useSessionViewType } from '@/Hooks/sessionView';
+import { useUrlPagination } from '@/Hooks/paginationUrlSync';
 
 export default function FavoritesPage() {
     const { user } = useAuth();
-    const [perPage, setPerPage] = useState(12);
-    const [pageQuery, setPageQuery] = useState(1);
     const [searchTerm, setSearchTerm] = useState<string>('');
     const [activeView, setActiveView] = useSessionViewType('favoritesView');
+    const {
+        page: pageQuery,
+        perPage,
+        setPage: setPageQuery,
+        setPerPage
+    } = useUrlPagination(1, 20);
     const searchQuery = useDebounceValue(searchTerm, 500);
     const [sortQuery, setSortQuery] = useState<string>(
         FilterLibrariesVidsandHelpfulLinksResident['Title (A to Z)']
@@ -39,10 +44,6 @@ export default function FavoritesPage() {
     const favorites = data?.data ?? [];
     const meta = data?.meta;
 
-    const handleSetPerPage = (val: number) => {
-        setPerPage(val);
-        setPageQuery(1);
-    };
     const handleChange = (newSearch: string) => {
         setSearchTerm(newSearch);
         setPageQuery(1);
@@ -98,7 +99,7 @@ export default function FavoritesPage() {
                     <Pagination
                         meta={meta}
                         setPage={setPageQuery}
-                        setPerPage={handleSetPerPage}
+                        setPerPage={setPerPage}
                     />
                 </div>
             )}

--- a/frontend/src/Pages/HelpfulLinks.tsx
+++ b/frontend/src/Pages/HelpfulLinks.tsx
@@ -16,17 +16,23 @@ import { useState } from 'react';
 import useSWR from 'swr';
 import ToggleView from '@/Components/ToggleView';
 import { useSessionViewType } from '@/Hooks/sessionView';
+import { useUrlPagination } from '@/Hooks/paginationUrlSync';
 
 export default function HelpfulLinks() {
-    const [perPage, setPerPage] = useState(20);
     const [searchTerm, setSearchTerm] = useState<string>('');
     const [activeView, setActiveView] = useSessionViewType('helpfulLinksView');
+    const {
+        page: pageQuery,
+        perPage,
+        setPage: setPageQuery,
+        setPerPage
+    } = useUrlPagination(1, 20);
+
     const searchQuery = useDebounceValue(searchTerm, 500);
     const [sortQuery, setSortQuery] = useState<string>(
         FilterLibrariesVidsandHelpfulLinksResident['Title (A to Z)']
     );
 
-    const [pageQuery, setPageQuery] = useState<number>(1);
     const {
         data: helpfulLinks,
         mutate: mutateHelpfulFavs,
@@ -38,11 +44,7 @@ export default function HelpfulLinks() {
     function updateFavorites() {
         void mutateHelpfulFavs();
     }
-    const handleSetPerPage = (perPage: number) => {
-        setPerPage(perPage);
-        setPageQuery(1);
-        updateFavorites();
-    };
+
     const helpfulLinksMeta = helpfulLinks?.data?.meta ?? {
         total: 0,
         per_page: 20,
@@ -105,7 +107,7 @@ export default function HelpfulLinks() {
                     <Pagination
                         meta={helpfulLinksMeta}
                         setPage={setPageQuery}
-                        setPerPage={handleSetPerPage}
+                        setPerPage={setPerPage}
                     />
                 </div>
             )}

--- a/frontend/src/Pages/HelpfulLinksManagement.tsx
+++ b/frontend/src/Pages/HelpfulLinksManagement.tsx
@@ -31,6 +31,7 @@ import {
 } from '@/Components/modals';
 import { useCheckResponse } from '@/Hooks/useCheckResponse';
 import { useSessionViewType } from '@/Hooks/sessionView';
+import { useUrlPagination } from '@/Hooks/paginationUrlSync';
 
 export default function HelpfulLinksManagement() {
     const { user } = useAuth();
@@ -38,8 +39,6 @@ export default function HelpfulLinksManagement() {
     const editLinkModal = useRef<HTMLDialogElement>(null);
     const deleteLinkModal = useRef<HTMLDialogElement>(null);
     const [currentLink, setCurrentLink] = useState<HelpfulLink | null>(null);
-    const [perPage, setPerPage] = useState<number>(10);
-    const [pageQuery, setPageQuery] = useState<number>(1);
     const [searchTerm, setSearchTerm] = useState<string>('');
     const searchQuery = useDebounceValue(searchTerm, 500);
     const [activeView, setActiveView] = useSessionViewType(
@@ -48,6 +47,12 @@ export default function HelpfulLinksManagement() {
     const [sortQuery, setSortQuery] = useState<string>(
         FilterLibrariesVidsandHelpfulLinksResident['Title (A to Z)']
     );
+    const {
+        page: pageQuery,
+        perPage,
+        setPage: setPageQuery,
+        setPerPage
+    } = useUrlPagination(1, 20);
     const { toaster } = useToast();
     const { data, mutate, error, isLoading } = useSWR<
         ServerResponseOne<HelpfulLinkAndSort>,
@@ -100,11 +105,6 @@ export default function HelpfulLinksManagement() {
         setPageQuery(1);
     };
 
-    const handleSetPerPage = (val: number) => {
-        setPerPage(val);
-        setPageQuery(1);
-        void mutate();
-    };
     return (
         <>
             <div className="flex flex-row justify-between items-center">
@@ -174,7 +174,7 @@ export default function HelpfulLinksManagement() {
                     <Pagination
                         meta={meta}
                         setPage={setPageQuery}
-                        setPerPage={handleSetPerPage}
+                        setPerPage={setPerPage}
                     />
                 </div>
             )}

--- a/frontend/src/Pages/OpenContent.tsx
+++ b/frontend/src/Pages/OpenContent.tsx
@@ -29,8 +29,8 @@ export default function OpenContent() {
     }, [activeTab]);
 
     const handlePageChange = (tab: Tab) => {
-        setActiveTab(tab);
         navigate(`/knowledge-center/${String(tab.value).toLowerCase()}`);
+        setActiveTab(tab);
     };
     const handleReturnToAdminView = () => {
         if (currentTabValue === 'favorites') {

--- a/frontend/src/Pages/OpenContentManagement.tsx
+++ b/frontend/src/Pages/OpenContentManagement.tsx
@@ -23,13 +23,20 @@ export default function OpenContentManagement() {
     }, [activeTab]);
 
     const handlePageChange = (tab: Tab) => {
-        setActiveTab(tab);
         navigate(`/knowledge-center-management/${tab.value}`);
+        setActiveTab(tab);
     };
 
     function navigateToStudentView() {
         navigate(`/knowledge-center/${activeTab.value}`);
     }
+    const getTabFromPath = (pathname: string) =>
+        tabOptions.find((t) => t.value === pathname.split('/')[2]) ??
+        tabOptions[0];
+
+    useEffect(() => {
+        setActiveTab(getTabFromPath(location.pathname));
+    }, [location.pathname]);
 
     return (
         <div className="px-5 pb-4">

--- a/frontend/src/Pages/ProgramManagement.tsx
+++ b/frontend/src/Pages/ProgramManagement.tsx
@@ -12,6 +12,7 @@ import Pagination from '@/Components/Pagination';
 import { useNavigate } from 'react-router-dom';
 import CategoryDropdownFilter from '@/Components/CategoryDropdownFilter';
 import { useSessionViewType } from '@/Hooks/sessionView';
+import { useUrlPagination } from '@/Hooks/paginationUrlSync';
 
 export enum sortPrograms {}
 
@@ -19,8 +20,13 @@ export default function ProgramManagement() {
     const { user } = useAuth();
     const [activeView, setActiveView] = useSessionViewType('programView');
     const [searchTerm, setSearchTerm] = useState('');
-    const [page, setPage] = useState(1);
-    const [perPage, setPerPage] = useState(20);
+    const {
+        page: page,
+        perPage,
+        setPage: setPage,
+        setPerPage
+    } = useUrlPagination(1, 20);
+
     const [categoryQueryString, setCategoryQueryString] = useState<string>('');
     const navigate = useNavigate();
     const { data, error, mutate } = useSWR<

--- a/frontend/src/Pages/StudentManagement.tsx
+++ b/frontend/src/Pages/StudentManagement.tsx
@@ -35,6 +35,7 @@ import {
 } from '@/Components/modals';
 import { useCheckResponse } from '@/Hooks/useCheckResponse';
 import { useNavigate } from 'react-router-dom';
+import { useUrlPagination } from '@/Hooks/paginationUrlSync';
 
 export default function StudentManagement() {
     const addUserModal = useRef<HTMLDialogElement>(null);
@@ -47,9 +48,14 @@ export default function StudentManagement() {
     const { toaster } = useToast();
     const [searchTerm, setSearchTerm] = useState('');
     const searchQuery = useDebounceValue(searchTerm, 300);
-    const [pageQuery, setPageQuery] = useState(1);
     const [sortQuery, setSortQuery] = useState('created_at DESC');
-    const [perPage, setPerPage] = useState(10);
+    const {
+        page: pageQuery,
+        perPage,
+        setPage: setPageQuery,
+        setPerPage
+    } = useUrlPagination(1, 20);
+
     const { data, mutate, error, isLoading } = useSWR<
         ServerResponseMany<User>,
         AxiosError
@@ -129,11 +135,6 @@ export default function StudentManagement() {
     const handleChange = (newSearch: string) => {
         setSearchTerm(newSearch);
         setPageQuery(1);
-    };
-    const handleSetPerPage = (val: number) => {
-        setPerPage(val);
-        setPageQuery(1);
-        void mutate();
     };
 
     const navigate = useNavigate();
@@ -322,7 +323,7 @@ export default function StudentManagement() {
                                 <Pagination
                                     meta={meta}
                                     setPage={setPageQuery}
-                                    setPerPage={handleSetPerPage}
+                                    setPerPage={setPerPage}
                                 />
                             )}
                     </div>

--- a/frontend/src/Pages/VideoManagement.tsx
+++ b/frontend/src/Pages/VideoManagement.tsx
@@ -30,6 +30,7 @@ import { LibrarySearchBar } from '@/Components/inputs';
 import LibrarySearchResultsModal from '@/Components/LibrarySearchResultsModal';
 import ToggleView from '@/Components/ToggleView';
 import { useSessionViewType } from '@/Hooks/sessionView';
+import { useUrlPagination } from '@/Hooks/paginationUrlSync';
 
 export default function VideoManagement() {
     const { user } = useAuth();
@@ -38,8 +39,12 @@ export default function VideoManagement() {
     const [searchTerm, setSearchTerm] = useState('');
     const videoErrorModal = useRef<HTMLDialogElement>(null);
     const [polling, setPolling] = useState<boolean>(false);
-    const [perPage, setPerPage] = useState(12);
-    const [pageQuery, setPageQuery] = useState(1);
+    const {
+        page: pageQuery,
+        perPage,
+        setPage: setPageQuery,
+        setPerPage
+    } = useUrlPagination(1, 20);
     const [sortQuery, setSortQuery] = useState<string>(
         FilterLibrariesVidsandHelpfulLinksAdmin['Title (A to Z)']
     );
@@ -121,12 +126,6 @@ export default function VideoManagement() {
                    The video download will be retried every 3 hours`;
     };
 
-    const handleSetPerPage = (val: number) => {
-        setPerPage(val);
-        setPageQuery(1);
-        void mutate();
-    };
-
     return (
         <>
             <div className="flex justify-between items-center">
@@ -193,7 +192,7 @@ export default function VideoManagement() {
                     <Pagination
                         meta={meta}
                         setPage={setPageQuery}
-                        setPerPage={handleSetPerPage}
+                        setPerPage={setPerPage}
                         specialPageSelecton
                     />
                 </div>


### PR DESCRIPTION
## Description of the change
PR Does: 

- Fixes the tab navigation/highlighting on the knowledge center, so that if you hit back and your last page was in the knowledge center, it navigates accordingly
- Updated pagination so that it is pushed onto the browsers history stack (through the url) so that if you navigate through pages, you are able to go back. 

- **Related issues**: closes ID # 83 in Asana 

## Screenshot(s)
https://github.com/user-attachments/assets/30545fc1-8223-4fa9-9751-042b84086ba5



## Additional context
This is a slightly different paradigm for our pagination, previously we were only adding the pagination information in the url of the api, this pr does add it to the actual visible url, we could have possibly used react routers navigate state, but this is ephemeral and would not persist across full page refreshes so, i thought that although this makes the url a little uglier, it does actually push that url onto our history stack and give us the ability to go back and forth regardless of refreshes. 

## Asana 
https://app.asana.com/0/1209460078641109/1209699141721785/f