### PR TITLE
fix: remove extra added brace in resident program route

### DIFF
--- a/frontend/src/Components/ResidentPrograms.tsx
+++ b/frontend/src/Components/ResidentPrograms.tsx
@@ -18,7 +18,7 @@ export default function ResidentPrograms({ user_id }: { user_id: string }) {
         error: programsError,
         isLoading
     } = useSWR<ServerResponseMany<ResidentProgramClassInfo>, Error>(
-        `/api/users/${user_id}/programs?page=${page}&per_page=${perPage}}`
+        `/api/users/${user_id}/programs?page=${page}&per_page=${perPage}`
     );
     const programs = programsResp?.data;
     const meta = programsResp?.meta;

--- a/provider-middleware/Dockerfile
+++ b/provider-middleware/Dockerfile
@@ -4,7 +4,7 @@ ARG GOLANG_VERSION=1.23.2
 FROM mwader/static-ffmpeg:$FFMPEG_VERSION AS ffmpeg
 
 FROM golang:$GOLANG_VERSION AS yt-dlp
-RUN curl -L https://github.com/yt-dlp/yt-dlp/releases/download/2025.03.27/yt-dlp -o /yt-dlp && chmod a+x /yt-dlp
+RUN curl -L https://github.com/yt-dlp/yt-dlp/releases/download/2025.03.31/yt-dlp -o /yt-dlp && chmod a+x /yt-dlp
 
 FROM golang:$GOLANG_VERSION-alpine as builder
 WORKDIR /app


### PR DESCRIPTION
## Description of the change

A squiggly got into the end of the route in the frontend for resident programs.....:( sad day..quick fix. 