### PR TITLE
display only resident data in operational insights page

### DIFF
--- a/backend/src/database/users.go
+++ b/backend/src/database/users.go
@@ -239,35 +239,31 @@ func (db *DB) IncrementUserLogin(username string) (int64, error) {
 		log.Errorf("Error getting user by username: %v", err)
 		return 0, newGetRecordsDBError(err, "users")
 	}
+	var total int64
 	if err := db.Exec(
-		`INSERT INTO login_metrics (user_id, total, last_login) 
+		`INSERT INTO login_metrics (user_id, total, last_login)
 		 VALUES (?, 1, CURRENT_TIMESTAMP) 
 		 ON CONFLICT (user_id) DO UPDATE 
-		 SET total = login_metrics.total + 1, last_login = CURRENT_TIMESTAMP`,
-		user.ID).Error; err != nil {
+		 SET total = login_metrics.total + 1, last_login = CURRENT_TIMESTAMP
+		 RETURNING total`,
+		user.ID).Scan(&total).Error; err != nil {
 		log.Errorf("Error incrementing login count: %v", err)
 		return 0, newUpdateDBError(err, "login_metrics")
 	}
 	now := time.Now()
 	rounded := now.Truncate(time.Hour)
-
-	if err := db.Exec(
-		`INSERT INTO login_activity (time_interval, facility_id, total_logins)
-		 VALUES (?, ?, ?)
-		 ON CONFLICT (time_interval, facility_id)
-		 DO UPDATE SET total_logins = login_activity.total_logins + 1`,
-		rounded, user.FacilityID, 1).Error; err != nil {
-		log.Errorf("Error incrementing login activity: %v", err)
-		return 0, newUpdateDBError(err, "login_activity")
+	if !user.IsAdmin() {
+		if err := db.Exec(
+			`INSERT INTO login_activity (time_interval, facility_id, total_logins)
+			 VALUES (?, ?, ?)
+			 ON CONFLICT (time_interval, facility_id)
+			 DO UPDATE SET total_logins = login_activity.total_logins + 1`,
+			rounded, user.FacilityID, 1).Error; err != nil {
+			log.Errorf("Error incrementing login activity: %v", err)
+			return 0, newUpdateDBError(err, "login_activity")
+		}
 	}
-
-	var count int64
-	err = db.Model(&models.LoginMetrics{}).Select("total").Where("user_id = ?", user.ID).Scan(&count).Error
-	if err != nil {
-		log.Errorf("Error counting login metrics: %v", err)
-		return 0, newGetRecordsDBError(err, "login_metrics")
-	}
-	return count, nil
+	return total, nil
 }
 
 func (db *DB) LogUserSessionStarted(userID uint, sessionID string) {
@@ -297,13 +293,18 @@ func (db *DB) LogUserSessionEnded(userID uint, sessionID string) {
 	}
 }
 
-func (db *DB) GetNumberOfActiveUsersForTimePeriod(args *models.QueryContext, active bool, days int, facilityId *uint) (int64, error) {
+func (db *DB) GetNumberOfActiveUsersForTimePeriod(args *models.QueryContext, active bool, days int, facilityId *uint) (int64, int, error) {
 	var count int64
 	var tx *gorm.DB
 	join := "JOIN login_metrics on users.id = login_metrics.user_id"
 	tx = db.WithContext(args.Ctx).Model(&models.User{})
 	if days == -1 {
 		tx = tx.Joins(join)
+		sysAdmin, err := db.GetSystemAdmin()
+		if err != nil {
+			return 0, days, err
+		}
+		days = int(time.Since(sysAdmin.CreatedAt).Hours() / 24)
 	} else {
 		daysAgo := time.Now().AddDate(0, 0, -days)
 		if active {
@@ -316,17 +317,20 @@ func (db *DB) GetNumberOfActiveUsersForTimePeriod(args *models.QueryContext, act
 	if facilityId != nil {
 		tx = tx.Where("facility_id = ?", *facilityId)
 	}
+	tx = tx.Where("role = 'student'")
 	if err := tx.Count(&count).Error; err != nil {
-		return 0, newGetRecordsDBError(err, "users")
+		return 0, days, newGetRecordsDBError(err, "users")
 	}
-	return count, nil
+	if days == 0 {
+		days = 1
+	}
+	return count, days, nil
 }
 
-func (db *DB) NewUsersInTimePeriod(args *models.QueryContext, days int, facilityId *uint) (int64, int64, error) {
-	var admin_count int64
+func (db *DB) NewUsersInTimePeriod(args *models.QueryContext, days int, facilityId *uint) (int64, error) {
 	var resident_count int64
 	daysAgo := time.Now().AddDate(0, 0, -days)
-	tx := db.WithContext(args.Ctx).Model(&models.User{}).Where("role ='student'")
+	tx := db.WithContext(args.Ctx).Model(&models.User{}).Where("role = 'student'")
 	if days != -1 {
 		tx = tx.Where("created_at >= ?", daysAgo)
 	}
@@ -334,19 +338,9 @@ func (db *DB) NewUsersInTimePeriod(args *models.QueryContext, days int, facility
 		tx = tx.Where("facility_id = ?", *facilityId)
 	}
 	if err := tx.Count(&resident_count).Error; err != nil {
-		return 0, 0, newGetRecordsDBError(err, "users")
+		return 0, newGetRecordsDBError(err, "users")
 	}
-	tx = db.WithContext(args.Ctx).Model(&models.User{}).Where("role IN ?", models.AdminRoles)
-	if days != -1 {
-		tx = tx.Where("created_at >= ?", daysAgo)
-	}
-	if facilityId != nil {
-		tx = tx.Where("facility_id = ?", *facilityId)
-	}
-	if err := tx.Count(&admin_count).Error; err != nil {
-		return 0, 0, newGetRecordsDBError(err, "users")
-	}
-	return resident_count, admin_count, nil
+	return resident_count, nil
 }
 
 func (db *DB) GetTotalLogins(args *models.QueryContext, days int, facilityId *uint) (int64, error) {
@@ -365,24 +359,16 @@ func (db *DB) GetTotalLogins(args *models.QueryContext, days int, facilityId *ui
 	return total, nil
 }
 
-func (db *DB) GetTotalUsers(args *models.QueryContext, facilityId *uint) (int64, int64, error) {
+func (db *DB) GetTotalUsers(args *models.QueryContext, facilityId *uint) (int64, error) {
 	var totalResidents int64
-	var totalAdmins int64
-	tx := db.WithContext(args.Ctx).Model(&models.User{}).Where("role = 'student'")
+	adminTx := db.WithContext(args.Ctx).Model(&models.User{}).Where("role = 'student'")
 	if facilityId != nil {
-		tx = tx.Where("facility_id = ?", *facilityId)
+		adminTx = adminTx.Where("facility_id = ?", *facilityId)
 	}
-	if err := tx.Count(&totalResidents).Error; err != nil {
-		return 0, 0, newGetRecordsDBError(err, "users")
+	if err := adminTx.Count(&totalResidents).Error; err != nil {
+		return 0, newGetRecordsDBError(err, "users")
 	}
-	tx = db.WithContext(args.Ctx).Model(&models.User{}).Where("role IN ?", models.AdminRoles)
-	if facilityId != nil {
-		tx = tx.Where("facility_id = ?", *facilityId)
-	}
-	if err := tx.Count(&totalAdmins).Error; err != nil {
-		return 0, 0, newGetRecordsDBError(err, "users")
-	}
-	return totalResidents, totalAdmins, nil
+	return totalResidents, nil
 }
 
 func (db *DB) GetLoginActivity(args *models.QueryContext, days int, facilityID *uint) ([]models.LoginActivity, error) {

--- a/frontend/src/Components/OperationalInsightsCharts.tsx
+++ b/frontend/src/Components/OperationalInsightsCharts.tsx
@@ -11,8 +11,11 @@ import { ResponsiveContainer } from 'recharts';
 import EngagementRateGraph from './EngagementRateGraph';
 import { useAuth, canSwitchFacility } from '@/useAuth';
 import DropdownControl from './inputs/DropdownControl';
+interface Props {
+    facilities: Facility[];
+}
 
-const OperationalInsights = () => {
+const OperationalInsights = ({ facilities }: Props) => {
     const [facility, setFacility] = useState('all');
     const [timeFilter, setTimeFilter] = useState<FilterPastTime>(
         FilterPastTime['Past 30 days']
@@ -26,14 +29,11 @@ const OperationalInsights = () => {
     >(
         `/api/login-metrics?facility=${facility}&days=${timeFilter}&reset=${resetCache}`
     );
-    const { data: facilitiesData } =
-        useSWR<ServerResponseOne<Facility[]>>('/api/facilities');
 
     useEffect(() => {
         void mutate();
     }, [facility, timeFilter, resetCache]);
 
-    const facilities = facilitiesData?.data;
     useEffect(() => {
         if (user && !canSwitchFacility(user)) {
             setFacility('');
@@ -44,9 +44,7 @@ const OperationalInsights = () => {
     const formattedDate =
         metrics && new Date(metrics.last_cache).toLocaleString('en-US', {});
 
-    const totalUsers =
-        (metrics?.data.total_residents ?? 0) +
-        (metrics?.data.total_admins ?? 0);
+    const totalUsers = metrics?.data.total_residents ?? 0;
 
     return (
         <div className="overflow-x-hidden">
@@ -103,6 +101,8 @@ const OperationalInsights = () => {
                         <div>
                             <p className="label label-text text-grey-3">
                                 Last updated: {formattedDate}
+                                <br />
+                                Includes residents only
                             </p>
                             <button
                                 className="button justify-self-end"
@@ -118,7 +118,7 @@ const OperationalInsights = () => {
                             title="Total Users"
                             number={totalUsers.toString()}
                             label="Users"
-                            tooltip="Total number of admins and residents in the facility"
+                            tooltip="Total number of residents in the facility"
                             tooltipClassName="tooltip-right"
                         />
                         <StatsCard
@@ -151,26 +151,12 @@ const OperationalInsights = () => {
                             }`}
                         />
                         <StatsCard
-                            title="New Admins Added"
-                            number={metrics.data.new_admins_added.toString()}
-                            label={
-                                metrics.data.new_admins_added === 1
-                                    ? 'Admin'
-                                    : 'Admins'
-                            }
-                            tooltip={`${
-                                timeFilter === FilterPastTime['All time']
-                                    ? 'All time number of new admins added'
-                                    : `Number of new admins added in the last ${timeFilter} days`
-                            }`}
-                        />
-                        <StatsCard
-                            title="New Residents Added"
+                            title="New Users Added"
                             number={metrics.data.new_residents_added.toString()}
                             label={
                                 metrics.data.new_residents_added === 1
-                                    ? 'Resident'
-                                    : 'Residents'
+                                    ? 'User'
+                                    : 'Users'
                             }
                             tooltip={`${
                                 timeFilter === FilterPastTime['All time']

--- a/frontend/src/Pages/OperationalInsights.tsx
+++ b/frontend/src/Pages/OperationalInsights.tsx
@@ -1,10 +1,14 @@
+import { Facility } from '@/common';
 import OperationalInsights from '@/Components/OperationalInsightsCharts';
+import { useLoaderData } from 'react-router-dom';
 
 export default function OperationalInsightsPage() {
+    const facilities = useLoaderData() as Facility[];
+
     return (
         <div>
             <div className="w-full flex flex-col gap-6 px-5 pb-4">
-                <OperationalInsights />
+                <OperationalInsights facilities={facilities} />
             </div>
         </div>
     );

--- a/frontend/src/Routes/App.tsx
+++ b/frontend/src/Routes/App.tsx
@@ -83,6 +83,7 @@ const adminRoutes = DeclareAuthenticatedRoutes(
         {
             path: 'operational-insights',
             element: <OperationalInsightsPage />,
+            loader: getFacilities,
             errorElement: <Error />,
             handle: {
                 title: 'Operational Insights'

--- a/frontend/src/common.ts
+++ b/frontend/src/common.ts
@@ -356,7 +356,6 @@ export interface LoginMetrics {
         percent_active: number;
         percent_inactive: number;
         total_residents: number;
-        total_admins: number;
         facility: string;
         new_residents_added: number;
         new_admins_added: number;

--- a/provider-middleware/video_dl.go
+++ b/provider-middleware/video_dl.go
@@ -304,7 +304,7 @@ func (vs *VideoService) retrySingleVideo(ctx context.Context, videoId int) error
 
 func (yt *VideoService) addVideos(ctx context.Context) error {
 	params := *yt.Body
-	urls := params["video_urls"].([]interface{})
+	urls := params["video_urls"].([]any)
 	logger().Infof("Adding videos: %v", urls)
 
 	for idx := range urls {


### PR DESCRIPTION
https://app.asana.com/1/1201607307149189/project/1209460078641109/task/1210093059550570

removes ambiguity by not mixing admin and resident data in the operational insights page.

also prevents storing admin metrics in login_activity table