### PR TITLE
fix: clamp text on program overview dashboard

### DIFF
--- a/backend/src/handlers/programs_handler.go
+++ b/backend/src/handlers/programs_handler.go
@@ -33,7 +33,7 @@ func (srv *Server) handleIndexPrograms(w http.ResponseWriter, r *http.Request, l
 	args := srv.getQueryContext(r)
 	programs, err := srv.Db.GetPrograms(&args)
 	if err != nil {
-		log.add("search", args.Search)
+		log.add("search_query", args.Search)
 		return newDatabaseServiceError(err)
 	}
 	return writePaginatedResponse(w, http.StatusOK, programs, args.IntoMeta())

--- a/frontend/src/Pages/ProgramOverviewDashboard.tsx
+++ b/frontend/src/Pages/ProgramOverviewDashboard.tsx
@@ -15,6 +15,7 @@ import {
     ServerResponseMany,
     ProgramOverview
 } from '@/common';
+import ClampedText from '@/Components/ClampedText';
 import ProgramOutcomes from '@/Components/ProgramOutcomes';
 import ProgressBar from '@/Components/ProgressBar';
 import useSWR from 'swr';
@@ -259,8 +260,8 @@ export default function ProgramOverviewDashboard() {
                                     }
                                 />
                             </th>
-                            <th>Class Name</th>
-                            <th>Instructor Name</th>
+                            <th className="w-[400px]">Class Name</th>
+                            <th className="w-[300px]">Instructor Name</th>
                             <th>Start Date</th>
                             <th>End Date</th>
                             <th className="w-[200px]">Enrollments</th>
@@ -319,8 +320,25 @@ export default function ProgramOverviewDashboard() {
                                             />
                                         </div>
                                     </td>
-                                    <td>{program_class.name}</td>
-                                    <td>{program_class.instructor_name}</td>
+                                    <td className="max-w-[400px]">
+                                        <ClampedText
+                                            as="div"
+                                            lines={1}
+                                            className="truncate"
+                                        >
+                                            {program_class.name}
+                                        </ClampedText>
+                                    </td>
+                                    <td className="max-w-[300px]">
+                                        <ClampedText
+                                            as="div"
+                                            lines={1}
+                                            className="truncate"
+                                        >
+                                            {program_class.instructor_name}
+                                        </ClampedText>
+                                    </td>
+
                                     <td>
                                         {new Date(
                                             program_class.start_dt

--- a/frontend/src/Pages/ProgramOverviewDashboard.tsx
+++ b/frontend/src/Pages/ProgramOverviewDashboard.tsx
@@ -247,10 +247,10 @@ export default function ProgramOverviewDashboard() {
 
             {/* classes table */}
             <div className="card p-4">
-                <table className="table w-full mb-4">
+                <table className="table w-full table-fixed  mb-4">
                     <thead className="bg-background">
                         <tr>
-                            <th>
+                            <th className="w-[150px]">
                                 <input
                                     type="checkbox"
                                     className="checkbox checkbox-sm"
@@ -260,10 +260,10 @@ export default function ProgramOverviewDashboard() {
                                     }
                                 />
                             </th>
-                            <th className="w-[400px]">Class Name</th>
-                            <th className="w-[300px]">Instructor Name</th>
-                            <th>Start Date</th>
-                            <th>End Date</th>
+                            <th className="w-full">Class Name</th>
+                            <th className="w-full">Instructor Name</th>
+                            <th className="w-full">Start Date</th>
+                            <th className="w-full">End Date</th>
                             <th className="w-[200px]">Enrollments</th>
                             <th className="w-[150px]">Status</th>
                         </tr>
@@ -320,21 +320,13 @@ export default function ProgramOverviewDashboard() {
                                             />
                                         </div>
                                     </td>
-                                    <td className="max-w-[400px]">
-                                        <ClampedText
-                                            as="div"
-                                            lines={1}
-                                            className="truncate"
-                                        >
+                                    <td>
+                                        <ClampedText as="div" lines={1}>
                                             {program_class.name}
                                         </ClampedText>
                                     </td>
-                                    <td className="max-w-[300px]">
-                                        <ClampedText
-                                            as="div"
-                                            lines={1}
-                                            className="truncate"
-                                        >
+                                    <td>
+                                        <ClampedText as="div" lines={1}>
                                             {program_class.instructor_name}
                                         </ClampedText>
                                     </td>


### PR DESCRIPTION
## Description of the change
Clamp text for the instructor name and class name on the program overview dashboard 

- **Related issues**: https://app.asana.com/1/1201607307149189/project/1209460078641109/task/1209977398530322?focus=true
- 
## Screenshot(s)
Clamped -
![image](https://github.com/user-attachments/assets/5449afbe-76dd-4aed-b889-7699a98142ca)

Not clamped - 
![image](https://github.com/user-attachments/assets/fed83580-08b3-4772-9469-dee5498c66f3)
