### PR TITLE
fix: guarantee only system admins may edit or delete facility

### DIFF
--- a/backend/src/database/programs.go
+++ b/backend/src/database/programs.go
@@ -12,7 +12,6 @@ type EnrollmentAndCompletionMetrics struct {
 	CompletionRate    float64 `json:"completion_rate"`
 }
 
-
 func (db *DB) GetProgramByID(id int) (*models.Program, error) {
 	content := &models.Program{}
 	if err := db.Preload("Facilities").First(content, id).Error; err != nil {

--- a/backend/src/handlers/facilites_handler_test.go
+++ b/backend/src/handlers/facilites_handler_test.go
@@ -129,8 +129,9 @@ const ozark string = "Ozark Correctional Center"
 
 func TestHandleUpdateFacility(t *testing.T) {
 	httpTests := []httpTest{
-		{"TestAdminCanUpdateFacility", "admin", map[string]any{"name": ozark}, http.StatusOK, ""},
+		{"TestAdminCanUpdateFacility", "sysadmin", map[string]any{"name": ozark}, http.StatusOK, ""},
 		{"TestUserCannotUpdateFacility", "student", nil, http.StatusUnauthorized, ""},
+		{"TestAdminCanDeleteFacility", "admin", nil, http.StatusUnauthorized, ""},
 	}
 	for _, test := range httpTests {
 		t.Run(test.testName, func(t *testing.T) {
@@ -179,7 +180,8 @@ func TestHandleUpdateFacility(t *testing.T) {
 func TestHandleDeleteFacility(t *testing.T) {
 	httpTests := []httpTest{
 		{"TestUserCannotDeleteFacility", "student", nil, http.StatusUnauthorized, ""},
-		{"TestAdminCanDeleteFacility", "admin", map[string]any{"message": "facility deleted successfully"}, http.StatusNoContent, ""},
+		{"TestAdminCanDeleteFacility", "sysadmin", map[string]any{"message": "facility deleted successfully"}, http.StatusNoContent, ""},
+		{"TestAdminCanDeleteFacility", "admin", nil, http.StatusUnauthorized, ""},
 	}
 	for _, test := range httpTests {
 		t.Run(test.testName, func(t *testing.T) {

--- a/backend/src/handlers/facilities_handler.go
+++ b/backend/src/handlers/facilities_handler.go
@@ -83,6 +83,9 @@ func (srv *Server) handleCreateFacility(w http.ResponseWriter, r *http.Request, 
 }
 
 func (srv *Server) handleUpdateFacility(w http.ResponseWriter, r *http.Request, log sLog) error {
+	if !userIsSystemAdmin(r) {
+		return newUnauthorizedServiceError()
+	}
 	id, err := strconv.Atoi(r.PathValue("id"))
 	if err != nil {
 		return newInvalidIdServiceError(err, "facility ID")
@@ -106,6 +109,9 @@ func (srv *Server) handleUpdateFacility(w http.ResponseWriter, r *http.Request, 
 * DELETE: /api/facility/{id}
  */
 func (srv *Server) handleDeleteFacility(w http.ResponseWriter, r *http.Request, log sLog) error {
+	if !userIsSystemAdmin(r) {
+		return newUnauthorizedServiceError()
+	}
 	id, err := strconv.Atoi(r.PathValue("id"))
 	if err != nil {
 		return newInvalidIdServiceError(err, "facility ID")

--- a/backend/src/handlers/programs_handler.go
+++ b/backend/src/handlers/programs_handler.go
@@ -65,7 +65,7 @@ func (srv *Server) handleShowProgram(w http.ResponseWriter, r *http.Request, log
 		log.add("program_id", id)
 		return newDatabaseServiceError(err)
 	}
-	
+
 	resultSet := ProgramOverviewResponse{
 		Program:           *program,
 		ActiveEnrollments: metrics.ActiveEnrollments,

--- a/frontend/src/Components/FacilityCard.tsx
+++ b/frontend/src/Components/FacilityCard.tsx
@@ -1,6 +1,11 @@
 import { Facility } from '@/common';
 import ULIComponent from '@/Components/ULIComponent.tsx';
-import { PencilSquareIcon, TrashIcon } from '@heroicons/react/24/outline';
+import {
+    PencilSquareIcon,
+    TrashIcon,
+    LockClosedIcon
+} from '@heroicons/react/24/outline';
+import { isSysAdmin, useAuth } from '@/useAuth';
 
 export default function FacilityCard({
     facility,
@@ -11,27 +16,39 @@ export default function FacilityCard({
     openEditFacility: (fac: Facility) => void;
     openDeleteFacility: (fac: Facility) => void;
 }) {
+    const { user } = useAuth();
     return (
         <tr className="bg-base-teal card p-4 w-full grid-cols-3 justify-items-center">
             <td className="justify-self-start">{facility.name}</td>
             <td className="">{facility.timezone}</td>
             <td className="flex flex-row gap-3 justify-self-end cursor-pointer">
-                <ULIComponent
-                    dataTip={'Edit Facility'}
-                    icon={PencilSquareIcon}
-                    onClick={() => {
-                        openEditFacility(facility);
-                    }}
-                />
-
-                <ULIComponent
-                    dataTip={'Delete Facility'}
-                    icon={TrashIcon}
-                    onClick={() => {
-                        openDeleteFacility(facility);
-                    }}
-                    tooltipClassName="tooltip-left"
-                />
+                {user && !isSysAdmin(user) ? (
+                    <ULIComponent
+                        dataTip={
+                            'Only UnlockEd staff can currently delete or edit facilities'
+                        }
+                        tooltipClassName="tooltip-left cursor-pointer"
+                        icon={LockClosedIcon}
+                    />
+                ) : (
+                    <>
+                        <ULIComponent
+                            dataTip={'Delete Facility'}
+                            icon={TrashIcon}
+                            onClick={() => {
+                                openDeleteFacility(facility);
+                            }}
+                            tooltipClassName="tooltip-left"
+                        />
+                        <ULIComponent
+                            dataTip={'Edit Facility'}
+                            icon={PencilSquareIcon}
+                            onClick={() => {
+                                openEditFacility(facility);
+                            }}
+                        />
+                    </>
+                )}
             </td>
         </tr>
     );

--- a/frontend/src/Pages/FacilityManagement.tsx
+++ b/frontend/src/Pages/FacilityManagement.tsx
@@ -18,6 +18,7 @@ import {
 } from '@/Components/modals';
 import { useCheckResponse } from '@/Hooks/useCheckResponse';
 import { useUrlPagination } from '@/Hooks/paginationUrlSync';
+import { isSysAdmin, useAuth } from '@/useAuth';
 
 export default function FacilityManagement() {
     const addFacilityModal = useRef<HTMLDialogElement>(null);
@@ -26,6 +27,7 @@ export default function FacilityManagement() {
     const { toaster } = useToast();
     const [targetFacility, setTargetFacility] =
         useState<TargetItem<Facility> | null>(null);
+    const { user } = useAuth();
 
     const {
         page: pageQuery,
@@ -64,6 +66,14 @@ export default function FacilityManagement() {
     }, [targetFacility]);
 
     const deleteFacility = async () => {
+        if (!user || !isSysAdmin(user)) {
+            toaster(
+                'Currently only UnlockEd staff may delete a facility',
+                ToastState.error
+            );
+            closeModal(deleteFacilityModal);
+            return;
+        }
         if (targetFacility?.target.id == 1) {
             toaster('Cannot delete default facility', ToastState.error);
             closeModal(deleteFacilityModal);


### PR DESCRIPTION
## Description of the change
PR Makes sure that only system admins can edit or delete facilities for the time being. 

- **Related issues**: https://app.asana.com/1/1201607307149189/project/1209460078641109/task/1210022616266304?focus=true

## Screenshot(s)
![image](https://github.com/user-attachments/assets/a2104dd7-4eab-4889-9da0-ffc5f1024d6e)
![image](https://github.com/user-attachments/assets/6e1fd3fd-e2fd-4937-91ad-285348e1723d)



