### PR TITLE
fix: fix display format of user names

### DIFF
--- a/frontend/src/Components/TransferSummaryPanel.tsx
+++ b/frontend/src/Components/TransferSummaryPanel.tsx
@@ -14,8 +14,9 @@ export default function TransferSummaryPanel({
                     <tr>
                         <td className="font-bold text-right">Resident Name:</td>
                         <td>
-                            {resident?.user.name_first}{' '}
                             {resident?.user.name_last}
+                            {', '}
+                            {resident?.user.name_first}
                         </td>
                     </tr>
                     <tr>

--- a/frontend/src/Components/forms/MapUserForm.tsx
+++ b/frontend/src/Components/forms/MapUserForm.tsx
@@ -103,9 +103,9 @@ export default function MapUserForm({
                 <UserCircleIcon className="h-10" />
                 <div className="flex-col">
                     <h3>
-                        {externalUser?.name_first +
-                            ' ' +
-                            externalUser?.name_last}
+                        {externalUser?.name_last +
+                            ', ' +
+                            externalUser?.name_first}
                     </h3>
                     <p className="body-small text-grey-3">
                         {externalUser?.username} • {externalUser?.email}

--- a/frontend/src/Components/modals/CompletionDetailsModal.tsx
+++ b/frontend/src/Components/modals/CompletionDetailsModal.tsx
@@ -31,7 +31,7 @@ export default function CompletionDetailsModal({
                             </h3>
                             <p>
                                 <span className="font-semibold">Name:</span>{' '}
-                                {`${completionDetails.user?.name_first} ${completionDetails.user?.name_last}`}
+                                {`${completionDetails.user?.name_last}, ${completionDetails.user?.name_first}`}
                             </p>
                             <p>
                                 <span className="font-semibold">

--- a/frontend/src/Pages/AdminManagement.tsx
+++ b/frontend/src/Pages/AdminManagement.tsx
@@ -202,8 +202,9 @@ export default function AdminManagement() {
                                             className="card p-4 w-full grid-cols-5 justify-items-center"
                                         >
                                             <td className="justify-self-start">
-                                                {targetUser.name_first}{' '}
                                                 {targetUser.name_last}
+                                                {', '}
+                                                {targetUser.name_first}
                                             </td>
                                             <td>{targetUser.username}</td>
                                             <td>

--- a/frontend/src/Pages/ProviderUserManagement.tsx
+++ b/frontend/src/Pages/ProviderUserManagement.tsx
@@ -220,9 +220,9 @@ export default function ProviderUserManagement() {
                                         className="border-gray-600 table-row"
                                     >
                                         <td>
-                                            {user.name_first +
-                                                ' ' +
-                                                user.name_last}
+                                            {user.name_last +
+                                                ', ' +
+                                                user.name_first}
                                         </td>
                                         <td>{user.username}</td>
                                         <td>{user.email}</td>

--- a/frontend/src/Pages/StudentManagement.tsx
+++ b/frontend/src/Pages/StudentManagement.tsx
@@ -213,8 +213,9 @@ export default function StudentManagement() {
                                             }
                                         >
                                             <td className="justify-self-start">
-                                                {user.name_first}{' '}
                                                 {user.name_last}
+                                                {', '}
+                                                {user.name_first}
                                             </td>
                                             <td>{user.username}</td>
                                             <td>{user.doc_id}</td>


### PR DESCRIPTION
## Description of the change
Reformats how we display users first and last name in tabular places. 

- **Related issues**: Closes Asana #109


## Additional context
I went through all of the cases on our frontend where we render name_first and name_last, I thought this was going to be a bigger ticket, so I'm not going to guarantee I didn't miss anywhere's but, i'm pretty sure I didn't...there's a couple places that we didn't change, like the Resident Profile, and any user facing places where it sounds more natural, or conversational to keep the users first name last name. 

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1209855394721661