### PR TITLE
fix: keep navbar pinned position across client route changes

### DIFF
--- a/frontend/src/Layouts/AuthenticatedLayout.tsx
+++ b/frontend/src/Layouts/AuthenticatedLayout.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import Navbar from '@/Components/Navbar';
 import { useMatches, UIMatch, Outlet, useLoaderData } from 'react-router-dom';
 import PageNav from '@/Components/PageNav';
@@ -55,6 +55,11 @@ export default function AuthenticatedLayout() {
         setIsNavPinned(false);
         setIsNavOpen(true);
     };
+    useEffect(() => {
+        if (!isNavPinned) {
+            setIsNavOpen(false);
+        }
+    }, [location.pathname]);
 
     const togglePin = () => {
         const newPinnedState = !isNavPinned;


### PR DESCRIPTION
https://app.asana.com/1/1201607307149189/project/1209460078641109/task/1209485070839570

the navbar now correctly reflects the state when a navigation item is clicked.