### PR TITLE
fix: fix dropdown display names for timezones

### DIFF
--- a/frontend/src/Components/inputs/DropdownInput.tsx
+++ b/frontend/src/Components/inputs/DropdownInput.tsx
@@ -36,7 +36,7 @@ export function DropdownInput({
             >
                 {Object.entries(enumType).map(([key, value]) => (
                     <option key={key} value={value}>
-                        {value}
+                        {key}
                     </option>
                 ))}
             </select>

--- a/frontend/src/Components/modals/index.ts
+++ b/frontend/src/Components/modals/index.ts
@@ -49,6 +49,7 @@ export interface Input {
     interfaceRef: string;
     required: boolean;
     enumType?: Record<string, string>;
+    displayNames?: Record<string, string>;
     length?: number;
     pattern?: Pattern;
     validate?:

--- a/frontend/src/Components/modals/index.ts
+++ b/frontend/src/Components/modals/index.ts
@@ -49,7 +49,6 @@ export interface Input {
     interfaceRef: string;
     required: boolean;
     enumType?: Record<string, string>;
-    displayNames?: Record<string, string>;
     length?: number;
     pattern?: Pattern;
     validate?:

--- a/frontend/src/common.ts
+++ b/frontend/src/common.ts
@@ -910,12 +910,12 @@ export enum FilterProgramClassEnrollments {
     'First Name (Z to A)' = 'name_first desc'
 }
 export enum Timezones {
-    'america/chicago' = 'America/Chicago',
-    'america/new_york' = 'America/New_York',
-    'america/anchorage' = 'America/Anchorage',
-    'america/los_angeles' = 'America/Los_Angeles',
-    'america/denver' = 'America/Denver',
-    'america/phoenix' = 'America/Phoenix'
+    'CST' = 'America/Chicago',
+    'EST' = 'America/New_York',
+    'AKST' = 'America/Anchorage',
+    'PST' = 'America/Los_Angeles',
+    'MDT' = 'America/Denver',
+    'MST' = 'America/Phoenix'
 }
 
 export enum FilterPastTime {


### PR DESCRIPTION
## Description of the change

Fixes how timezones are being displayed, and adds an optional dispalyNames parameter to the DropdownInput for future enum display issues. 

- **Related issues**: https://app.asana.com/1/1201607307149189/project/1209460078641109/task/1210072188481737?focus=true

## Screenshot(s)
![image](https://github.com/user-attachments/assets/df96c561-f8ff-46e8-bbeb-a6025d728f9e)



