### PR TITLE
fix: change password logic for admin and resident specificity

### DIFF
--- a/frontend/src/Components/modals/TextOnlyModal.tsx
+++ b/frontend/src/Components/modals/TextOnlyModal.tsx
@@ -41,7 +41,11 @@ export const TextOnlyModal = forwardRef(function TextModal(
                     <span className={`text-3xl font-semibold text-neutral`}>
                         {title}
                     </span>
-                    {typeof text === 'string' ? <p>{text}</p> : text}
+                    {typeof text === 'string' ? (
+                        <p className="whitespace-pre-line">{text}</p>
+                    ) : (
+                        text
+                    )}
                     {type === TextModalType.Information ? (
                         <>{children}</>
                     ) : (

--- a/frontend/src/Pages/AdminManagement.tsx
+++ b/frontend/src/Pages/AdminManagement.tsx
@@ -386,7 +386,8 @@ export default function AdminManagement() {
                 ref={showUserPassword}
                 type={TextModalType.Information}
                 title={'New Password'}
-                text={`Copy your password now. If you lose it, you'll need to generate a new one.`}
+                text={` Copy the password below and share it with the admin. 
+                        If it's lost, you’ll need to reset it again.`}
                 onSubmit={() => {}} //eslint-disable-line
                 onClose={() => handleCancelModal(showUserPassword)}
             >

--- a/frontend/src/Pages/StudentManagement.tsx
+++ b/frontend/src/Pages/StudentManagement.tsx
@@ -378,7 +378,8 @@ export default function StudentManagement() {
                 ref={showUserPassword}
                 type={TextModalType.Information}
                 title={'New Password'}
-                text={`Copy your password now. If you lose it, you'll need to generate a new one.`}
+                text={` Copy the password below and share it with the resident.
+                        If it's lost, you’ll need to reset it again.`}
                 onSubmit={() => {}} //eslint-disable-line
                 onClose={() => handleCancelModal(showUserPassword)}
             >


### PR DESCRIPTION
## Description of the change
Add user and admin specific language when displaying a users temporary password. 


- **Related issues**: https://app.asana.com/1/1201607307149189/project/1209460078641109/task/1209876778899413?focus=true

## Screenshot(s)

![image](https://github.com/user-attachments/assets/43f5d34e-f4f6-4b74-9f6f-bc4c0fd276ed)
![image](https://github.com/user-attachments/assets/17190146-a991-448a-ace5-1a800db1e1fc)
