### PR TITLE
feat: update resident profile and add account history

### DIFF
--- a/backend/src/database/DB.go
+++ b/backend/src/database/DB.go
@@ -126,6 +126,8 @@ func MigrateTesting(db *gorm.DB) {
 		&models.OpenContentFavorite{},
 		&models.UserEnrollment{},
 		&models.UserCourseActivityTotals{},
+		&models.ProgramClassesHistory{},
+		&models.UserAccountHistory{},
 	}
 	for _, table := range TableList {
 		logrus.Printf("Migrating %T table...", table)

--- a/backend/src/database/users.go
+++ b/backend/src/database/users.go
@@ -530,7 +530,7 @@ func (db *DB) GetUserAccountHistory(args *models.QueryContext, userID uint) ([]m
 	if err := tx.Count(&args.Total).Error; err != nil {
 		return nil, newGetRecordsDBError(err, "user_account_history")
 	}
-	if err := tx.Order("uah." + args.OrderClause()).
+	if err := tx.Order("uah.created_at desc").
 		Offset(args.CalcOffset()).
 		Limit(args.PerPage).
 		Scan(&history).Error; err != nil {

--- a/backend/src/database/users.go
+++ b/backend/src/database/users.go
@@ -98,18 +98,6 @@ func (db *DB) TransferResident(ctx *models.QueryContext, userID int, currFacilit
 		trans.Rollback()
 		return newUpdateDBError(err, "users")
 	}
-	uintFacID := uint(transFacilityID)
-	history := models.UserAccountHistory{
-		UserID:     uint(userID),
-		AdminID:    &ctx.UserID,
-		Action:     models.FacilityTransfer,
-		FacilityID: &uintFacID,
-		CreatedAt:  time.Now(),
-	}
-	if err := trans.Create(&history).Error; err != nil {
-		trans.Rollback()
-		return newCreateDBError(err, "user_account_history")
-	}
 	if err := trans.Commit().Error; err != nil {
 		return NewDBError(err, "unable to commit DB transaction")
 	}

--- a/backend/src/handlers/auth.go
+++ b/backend/src/handlers/auth.go
@@ -310,6 +310,10 @@ func (srv *Server) handleResetPassword(w http.ResponseWriter, r *http.Request, l
 	}
 	resp := map[string]string{}
 	resp["redirect_to"] = AuthCallbackRoute
+	setPassword := models.NewUserAccountHistory(claims.UserID, models.SetPassword, nil, nil, nil)
+	if err := srv.Db.InsertUserAccountHistoryAction(r.Context(), setPassword); err != nil {
+		return newCreateRequestServiceError(err)
+	}
 	return writeJsonResponse(w, http.StatusOK, resp)
 }
 

--- a/backend/src/handlers/user_handler.go
+++ b/backend/src/handlers/user_handler.go
@@ -23,6 +23,7 @@ func (srv *Server) registerUserRoutes() []routeDef {
 		{"GET /api/users/resident-verify", srv.handleResidentVerification, true, axx},
 		{"PATCH /api/users/resident-transfer", srv.handleResidentTransfer, true, axx},
 		{"POST /api/users/student-password", srv.handleResetStudentPassword, true, axx},
+		{"GET /api/user-account-history/{id}", srv.handleGetUserAccountHistory, true, axx},
 	}
 }
 
@@ -98,6 +99,7 @@ func (srv *Server) handleShowUser(w http.ResponseWriter, r *http.Request, log sL
 * TODO: transactional
 **/
 func (srv *Server) handleCreateUser(w http.ResponseWriter, r *http.Request, log sLog) error {
+	claims := r.Context().Value(ClaimsKey).(*Claims)
 	reqForm := struct {
 		User      models.User `json:"user"`
 		Providers []int       `json:"provider_platforms"`
@@ -147,6 +149,16 @@ func (srv *Server) handleCreateUser(w http.ResponseWriter, r *http.Request, log 
 	}{
 		User:         reqForm.User,
 		TempPassword: tempPw,
+	}
+	if reqForm.User.Role == models.Student {
+		accountCreation := models.NewUserAccountHistory(reqForm.User.ID, models.AccountCreation, &claims.UserID, nil, nil)
+		if err := srv.Db.InsertUserAccountHistoryAction(r.Context(), accountCreation); err != nil {
+			return newCreateRequestServiceError(err)
+		}
+		facilityTransfer := models.NewUserAccountHistory(reqForm.User.ID, models.FacilityTransfer, &claims.UserID, &claims.FacilityID, nil)
+		if err := srv.Db.InsertUserAccountHistoryAction(r.Context(), facilityTransfer); err != nil {
+			return newCreateRequestServiceError(err)
+		}
 	}
 	// if we aren't in a testing environment, register the user as an Identity with Kratos + Kolibri
 	if !srv.isTesting(r) {
@@ -270,6 +282,10 @@ func (srv *Server) handleResetStudentPassword(w http.ResponseWriter, r *http.Req
 			}
 		}
 	}
+	resetPassword := models.NewUserAccountHistory(temp.UserID, models.ResetPassword, &claims.UserID, nil, nil)
+	if err := srv.Db.InsertUserAccountHistoryAction(r.Context(), resetPassword); err != nil {
+		return newCreateRequestServiceError(err)
+	}
 	return writeJsonResponse(w, http.StatusOK, response)
 }
 
@@ -291,6 +307,19 @@ func validateUser(user *models.User) string {
 		return "alphanum"
 	}
 	return ""
+}
+
+func (srv *Server) handleGetUserAccountHistory(w http.ResponseWriter, r *http.Request, log sLog) error {
+	id, err := strconv.Atoi(r.PathValue("id"))
+	if err != nil {
+		return newInvalidIdServiceError(err, "user ID")
+	}
+	args := srv.getQueryContext(r)
+	history, err := srv.Db.GetUserAccountHistory(&args, uint(id))
+	if err != nil {
+		return newDatabaseServiceError(err)
+	}
+	return writePaginatedResponse(w, http.StatusOK, history, args.IntoMeta())
 }
 
 func (srv *Server) handleResidentVerification(w http.ResponseWriter, r *http.Request, log sLog) error {

--- a/backend/src/handlers/user_handler.go
+++ b/backend/src/handlers/user_handler.go
@@ -155,7 +155,7 @@ func (srv *Server) handleCreateUser(w http.ResponseWriter, r *http.Request, log 
 		if err := srv.Db.InsertUserAccountHistoryAction(r.Context(), accountCreation); err != nil {
 			return newCreateRequestServiceError(err)
 		}
-		facilityTransfer := models.NewUserAccountHistory(reqForm.User.ID, models.FacilityTransfer, &claims.UserID, &claims.FacilityID, nil)
+		facilityTransfer := models.NewUserAccountHistory(reqForm.User.ID, models.FacilityTransfer, &claims.UserID, nil, &claims.FacilityID)
 		if err := srv.Db.InsertUserAccountHistoryAction(r.Context(), facilityTransfer); err != nil {
 			return newCreateRequestServiceError(err)
 		}
@@ -380,5 +380,10 @@ func (srv *Server) handleResidentTransfer(w http.ResponseWriter, r *http.Request
 		return newInternalServerServiceError(err, "error updating facility in kratos")
 	}
 	log.info("successfully transferred resident")
+	transFacilityID := uint(transRequest.TransFacilityID)
+	facilityTransfer := models.NewUserAccountHistory(uint(transRequest.UserID), models.FacilityTransfer, &args.UserID, nil, &transFacilityID)
+	if err := srv.Db.InsertUserAccountHistoryAction(r.Context(), facilityTransfer); err != nil {
+		return newCreateRequestServiceError(err)
+	}
 	return writeJsonResponse(w, int(http.StatusNoContent), "successfully transferred resident")
 }

--- a/backend/src/handlers/user_handler.go
+++ b/backend/src/handlers/user_handler.go
@@ -315,6 +315,9 @@ func (srv *Server) handleGetUserAccountHistory(w http.ResponseWriter, r *http.Re
 		return newInvalidIdServiceError(err, "user ID")
 	}
 	args := srv.getQueryContext(r)
+	if !srv.canViewUserData(r, id) {
+		return newUnauthorizedServiceError()
+	}
 	history, err := srv.Db.GetUserAccountHistory(&args, uint(id))
 	if err != nil {
 		return newDatabaseServiceError(err)

--- a/backend/src/handlers/user_handler.go
+++ b/backend/src/handlers/user_handler.go
@@ -23,7 +23,7 @@ func (srv *Server) registerUserRoutes() []routeDef {
 		{"GET /api/users/resident-verify", srv.handleResidentVerification, true, axx},
 		{"PATCH /api/users/resident-transfer", srv.handleResidentTransfer, true, axx},
 		{"POST /api/users/student-password", srv.handleResetStudentPassword, true, axx},
-		{"GET /api/user-account-history/{id}", srv.handleGetUserAccountHistory, true, axx},
+		{"GET /api/users/{id}/account-history", srv.handleGetUserAccountHistory, true, axx},
 	}
 }
 

--- a/backend/src/models/program_classes.go
+++ b/backend/src/models/program_classes.go
@@ -61,3 +61,14 @@ type ProgramClassDetail struct {
 	FacilityName string `json:"facility_name"`
 	Enrolled     int    `json:"enrolled"`
 }
+
+type ProgramClassesHistory struct {
+	ID           uint        `json:"id"`
+	ParentRefID  uint        `json:"parent_ref_id"`
+	NameTable    string      `json:"table_name" gorm:"size:255"` // cant use TableName because used below
+	BeforeUpdate interface{} `json:"before_update" gorm:"type:json"`
+	AfterUpdate  interface{} `json:"after_update" gorm:"type:json"`
+	CreatedAt    time.Time   `json:"created_at"`
+}
+
+func (ProgramClassesHistory) TableName() string { return "program_classes_history" }

--- a/backend/src/models/users.go
+++ b/backend/src/models/users.go
@@ -91,3 +91,53 @@ func (user *User) GetTraits() map[string]interface{} {
 func (user *User) IsAdmin() bool {
 	return slices.Contains(AdminRoles, user.Role)
 }
+
+type UserAccountHistory struct {
+	UserID                  uint                     `json:"user_id" gorm:"primaryKey"`
+	AdminID                 *uint                    `json:"admin_id"`
+	Action                  UserAccountHistoryAction `json:"action" gorm:"size:255;primaryKey"`
+	ProgramClassesHistoryID *uint                    `json:"program_classes_history_id"`
+	FacilityID              *uint                    `json:"facility_id"`
+	CreatedAt               time.Time                `json:"created_at" gorm:"primaryKey"`
+
+	User                  *User                  `json:"user,omitempty" gorm:"foreignKey:UserID;constraint:OnDelete:CASCADE,OnUpdate:CASCADE"`
+	Admin                 *User                  `json:"admin,omitempty" gorm:"foreignKey:AdminID;constraint:OnDelete:CASCADE,OnUpdate:CASCADE"`
+	ProgramClassesHistory *ProgramClassesHistory `json:"program_classes_history,omitempty" gorm:"foreignKey:ProgramClassesHistoryID;constraint:OnDelete:CASCADE,OnUpdate:CASCADE"`
+	Facility              *Facility              `json:"facility,omitempty" gorm:"foreignKey:FacilityID;constraint:OnDelete:CASCADE,OnUpdate:CASCADE"`
+}
+
+func (UserAccountHistory) TableName() string {
+	return "user_account_history"
+}
+
+type UserAccountHistoryAction string
+
+const (
+	AccountCreation  UserAccountHistoryAction = "account_creation"
+	FacilityTransfer UserAccountHistoryAction = "facility_transfer"
+	SetPassword      UserAccountHistoryAction = "set_password"
+	ResetPassword    UserAccountHistoryAction = "reset_password"
+)
+
+type UserAccountHistoryResponse struct {
+	Action                  UserAccountHistoryAction `json:"action"`
+	CreatedAt               time.Time                `json:"created_at"`
+	UserID                  uint                     `json:"user_id"`
+	UserUsername            string                   `json:"user_username"`
+	AdminUsername           *string                  `json:"admin_username"`
+	FacilityName            *string                  `json:"facility_name"`
+	ProgramClassesHistoryID *uint                    `json:"program_classes_history_id"`
+
+	ProgramClassesHistory *ProgramClassesHistory `json:"program_classes_history,omitempty" gorm:"foreignKey:ProgramClassesHistoryID;constraint:OnDelete:SET NULL"`
+}
+
+func NewUserAccountHistory(userID uint, action UserAccountHistoryAction, adminID *uint, programClassesHistoryID *uint, facilityID *uint) *UserAccountHistory {
+	return &UserAccountHistory{
+		UserID:                  userID,
+		AdminID:                 adminID,
+		Action:                  action,
+		ProgramClassesHistoryID: programClassesHistoryID,
+		FacilityID:              facilityID,
+		CreatedAt:               time.Now(),
+	}
+}

--- a/frontend/src/Components/EngagementRateGraph.tsx
+++ b/frontend/src/Components/EngagementRateGraph.tsx
@@ -107,7 +107,7 @@ const EngagementRateGraph = ({ data, viewType }: EngagementRateGraphProps) => {
         <ResponsiveContainer width="100%" height="100%" className="pt-2">
             <LineChart
                 data={processedData}
-                margin={{ top: 20, right: 30, left: 50, bottom: 40 }}
+                margin={{ left: 20, right: 30, top: 20, bottom: 20 }}
             >
                 <CartesianGrid stroke={strokeColor} strokeDasharray="3 3" />
                 <XAxis
@@ -115,6 +115,10 @@ const EngagementRateGraph = ({ data, viewType }: EngagementRateGraphProps) => {
                     interval={xTicks}
                     stroke={strokeColor}
                     label={{
+                        value:
+                            viewType === 'peakLogin'
+                                ? 'Time of day'
+                                : 'Last 30 days',
                         style: { fill: strokeColor },
                         dy: 20,
                         zIndex: 100

--- a/frontend/src/Components/OperationalInsightsCharts.tsx
+++ b/frontend/src/Components/OperationalInsightsCharts.tsx
@@ -172,24 +172,19 @@ const OperationalInsights = () => {
                     </div>
 
                     <div className="card card-row-padding overflow-hidden">
-                        <h1 className="">Peak Login Times</h1>
-                        <div className=" items-stretch gap-12 px-10 pt-10 ">
-                            <div className="w-full h-[500px] overflow-visible">
-                                <ResponsiveContainer
-                                    className="w-full h-full overflow-visible"
-                                    width="100%"
-                                    height="100%"
-                                    debounce={500}
-                                >
-                                    <EngagementRateGraph
-                                        data={
-                                            metrics?.data.peak_login_times || []
-                                        }
-                                        viewType="peakLogin"
-                                    />
-                                </ResponsiveContainer>
-                            </div>
-                        </div>
+                        <h2>Peak Login Times</h2>
+                        <ResponsiveContainer
+                            className="w-full h-full overflow-visible"
+                            width="100%"
+                            height="250px"
+                            debounce={500}
+                            maxHeight={250}
+                        >
+                            <EngagementRateGraph
+                                data={metrics?.data.peak_login_times || []}
+                                viewType="peakLogin"
+                            />
+                        </ResponsiveContainer>
                     </div>
                 </>
             )}

--- a/frontend/src/Components/cards/AccountHistoryRowCard.tsx
+++ b/frontend/src/Components/cards/AccountHistoryRowCard.tsx
@@ -1,0 +1,37 @@
+import { UserAccountHistoryResponse } from '@/common';
+
+function AccountHistoryRowCard({
+    activity
+}: {
+    activity: UserAccountHistoryResponse;
+}) {
+    let introText;
+    switch (activity.action) {
+        case 'account_creation':
+            introText = 'Account created by ' + activity.admin_username;
+            break;
+        case 'facility_transfer':
+            introText =
+                'Account assigned to ' +
+                activity.facility_name +
+                ' by ' +
+                activity.admin_username;
+            break;
+        case 'set_password':
+            introText = 'New password set by ' + activity.user_username;
+            break;
+        case 'reset_password':
+            introText =
+                'Password reset initiated by ' + activity.admin_username;
+            break;
+    }
+    if (!introText) return;
+    return (
+        <p className="body">
+            {introText} (
+            {new Date(activity.created_at).toLocaleDateString('en-US')})
+        </p>
+    );
+}
+
+export default AccountHistoryRowCard;

--- a/frontend/src/Components/cards/index.tsx
+++ b/frontend/src/Components/cards/index.tsx
@@ -1,0 +1,4 @@
+export { default as AccountHistoryRowCard } from './AccountHistoryRowCard';
+export { default as HelpfulLinkCard } from './HelpfulLinkCard';
+export { default as LibrarySearchResultCard } from './LibrarySearchResultCard';
+export { default as OpenContentCard } from './OpenContentCard';

--- a/frontend/src/Components/helperFunctions/calculateEngagementMetrics.tsx
+++ b/frontend/src/Components/helperFunctions/calculateEngagementMetrics.tsx
@@ -1,0 +1,29 @@
+import { ResidentEngagementProfile } from '@/common';
+
+const calculateEngagementMetrics = (
+    metrics: ResidentEngagementProfile | undefined
+) => {
+    const isLessAvgThanOneHour =
+        (metrics?.activity_engagement.total_hours_active_weekly ?? 0) < 1;
+    const isLessThanOneHour =
+        (metrics?.activity_engagement.total_hours_engaged ?? 0) < 1;
+
+    const avgNumber = isLessAvgThanOneHour
+        ? (
+              metrics?.activity_engagement.total_minutes_active_weekly ?? 0
+          ).toFixed(2)
+        : (metrics?.activity_engagement.total_hours_active_weekly ?? 0).toFixed(
+              2
+          );
+
+    const weekNumber = isLessThanOneHour
+        ? (metrics?.activity_engagement.total_minutes_engaged ?? 0).toFixed(2)
+        : (metrics?.activity_engagement.total_hours_engaged ?? 0).toFixed(2);
+
+    const avgLabel = isLessAvgThanOneHour ? 'Min' : 'Hrs';
+    const weekLabel = isLessThanOneHour ? 'Minutes' : 'Hours';
+
+    return { avgNumber, weekNumber, avgLabel, weekLabel };
+};
+
+export default calculateEngagementMetrics;

--- a/frontend/src/Components/inputs/DropdownControl.tsx
+++ b/frontend/src/Components/inputs/DropdownControl.tsx
@@ -2,10 +2,6 @@ import { Dispatch, SetStateAction } from 'react';
 
 interface DropdownControlProps {
     label?: string;
-    /**
-     * Optional attribute is used for enabling the lable for being the first item displayed in the list
-     */
-    useLabel?: boolean;
     setState?: Dispatch<SetStateAction<string>>;
     customCallback?: (value: string) => void;
     enumType: Record<string, string>;
@@ -16,8 +12,7 @@ export default function DropdownControl({
     label,
     setState: callback,
     customCallback,
-    enumType,
-    useLabel = false
+    enumType
 }: DropdownControlProps) {
     return (
         <label className="form-control">
@@ -33,14 +28,10 @@ export default function DropdownControl({
                     }
                 }}
             >
-                {label && !useLabel ? (
+                {label && (
                     <option value="" disabled>
                         {label}
                     </option>
-                ) : label && useLabel ? (
-                    <option value={label}>{label}</option>
-                ) : (
-                    ''
                 )}
                 {Object.entries(enumType).map(([key, value]) => (
                     <option key={key} value={value}>

--- a/frontend/src/Pages/ResidentProfile.tsx
+++ b/frontend/src/Pages/ResidentProfile.tsx
@@ -59,14 +59,14 @@ function OpenContentCardToggle({
     return (
         <div className="flex flex-row gap-4">
             <h2
-                className={`cursor-pointer ${activeTab === 'libraries' ? activeTabStyle : ''}`}
+                className={`cursor-pointer font-normal ${activeTab === 'libraries' ? activeTabStyle : ''}`}
                 onClick={() => setActiveTab('libraries')}
             >
                 Top Viewed Libraries
             </h2>
             <span>|</span>
             <h2
-                className={`cursor-pointer ${activeTab === 'videos' ? activeTabStyle : ''}`}
+                className={`cursor-pointer font-normal ${activeTab === 'videos' ? activeTabStyle : ''}`}
                 onClick={() => setActiveTab('videos')}
             >
                 Recently Viewed Videos
@@ -93,7 +93,7 @@ const ResidentProfile = () => {
     const { data: activityHistory, error: activityHistoryError } = useSWR<
         ServerResponseMany<UserAccountHistoryResponse>,
         AxiosError
-    >(`/api/user-account-history/${residentId}?page=${page}&per_page=5`);
+    >(`/api/users/${residentId}/account-history?page=${page}&per_page=5`);
 
     const [activeTab, setActiveTab] = useState<'libraries' | 'videos'>(
         'libraries'
@@ -191,7 +191,7 @@ const ResidentProfile = () => {
                                         : 'N/A'
                                 }
                             />
-                            <div className="flex flex-row gap-2 mt-4">
+                            <div className="flex flex-row gap-2 mt-4 justify-center">
                                 <button className="button bg-grey-1 text-error">
                                     Delete Resident
                                 </button>

--- a/frontend/src/common.ts
+++ b/frontend/src/common.ts
@@ -892,3 +892,29 @@ export interface ResidentEngagementProfile {
     top_libraries: OpenContentResponse[];
     recent_videos: OpenContentResponse[];
 }
+
+export interface UserAccountHistoryResponse {
+    action: UserAccountHistoryAction;
+    created_at: Date;
+    user_id: number;
+    user_username: string;
+    admin_username?: string;
+    facility_name?: string;
+    program_classes_history_id?: number;
+    program_classes_history?: ProgramClassesHistory;
+}
+
+export interface ProgramClassesHistory {
+    id: number;
+    parent_ref_id: number;
+    table_name: string; // renamed from NameTable for consistency
+    before_update: Record<string, unknown>; // using Record to represent JSON structure
+    after_update: Record<string, unknown>; // using Record to represent JSON structure
+    created_at: Date;
+}
+
+export type UserAccountHistoryAction =
+    | 'account_creation'
+    | 'facility_transfer'
+    | 'set_password'
+    | 'reset_password';


### PR DESCRIPTION
## Description of the change

- Updates a few UI things on resident profile page (not specific to this ticket) but just to keep the UI consistent with other pages.
- changes the top libraries/recently viewed videos to one card with a toggle
- adds in account history card with pagination (UI)
- adds the backend for adding account history with the following actions
    - account creation
    - resetting a password by an admin
    - setting a password by the user
    - added to a facility (only on account creation)
- **Related issues**: Closes [Capture & Display User Activity ](https://app.asana.com/0/1209460078641109/1209825280254697/f)

## Screenshot(s)

https://github.com/user-attachments/assets/d880757a-8480-4223-b1d4-afcda8b3af76

