### PR TITLE
fix: cancel enrollments upon cancelled class

### DIFF
--- a/backend/src/database/class_enrollments.go
+++ b/backend/src/database/class_enrollments.go
@@ -42,6 +42,17 @@ func (db *DB) GetEnrollmentsForClass(page, perPage, classId int) (int64, []model
 	return total, content, nil
 }
 
+func (db *DB) GetAllActiveEnrollmentsForClassByClassID(classID int) ([]models.ProgramClassEnrollment, error) {
+	var content []models.ProgramClassEnrollment
+	err := db.
+		Where("class_id = ? AND enrollment_status = ?", classID, models.Enrolled).
+		Find(&content).Error
+	if err != nil {
+		return nil, newNotFoundDBError(err, "class enrollments")
+	}
+	return content, nil
+}
+
 func (db *DB) GetProgramClassEnrollmentsForFacility(page, perPage int, facilityID uint) (int64, []models.ProgramClassEnrollment, error) {
 	content := []models.ProgramClassEnrollment{}
 	var total int64 //count

--- a/backend/src/database/class_enrollments.go
+++ b/backend/src/database/class_enrollments.go
@@ -42,16 +42,6 @@ func (db *DB) GetEnrollmentsForClass(page, perPage, classId int) (int64, []model
 	return total, content, nil
 }
 
-func (db *DB) GetAllActiveEnrollmentsForClassIDs(classIDs []int) ([]models.ProgramClassEnrollment, error) {
-	var enrollments []models.ProgramClassEnrollment
-	if err := db.
-		Where("class_id IN ? AND enrollment_status = ?", classIDs, models.Enrolled).
-		Find(&enrollments).Error; err != nil {
-		return nil, newNotFoundDBError(err, "active class enrollments")
-	}
-	return enrollments, nil
-}
-
 func (db *DB) GetProgramClassEnrollmentsForFacility(page, perPage int, facilityID uint) (int64, []models.ProgramClassEnrollment, error) {
 	content := []models.ProgramClassEnrollment{}
 	var total int64 //count

--- a/backend/src/database/class_enrollments.go
+++ b/backend/src/database/class_enrollments.go
@@ -174,20 +174,18 @@ func (db *DB) UpdateProgramClassEnrollments(classId int, userIds []int, status s
 	return nil
 }
 
-func (db *DB) UpdateProgramClassEnrollmentsForCancelledProgram(classIDs []int, classMap map[string]any) error {
+func (db *DB) UpdateProgramClasses(classIDs []int, classMap map[string]any) error {
 	tx := db.Begin()
 	if tx.Error != nil {
 		return newUpdateDBError(tx.Error, "begin transaction")
 	}
 	if status, ok := classMap["status"]; ok &&
 		status == string(models.Cancelled) {
-
 		if err := tx.
 			Model(&models.ProgramClassEnrollment{}).
 			Where("class_id IN ? AND enrollment_status = ?", classIDs, models.Enrolled).
 			Update("enrollment_status", models.EnrollmentCancelled).
 			Error; err != nil {
-
 			tx.Rollback()
 			return newUpdateDBError(err, "class enrollment statuses")
 		}
@@ -197,7 +195,6 @@ func (db *DB) UpdateProgramClassEnrollmentsForCancelledProgram(classIDs []int, c
 		Where("id IN ?", classIDs).
 		Updates(classMap).
 		Error; err != nil {
-
 		tx.Rollback()
 		return newUpdateDBError(err, "program classes")
 	}

--- a/backend/src/database/program_classes.go
+++ b/backend/src/database/program_classes.go
@@ -64,7 +64,7 @@ func (db *DB) GetTotalEnrollmentsByClassID(id int) (int64, error) {
 	return count, nil
 }
 
-func (db *DB) UpdateProgramClasses(classMap map[string]interface{}, ids []int) error {
+func (db *DB) UpdateProgramClasses(classMap map[string]any, ids []int) error {
 	if err := db.Model(&models.ProgramClass{}).Where("id IN ?", ids).Updates(classMap).Error; err != nil {
 		return newUpdateDBError(err, "program classes")
 	}

--- a/backend/src/database/program_classes.go
+++ b/backend/src/database/program_classes.go
@@ -64,13 +64,6 @@ func (db *DB) GetTotalEnrollmentsByClassID(id int) (int64, error) {
 	return count, nil
 }
 
-func (db *DB) UpdateProgramClasses(classMap map[string]any, ids []int) error {
-	if err := db.Model(&models.ProgramClass{}).Where("id IN ?", ids).Updates(classMap).Error; err != nil {
-		return newUpdateDBError(err, "program classes")
-	}
-	return nil
-}
-
 func (db *DB) GetProgramClassDetailsByID(id int, args *models.QueryContext) ([]models.ProgramClassDetail, error) {
 	var classDetails []models.ProgramClassDetail
 	query := db.WithContext(args.Ctx).Table("program_classes ps").

--- a/backend/src/handlers/classes_handler.go
+++ b/backend/src/handlers/classes_handler.go
@@ -122,20 +122,13 @@ func (srv *Server) handleUpdateClasses(w http.ResponseWriter, r *http.Request, l
 	}
 	claims := r.Context().Value(ClaimsKey).(*Claims)
 	classMap["update_user_id"] = claims.UserID
-	if classMap["status"] == "Cancelled" {
-		for _, classID := range classIDs {
-			enrollments, err := srv.Db.GetAllActiveEnrollmentsForClassByClassID(classID)
-			if err != nil {
-				return newDatabaseServiceError(err)
-			}
-			var userIDs []int
-			for _, user := range enrollments {
-				userIDs = append(userIDs, int(user.UserID))
-			}
-			err = srv.Db.UpdateProgramClassEnrollments(classID, userIDs, string(models.EnrollmentCancelled))
-			if err != nil {
-				return newDatabaseServiceError(err)
-			}
+
+	if classMap["status"] == string(models.EnrollmentCancelled) {
+		if err := srv.Db.UpdateProgramClassEnrollmentsPerEnrollment(
+			classIDs,
+			string(models.EnrollmentCancelled),
+		); err != nil {
+			return newDatabaseServiceError(err)
 		}
 	}
 	err := srv.Db.UpdateProgramClasses(classMap, classIDs)

--- a/backend/src/handlers/classes_handler.go
+++ b/backend/src/handlers/classes_handler.go
@@ -123,11 +123,8 @@ func (srv *Server) handleUpdateClasses(w http.ResponseWriter, r *http.Request, l
 	claims := r.Context().Value(ClaimsKey).(*Claims)
 	classMap["update_user_id"] = claims.UserID
 
-	if classMap["status"] == string(models.EnrollmentCancelled) {
-		if err := srv.Db.UpdateProgramClassEnrollmentsPerEnrollment(
-			classIDs,
-			string(models.EnrollmentCancelled),
-		); err != nil {
+	if classMap["status"] == string(models.Cancelled) {
+		if err := srv.Db.UpdateProgramClassEnrollmentsPerEnrollment(classIDs, string(models.EnrollmentCancelled)); err != nil {
 			return newDatabaseServiceError(err)
 		}
 	}

--- a/backend/src/handlers/classes_handler.go
+++ b/backend/src/handlers/classes_handler.go
@@ -124,14 +124,11 @@ func (srv *Server) handleUpdateClasses(w http.ResponseWriter, r *http.Request, l
 	classMap["update_user_id"] = claims.UserID
 
 	if classMap["status"] == string(models.Cancelled) {
-		if err := srv.Db.UpdateProgramClassEnrollmentsPerEnrollment(classIDs, string(models.EnrollmentCancelled)); err != nil {
+		if err := srv.Db.UpdateProgramClassEnrollmentsForCancelledProgram(classIDs, classMap); err != nil {
 			return newDatabaseServiceError(err)
 		}
 	}
-	err := srv.Db.UpdateProgramClasses(classMap, classIDs)
-	if err != nil {
-		return newDatabaseServiceError(err)
-	}
+
 	return writeJsonResponse(w, http.StatusOK, "Successfully updated program class")
 }
 

--- a/backend/src/handlers/classes_handler.go
+++ b/backend/src/handlers/classes_handler.go
@@ -120,13 +120,12 @@ func (srv *Server) handleUpdateClasses(w http.ResponseWriter, r *http.Request, l
 	if err := json.NewDecoder(r.Body).Decode(&classMap); err != nil {
 		return newJSONReqBodyServiceError(err)
 	}
+
 	claims := r.Context().Value(ClaimsKey).(*Claims)
 	classMap["update_user_id"] = claims.UserID
 
-	if classMap["status"] == string(models.Cancelled) {
-		if err := srv.Db.UpdateProgramClassEnrollmentsForCancelledProgram(classIDs, classMap); err != nil {
-			return newDatabaseServiceError(err)
-		}
+	if err := srv.Db.UpdateProgramClasses(classIDs, classMap); err != nil {
+		return newDatabaseServiceError(err)
 	}
 
 	return writeJsonResponse(w, http.StatusOK, "Successfully updated program class")


### PR DESCRIPTION
## Description of the change
This pull request makes sure that when an admin cancels a class all Enrolled students enrollment status is marked as Cancelled

- **Related issues**: https://app.asana.com/1/1201607307149189/project/1209460078641109/task/1210072150791608?focus=true

