### PR TITLE
fix: remove doc_id for admins

### DIFF
--- a/frontend/src/Components/modals/index.ts
+++ b/frontend/src/Components/modals/index.ts
@@ -242,15 +242,17 @@ export const getUserInputs = (
                     'Username can only contain letters and numbers without spaces'
             },
             disabled: action === CRUDActions.Edit
-        },
-        {
+        }
+    ];
+    if (!AdminRoles.includes(userRole)) {
+        inputs.push({
             type: FormInputTypes.Text,
             label: 'Department of Corrections ID',
             interfaceRef: 'doc_id',
             required: true,
             length: 25
-        }
-    ];
+        });
+    }
     if (AdminRoles.includes(userRole)) {
         inputs.push({
             type: FormInputTypes.Text,

--- a/frontend/src/common.ts
+++ b/frontend/src/common.ts
@@ -18,7 +18,7 @@ export interface User {
     name_first: string;
     name_last: string;
     username: string;
-    doc_id: string;
+    doc_id?: string;
     role: UserRole;
     email: string;
     password_reset?: boolean;


### PR DESCRIPTION
## Description of the change
This PR fixes the doc_id in the admin flow

- **Related issues**: closes asana id # 113

## Screenshot(s)
resident 
![image](https://github.com/user-attachments/assets/e7d3e17e-fdea-4483-8fc2-453e51486bf4)

Admin
![image](https://github.com/user-attachments/assets/835c5312-2e6d-42a0-b401-cf4486455121)



## Additional context
https://app.asana.com/0/1209460078641109/1209864919491806/f