### PR TITLE
fix: move other to bottom of enum

### DIFF
--- a/frontend/src/common.ts
+++ b/frontend/src/common.ts
@@ -474,8 +474,8 @@ export enum FundingType {
     FEDERAL_GRANTS = 'Federal_Grants',
     INMATE_WELFARE = 'Inmate_Welfare_Funds',
     NON_PROFIT_ORGANIZATION = 'Nonprofit_Organizations',
-    OTHER = 'Other',
-    STATE_GRANTS = 'State_Grants'
+    STATE_GRANTS = 'State_Grants',
+    OTHER = 'Other'
 }
 
 export enum ProgramType {


### PR DESCRIPTION
## Description of the change
moves "Other" to bottom of the funding type enum 

- **Related issues**: closes asana 117

## Screenshot(s)

![image](https://github.com/user-attachments/assets/50bed130-f072-44b9-b9ec-9633880ab9e3)

## Additional context

https://app.asana.com/1/1201607307149189/project/1209460078641109/task/1209876762905717?focus=true