### PR TITLE
feat: add ability to change program status 

### DIFF
--- a/backend/src/database/program_classes.go
+++ b/backend/src/database/program_classes.go
@@ -8,7 +8,7 @@ import (
 
 func (db *DB) GetClassByID(id int) (*models.ProgramClass, error) {
 	content := &models.ProgramClass{}
-	if err := db.Preload("Events").Preload("Enrollments").First(content, "id = ?", id).Error; err != nil {
+	if err := db.Preload("Events").Preload("Enrollments").Preload("Program").First(content, "id = ?", id).Error; err != nil {
 		return nil, newNotFoundDBError(err, "program classes")
 	}
 	var enrollments int

--- a/backend/src/database/programs.go
+++ b/backend/src/database/programs.go
@@ -103,6 +103,21 @@ func (db *DB) UpdateProgram(content *models.Program) (*models.Program, error) {
 	return content, nil
 }
 
+func (db *DB) UpdateProgramStatus(programUpdate map[string]any, id int) (bool, error) {
+	var count int64
+	err := db.Model(&models.ProgramClass{}).Where("program_id = ? and status IN ?", id, []models.ClassStatus{models.Active, models.Scheduled}).Count(&count).Error
+	if err != nil {
+		return false, newGetRecordsDBError(err, "program_classes")
+	}
+	if count > 0 && programUpdate["archived_at"] != nil {
+		return false, nil
+	}
+	if err := db.Model(&models.Program{}).Where("id = ?", id).Updates(programUpdate).Error; err != nil {
+		return false, newUpdateDBError(err, "program status")
+	}
+	return true, nil
+}
+
 func (db *DB) DeleteProgram(id int) error {
 	if err := db.Delete(&models.Program{}, id).Error; err != nil {
 		return newDeleteDBError(err, "programs")

--- a/backend/src/handlers/classes_handler.go
+++ b/backend/src/handlers/classes_handler.go
@@ -66,8 +66,8 @@ func (srv *Server) handleCreateClass(w http.ResponseWriter, r *http.Request, log
 	if err != nil {
 		return writeJsonResponse(w, http.StatusInternalServerError, "Error retrieving program")
 	}
-	if !program.IsActive && !srv.isTesting(r) {
-		return writeJsonResponse(w, http.StatusConflict, "Program is inactive unable to create class")
+	if !program.IsActive && !srv.isTesting(r) || program.ArchivedAt != nil && !srv.isTesting(r) {
+		return writeJsonResponse(w, http.StatusConflict, "Program is inactive or archived unable to create class")
 	}
 	var class models.ProgramClass
 	err = json.NewDecoder(r.Body).Decode(&class)

--- a/backend/src/handlers/classes_handler.go
+++ b/backend/src/handlers/classes_handler.go
@@ -62,6 +62,13 @@ func (srv *Server) handleCreateClass(w http.ResponseWriter, r *http.Request, log
 	if err != nil {
 		return newInvalidIdServiceError(err, "program ID")
 	}
+	program, err := srv.Db.GetProgramByID(id)
+	if err != nil {
+		return writeJsonResponse(w, http.StatusInternalServerError, "Error retrieving program")
+	}
+	if !program.IsActive && !srv.isTesting(r) {
+		return writeJsonResponse(w, http.StatusConflict, "Program is inactive unable to create class")
+	}
 	var class models.ProgramClass
 	err = json.NewDecoder(r.Body).Decode(&class)
 	defer r.Body.Close()

--- a/backend/src/handlers/programs_handler.go
+++ b/backend/src/handlers/programs_handler.go
@@ -202,8 +202,9 @@ func (srv *Server) handleUpdateProgramStatus(w http.ResponseWriter, r *http.Requ
 		return newInvalidIdServiceError(err, "program ID")
 	}
 	log.add("program_id", id)
-	claims := r.Context().Value(ClaimsKey).(*Claims)
-	programUpdate["update_user_id"] = claims.UserID
+	// These will need to be uncommented once the update_user_id is added to the database
+	//claims := r.Context().Value(ClaimsKey).(*Claims)
+	//programUpdate["update_user_id"] = claims.UserID
 	updated, err := srv.Db.UpdateProgramStatus(programUpdate, id)
 	if err != nil {
 		return newDatabaseServiceError(err)

--- a/backend/src/handlers/programs_handler.go
+++ b/backend/src/handlers/programs_handler.go
@@ -197,6 +197,7 @@ func (srv *Server) handleUpdateProgramStatus(w http.ResponseWriter, r *http.Requ
 	if err := json.NewDecoder(r.Body).Decode(&programUpdate); err != nil {
 		return newJSONReqBodyServiceError(err)
 	}
+	defer r.Body.Close()
 	id, err := strconv.Atoi(r.PathValue("id"))
 	if err != nil {
 		return newInvalidIdServiceError(err, "program ID")

--- a/frontend/src/Components/ClassLayout.tsx
+++ b/frontend/src/Components/ClassLayout.tsx
@@ -21,9 +21,8 @@ import StatsCard from './StatsCard';
 
 function ClassInfoCard({ classInfo }: { classInfo?: Class }) {
     const navigate = useNavigate();
-    const programDisabled =
-        classInfo?.program.archived_at === null ||
-        classInfo?.program.is_active === false;
+
+    const programDisabled = classInfo?.program.archived_at !== null;
     return (
         <div className="card card-row-padding flex flex-col h-full">
             <h1>Class Info</h1>

--- a/frontend/src/Components/ClassLayout.tsx
+++ b/frontend/src/Components/ClassLayout.tsx
@@ -21,6 +21,9 @@ import StatsCard from './StatsCard';
 
 function ClassInfoCard({ classInfo }: { classInfo?: Class }) {
     const navigate = useNavigate();
+    const programDisabled =
+        classInfo?.program.archived_at === null ||
+        classInfo?.program.is_active === false;
     return (
         <div className="card card-row-padding flex flex-col h-full">
             <h1>Class Info</h1>
@@ -58,12 +61,13 @@ function ClassInfoCard({ classInfo }: { classInfo?: Class }) {
             <p className="body">Room: {classInfo?.events[0].room}</p>
             <div className="flex flex-row gap-2 mt-6 justify-center">
                 <button
-                    className="button"
+                    className={`button ${programDisabled ? 'opacity-50 cursor-not-allowed ' : ''}`}
                     onClick={() => {
                         navigate(
                             `/programs/${classInfo?.program_id}/classes/${classInfo?.id}`
                         );
                     }}
+                    disabled={programDisabled}
                 >
                     <PencilSquareIcon className="w-4 my-auto" />
                     Edit Class Details

--- a/frontend/src/Components/ClassStatus.tsx
+++ b/frontend/src/Components/ClassStatus.tsx
@@ -117,7 +117,7 @@ export default function ClassStatus({
             SelectedClassStatus.Paused,
             [ClassStatusOptions.Active, ClassStatusOptions.Cancel]
         ],
-        [SelectedClassStatus.Completed, []],//just in case, setting to empty array
+        [SelectedClassStatus.Completed, []], //just in case, setting to empty array
         [SelectedClassStatus.Cancelled, []]
     ]);
 
@@ -198,6 +198,7 @@ export default function ClassStatus({
                 program_class={program_class}
                 mutate={mutateClasses}
                 setSelectedStatus={setSelectedStatus}
+                onClose={() => setSelectedModifyOption(undefined)}
             />
         </>
     );

--- a/frontend/src/Components/ProgramStatus.tsx
+++ b/frontend/src/Components/ProgramStatus.tsx
@@ -23,7 +23,7 @@ function ProgramStatusPill({
     let background: string, text: string;
     switch (status) {
         case ProgramEffectiveStatus.Available:
-            background = 'bg-teal-4 text-white';
+            background = 'bg-[#B0DFDA] text-[#002E2A]';
             text = 'Available';
             break;
         case ProgramEffectiveStatus.Inactive:
@@ -31,7 +31,7 @@ function ProgramStatusPill({
             text = 'Inactive';
             break;
         case ProgramEffectiveStatus.Archived:
-            background = 'bg-grey-3 text-body-text';
+            background = 'bg-grey-2 text-body-text';
             text = 'Archived';
             break;
     }
@@ -73,7 +73,6 @@ export default function ProgramStatus({
         null
     );
 
-    // use the shared hook for toasts, modal‑closing, and SWR mutate on success
     const checkResponse = useCheckResponse({
         mutate,
         refModal: modifyProgramRef
@@ -101,21 +100,21 @@ export default function ProgramStatus({
         let resp = { success: false, message: '' };
 
         if (selectedAction === 'set_available') {
-            resp = await API.patch(`programs/${program.program_id}`, {
-                status: true
+            resp = await API.patch(`programs/${program.program_id}/status`, {
+                is_active: true
             });
         } else if (selectedAction === 'set_inactive') {
-            resp = await API.patch(`programs/${program.program_id}`, {
-                status: false
+            resp = await API.patch(`programs/${program.program_id}/status`, {
+                is_active: false
             });
         } else if (selectedAction === 'archive') {
-            resp = await API.patch(`programs/${program.program_id}`, {
+            resp = await API.patch(`programs/${program.program_id}/status`, {
                 archived_at: new Date().toISOString()
             });
         } else if (selectedAction === 'reactivate') {
-            resp = await API.patch(`programs/${program.program_id}`, {
+            resp = await API.patch(`programs/${program.program_id}/status`, {
                 archived_at: null,
-                status: newStatus
+                is_active: newStatus
             });
         }
 
@@ -173,7 +172,6 @@ export default function ProgramStatus({
                     </ul>
                 )}
             </div>
-
             <ModifyProgramModal
                 ref={modifyProgramRef}
                 action={selectedAction}

--- a/frontend/src/Components/ProgramStatus.tsx
+++ b/frontend/src/Components/ProgramStatus.tsx
@@ -1,0 +1,186 @@
+import { useEffect, useRef, useState } from 'react';
+import { KeyedMutator } from 'swr';
+import { showModal } from './modals';
+import API from '@/api/api';
+import ModifyProgramModal from './modals/ModifyProgramModal';
+import { useCheckResponse } from '@/Hooks/useCheckResponse';
+import {
+    ProgramsOverviewTable,
+    ServerResponseMany,
+    ProgramEffectiveStatus,
+    ProgramAction
+} from '@/common';
+import { ChevronDownIcon } from '@heroicons/react/24/outline';
+import ULIComponent from '@/Components/ULIComponent';
+
+function ProgramStatusPill({
+    status,
+    closed
+}: {
+    status: ProgramEffectiveStatus;
+    closed: boolean;
+}) {
+    let background: string, text: string;
+    switch (status) {
+        case ProgramEffectiveStatus.Available:
+            background = 'bg-teal-4 text-white';
+            text = 'Available';
+            break;
+        case ProgramEffectiveStatus.Inactive:
+            background = 'bg-grey-2 text-body-text';
+            text = 'Inactive';
+            break;
+        case ProgramEffectiveStatus.Archived:
+            background = 'bg-grey-3 text-body-text';
+            text = 'Archived';
+            break;
+    }
+    return (
+        <div
+            className={`inline-flex items-center gap-1 catalog-pill mx-0 w-full justify-between ${background} ${
+                closed ? '' : 'cursor-pointer'
+            }`}
+        >
+            <span>{text}</span>
+            {!closed && <ULIComponent icon={ChevronDownIcon} />}
+        </div>
+    );
+}
+
+function getEffectiveStatus(
+    program: ProgramsOverviewTable
+): ProgramEffectiveStatus {
+    if (program.archived_at !== null) {
+        return ProgramEffectiveStatus.Archived;
+    } else if (program.status) {
+        return ProgramEffectiveStatus.Available;
+    } else {
+        return ProgramEffectiveStatus.Inactive;
+    }
+}
+
+export default function ProgramStatus({
+    program,
+    mutate
+}: {
+    program: ProgramsOverviewTable;
+    mutate: KeyedMutator<ServerResponseMany<ProgramsOverviewTable>>;
+}) {
+    const [dropdownOpen, setDropdownOpen] = useState(false);
+    const effectiveStatus = getEffectiveStatus(program);
+    const modifyProgramRef = useRef<HTMLDialogElement>(null);
+    const [selectedAction, setSelectedAction] = useState<ProgramAction | null>(
+        null
+    );
+
+    // use the shared hook for toasts, modal‑closing, and SWR mutate on success
+    const checkResponse = useCheckResponse({
+        mutate,
+        refModal: modifyProgramRef
+    });
+
+    const programActions = new Map<ProgramEffectiveStatus, ProgramAction[]>([
+        [ProgramEffectiveStatus.Available, ['set_inactive', 'archive']],
+        [ProgramEffectiveStatus.Inactive, ['set_available', 'archive']],
+        [ProgramEffectiveStatus.Archived, ['reactivate']]
+    ]);
+    const availableActions = programActions.get(effectiveStatus) ?? [];
+
+    function openSelectionModal(action: ProgramAction) {
+        setSelectedAction(action);
+        setDropdownOpen(false);
+    }
+
+    useEffect(() => {
+        if (selectedAction) {
+            showModal(modifyProgramRef);
+        }
+    }, [selectedAction]);
+
+    async function handleConfirm(newStatus?: boolean) {
+        let resp = { success: false, message: '' };
+
+        if (selectedAction === 'set_available') {
+            resp = await API.patch(`programs/${program.program_id}`, {
+                status: true
+            });
+        } else if (selectedAction === 'set_inactive') {
+            resp = await API.patch(`programs/${program.program_id}`, {
+                status: false
+            });
+        } else if (selectedAction === 'archive') {
+            resp = await API.patch(`programs/${program.program_id}`, {
+                archived_at: new Date().toISOString()
+            });
+        } else if (selectedAction === 'reactivate') {
+            resp = await API.patch(`programs/${program.program_id}`, {
+                archived_at: null,
+                status: newStatus
+            });
+        }
+
+        checkResponse(
+            resp.success,
+            selectedAction === 'archive'
+                ? 'This program has active or scheduled classes. A program cannot be archived until all classes are completed or canceled.'
+                : resp.message || 'Unable to update program status',
+            'Program updated successfully'
+        );
+    }
+
+    return (
+        <>
+            <div
+                className="relative"
+                onClick={(e) => {
+                    setDropdownOpen(!dropdownOpen);
+                    e.stopPropagation();
+                }}
+                onBlur={(e) => {
+                    if (!e.currentTarget.contains(e.relatedTarget as Node)) {
+                        setDropdownOpen(false);
+                    }
+                }}
+                tabIndex={0}
+            >
+                <ProgramStatusPill
+                    status={effectiveStatus}
+                    closed={availableActions.length === 0}
+                />
+                {dropdownOpen && (
+                    <ul className="absolute left-0 bg-inner-background rounded-box shadow-lg p-2 overflow-y-auto z-10 w-full">
+                        {availableActions.map((action) => (
+                            <li key={action} className="w-full">
+                                <div
+                                    className="flex items-center space-x-2 px-2 py-1 hover:bg-grey-2 rounded cursor-pointer"
+                                    onClick={(e) => {
+                                        e.stopPropagation();
+                                        openSelectionModal(action);
+                                    }}
+                                >
+                                    <span className="text-sm">
+                                        {action === 'set_available'
+                                            ? 'Available'
+                                            : action === 'set_inactive'
+                                              ? 'Inactive'
+                                              : action === 'archive'
+                                                ? 'Archive'
+                                                : 'Reactivate'}
+                                    </span>
+                                </div>
+                            </li>
+                        ))}
+                    </ul>
+                )}
+            </div>
+
+            <ModifyProgramModal
+                ref={modifyProgramRef}
+                action={selectedAction}
+                program={program}
+                onConfirm={() => void handleConfirm()}
+                onClose={() => setSelectedAction(null)}
+            />
+        </>
+    );
+}

--- a/frontend/src/Components/ProgramStatus.tsx
+++ b/frontend/src/Components/ProgramStatus.tsx
@@ -180,7 +180,7 @@ export default function ProgramStatus({
                 ref={modifyProgramRef}
                 action={selectedAction}
                 program={program}
-                onConfirm={() => void handleConfirm()}
+                onConfirm={(newStatus) => void handleConfirm(newStatus)}
                 onClose={() => setSelectedAction(null)}
             />
         </>

--- a/frontend/src/Components/ProgramStatus.tsx
+++ b/frontend/src/Components/ProgramStatus.tsx
@@ -121,13 +121,14 @@ export default function ProgramStatus({
             body
         )) as ServerResponseOne<UpdateStatusResponse>;
 
-        const list = resp.data.facilities?.join(', ');
-
-        checkResponse(
-            resp.data.updated,
-            `Cannot archive: active or scheduled classes still exist at: ${list}`,
-            resp.data.message
-        );
+        if (resp.success) {
+            const list = resp.data.facilities?.join(', ');
+            checkResponse(
+                resp.data.updated,
+                `Cannot archive: active or scheduled classes still exist at: ${list}`,
+                resp.data.message
+            );
+        }
     }
 
     return (

--- a/frontend/src/Components/modals/ModifyClassModal.tsx
+++ b/frontend/src/Components/modals/ModifyClassModal.tsx
@@ -46,7 +46,8 @@ const ModifyClassModal = forwardRef(function (
         action,
         program_class,
         mutate,
-        setSelectedStatus
+        setSelectedStatus,
+        onClose
     }: {
         action: ClassStatusOptions | undefined;
         program_class: Class;
@@ -56,6 +57,7 @@ const ModifyClassModal = forwardRef(function (
         setSelectedStatus: React.Dispatch<
             React.SetStateAction<SelectedClassStatus>
         >;
+        onClose?: () => void;
     },
     ref: React.ForwardedRef<HTMLDialogElement>
 ) {
@@ -84,6 +86,7 @@ const ModifyClassModal = forwardRef(function (
     }
     function close() {
         closeModal(ref);
+        onClose?.();
     }
     return (
         <div onClick={(e) => e.stopPropagation()}>

--- a/frontend/src/Components/modals/ModifyProgramModal.tsx
+++ b/frontend/src/Components/modals/ModifyProgramModal.tsx
@@ -55,7 +55,10 @@ const ModifyProgramModal = forwardRef(function (
                 onClick={(e) => e.stopPropagation()}
             >
                 <div className="modal-box" onClick={(e) => e.stopPropagation()}>
-                    <h3 className="font-bold text-lg">{title}</h3>
+                    <span className={`text-3xl font-semibold text-neutral`}>
+                        {' '}
+                        {title}
+                    </span>
                     <p className="py-4">{text}</p>
                     <div className="form-control">
                         <label className="label cursor-pointer">

--- a/frontend/src/Components/modals/ModifyProgramModal.tsx
+++ b/frontend/src/Components/modals/ModifyProgramModal.tsx
@@ -1,0 +1,131 @@
+import { TextOnlyModal } from './TextOnlyModal';
+import { closeModal, TextModalType } from '.';
+import { forwardRef, useState } from 'react';
+import { ProgramsOverviewTable, ProgramAction } from '@/common';
+
+export const ProgramActionMessages = {
+    set_available: {
+        title: 'Set to Available',
+        text: 'Setting this program to available will allow new classes to be created. Are you sure?'
+    },
+    set_inactive: {
+        title: 'Set to Inactive',
+        text: 'Marking this program inactive will prevent new classes from being created. Existing active and scheduled classes will continue. Scheduled classes will require manual review if you wish to cancel them. Are you sure?'
+    },
+    archive: {
+        title: 'Archive Program',
+        text: 'Are you sure you would like to archive this program? Archiving this program will prevent new classes from being created. Existing data will remain available for reporting.'
+    },
+    reactivate: {
+        title: 'Reactivate Program',
+        text: 'Reactivating this program will make it available again for use. Please choose the program’s new status:'
+    }
+};
+
+const ModifyProgramModal = forwardRef(function (
+    {
+        action,
+        onConfirm,
+        onClose
+    }: {
+        action: ProgramAction | null;
+        program: ProgramsOverviewTable;
+        onConfirm: (newStatus?: boolean) => void;
+        onClose: () => void;
+    },
+    ref: React.ForwardedRef<HTMLDialogElement>
+) {
+    const [chosenStatus, setChosenStatus] = useState<boolean>(true);
+
+    if (!action) return null;
+
+    const { title, text } = ProgramActionMessages[action];
+
+    function close() {
+        setChosenStatus(false);
+        closeModal(ref);
+        onClose?.();
+    }
+
+    if (action === 'reactivate') {
+        return (
+            <dialog
+                ref={ref}
+                className="modal"
+                onClick={(e) => e.stopPropagation()}
+            >
+                <div className="modal-box" onClick={(e) => e.stopPropagation()}>
+                    <h3 className="font-bold text-lg">{title}</h3>
+                    <p className="py-4">{text}</p>
+                    <div className="form-control">
+                        <label className="label cursor-pointer">
+                            <span className="label-text">Available</span>
+                            <input
+                                type="radio"
+                                name="status"
+                                className="radio"
+                                checked={chosenStatus}
+                                onChange={(e) => {
+                                    e.stopPropagation();
+                                    setChosenStatus(true);
+                                }}
+                            />
+                        </label>
+                        <label className="label cursor-pointer">
+                            <span className="label-text">Inactive</span>
+                            <input
+                                type="radio"
+                                name="status"
+                                className="radio"
+                                checked={!chosenStatus}
+                                onChange={(e) => {
+                                    e.stopPropagation();
+                                    setChosenStatus(false);
+                                }}
+                            />
+                        </label>
+                    </div>
+                    <div className="modal-action">
+                        <button
+                            className="btn"
+                            onClick={(e) => {
+                                e.stopPropagation();
+                                close();
+                            }}
+                        >
+                            Cancel
+                        </button>
+                        <button
+                            className="btn btn-primary"
+                            onClick={(e) => {
+                                e.stopPropagation();
+                                onConfirm(chosenStatus);
+                                close();
+                            }}
+                        >
+                            Confirm
+                        </button>
+                    </div>
+                </div>
+            </dialog>
+        );
+    }
+
+    return (
+        <div onClick={(e) => e.stopPropagation()}>
+            <TextOnlyModal
+                ref={ref}
+                type={TextModalType.Confirm}
+                title={title}
+                text={text}
+                onSubmit={() => {
+                    onConfirm();
+                    close();
+                }}
+                onClose={close}
+            />
+        </div>
+    );
+});
+
+export default ModifyProgramModal;

--- a/frontend/src/Components/modals/ModifyProgramModal.tsx
+++ b/frontend/src/Components/modals/ModifyProgramModal.tsx
@@ -10,7 +10,7 @@ export const ProgramActionMessages = {
     },
     set_inactive: {
         title: 'Set to Inactive',
-        text: 'Marking this program inactive will prevent new classes from being created. Existing active and scheduled classes will continue. Scheduled classes will require manual review if you wish to cancel them. Are you sure?'
+        text: ' You won’t be able to create new classes for this program. \n Existing and scheduled classes will continue unless you cancel them manually.'
     },
     archive: {
         title: 'Archive Program',

--- a/frontend/src/Components/modals/TextOnlyModal.tsx
+++ b/frontend/src/Components/modals/TextOnlyModal.tsx
@@ -42,7 +42,7 @@ export const TextOnlyModal = forwardRef(function TextModal(
                         {title}
                     </span>
                     {typeof text === 'string' ? (
-                        <p className="whitespace-pre-line">{text}</p>
+                        <p className="whitespace-pre-line body">{text}</p>
                     ) : (
                         text
                     )}

--- a/frontend/src/Pages/ClassManagementForm.tsx
+++ b/frontend/src/Pages/ClassManagementForm.tsx
@@ -80,9 +80,11 @@ export default function ClassManagementForm() {
             const toasterMsg =
                 class_id && response.message.includes('unenrolling')
                     ? 'Cannot update class until unenrolling residents'
-                    : class_id
-                      ? 'Failed to update class'
-                      : 'Failed to create class';
+                    : response.message.includes('inactive')
+                      ? 'Cannot create class for an inactive program'
+                      : class_id
+                        ? 'Failed to update class'
+                        : 'Failed to create class';
             toaster(toasterMsg, ToastState.error);
             console.error(
                 `error occurred while trying to create/update class, error message: ${response.message}`

--- a/frontend/src/Pages/ProgramManagement.tsx
+++ b/frontend/src/Pages/ProgramManagement.tsx
@@ -108,7 +108,7 @@ export function ProgramRow({
                 <TagsWithFormatting types={creditTypes} />
             </td>
             <td>{transformStringToArray(program.funding_type)}</td>
-            <td>
+            <td className="text-left">
                 <ProgramStatus program={program} mutate={mutate} />
             </td>
         </tr>

--- a/frontend/src/Pages/ProgramManagement.tsx
+++ b/frontend/src/Pages/ProgramManagement.tsx
@@ -10,7 +10,7 @@ import {
     ProgramsFacilitiesStats,
     UserRole
 } from '@/common';
-import useSWR from 'swr';
+import useSWR, { KeyedMutator } from 'swr';
 import { InformationCircleIcon } from '@heroicons/react/24/outline';
 import { useLoaderData } from 'react-router-dom';
 import Pagination from '@/Components/Pagination';
@@ -19,8 +19,6 @@ import CategoryDropdownFilter from '@/Components/CategoryDropdownFilter';
 import { useUrlPagination } from '@/Hooks/paginationUrlSync';
 import DropdownControl from '@/Components/inputs/DropdownControl';
 import StatsCard from '@/Components/StatsCard';
-import GreyPill from '@/Components/pill-labels/GreyPill';
-import TealPill from '@/Components/pill-labels/TealPill';
 import ULIComponent from '@/Components/ULIComponent';
 import { useDebounceValue } from 'usehooks-ts';
 import {
@@ -28,13 +26,16 @@ import {
     transformStringToArray
 } from '@/Components/helperFunctions';
 import { AddButton } from '@/Components/inputs';
+import ProgramStatus from '@/Components/ProgramStatus';
 
 export function ProgramRow({
     program,
-    tableCols
+    tableCols,
+    mutate
 }: {
     program: ProgramsOverviewTable;
     tableCols: string;
+    mutate: KeyedMutator<ServerResponseMany<ProgramsOverviewTable>>;
 }) {
     const { user } = useAuth();
     const navigate = useNavigate();
@@ -74,7 +75,10 @@ export function ProgramRow({
     return (
         <tr
             className={`grid ${tableCols} justify-items-center gap-2 items-center text-center card !mr-0 px-2 py-2 ${background} cursor-pointer`}
-            onClick={() => navigate(`${program.program_id}`)}
+            onClick={(e) => {
+                e.stopPropagation();
+                navigate(`${program.program_id}`);
+            }}
         >
             <td>{program.program_name}</td>
             {user?.role != UserRole.FacilityAdmin && (
@@ -105,11 +109,7 @@ export function ProgramRow({
             </td>
             <td>{transformStringToArray(program.funding_type)}</td>
             <td>
-                {program.status ? (
-                    <TealPill children={'Active'} />
-                ) : (
-                    <GreyPill children={'Inactive'} />
-                )}
+                <ProgramStatus program={program} mutate={mutate} />
             </td>
         </tr>
     );
@@ -330,6 +330,7 @@ export default function ProgramManagement() {
                                     key={index}
                                     program={program}
                                     tableCols={tableCols}
+                                    mutate={mutate}
                                 />
                             ))
                         )}

--- a/frontend/src/Pages/ProgramOverviewDashboard.tsx
+++ b/frontend/src/Pages/ProgramOverviewDashboard.tsx
@@ -157,10 +157,6 @@ export default function ProgramOverviewDashboard() {
         archiveClassesRef.current?.close();
     }
 
-    const isAddClassDisabled = !program.facilities.some(
-        (facility) => facility.id === userFacilityId
-    );
-
     function commaSeparatedList<T extends string>(
         enumArray: T[] | null | undefined
     ): string {
@@ -169,6 +165,14 @@ export default function ProgramOverviewDashboard() {
             .map((ele) => String(ele).replace(/_/g, ' '))
             .join(', ');
     }
+
+    const isAddClassDisabled =
+        !program.facilities.some(
+            (facility) => facility.id === userFacilityId
+        ) ||
+        !program.is_active ||
+        program.archived_at != '';
+
     return (
         <div className="p-4 px-5">
             <div className="flex flex-col gap-4">

--- a/frontend/src/Pages/ProgramOverviewDashboard.tsx
+++ b/frontend/src/Pages/ProgramOverviewDashboard.tsx
@@ -166,12 +166,10 @@ export default function ProgramOverviewDashboard() {
             .join(', ');
     }
 
-    const isAddClassDisabled =
-        !program.facilities.some(
-            (facility) => facility.id === userFacilityId
-        ) ||
-        !program.is_active ||
-        program.archived_at != null;
+    const canAddClass =
+        program.facilities.some((f) => f.id === userFacilityId) &&
+        program.is_active &&
+        program.archived_at == null;
 
     return (
         <div className="p-4 px-5">
@@ -282,7 +280,7 @@ export default function ProgramOverviewDashboard() {
                         </button>
                     ) : (
                         <AddButton
-                            disabled={isAddClassDisabled}
+                            disabled={canAddClass}
                             label="Add Class"
                             onClick={() =>
                                 navigate(`/programs/${id}/classes/new`)

--- a/frontend/src/Pages/ProgramOverviewDashboard.tsx
+++ b/frontend/src/Pages/ProgramOverviewDashboard.tsx
@@ -171,7 +171,7 @@ export default function ProgramOverviewDashboard() {
             (facility) => facility.id === userFacilityId
         ) ||
         !program.is_active ||
-        program.archived_at != '';
+        program.archived_at != null;
 
     return (
         <div className="p-4 px-5">

--- a/frontend/src/common.ts
+++ b/frontend/src/common.ts
@@ -1114,3 +1114,15 @@ export type ActivityHistoryAction =
     | 'progclass_history';
 
 export type ErrorType = 'unauthorized' | 'not-found' | 'server-error';
+
+export enum ProgramEffectiveStatus {
+    Available = 'Available',
+    Inactive = 'Inactive',
+    Archived = 'Archived'
+}
+
+export type ProgramAction =
+    | 'set_available'
+    | 'set_inactive'
+    | 'archive'
+    | 'reactivate';

--- a/frontend/src/common.ts
+++ b/frontend/src/common.ts
@@ -707,6 +707,7 @@ export interface Program {
     tags: ProgramTag[];
     is_favorited: boolean;
     facilities: Facility[];
+    archived_at: string;
 }
 
 export interface ProgramOverview extends Program {

--- a/frontend/src/common.ts
+++ b/frontend/src/common.ts
@@ -764,6 +764,7 @@ export interface Class {
     enrollments?: ClassEnrollment[];
     events: ProgramClassEvent[];
     created_at: Date;
+    program: Program;
 }
 export interface ResidentProgramOverview {
     program_name: string;


### PR DESCRIPTION
## Description of the change

Updates the Program Management page/table so that users can update the status of a Program 

- **Related issues**: Closes https://app.asana.com/1/1201607307149189/project/1209460078641109/task/1209699133678261?focus=true 


## Screenshot(s)
![image](https://github.com/user-attachments/assets/29610df4-56a8-43b4-96e8-69fb6b69aaaa)


## Additional context

There was a bug in my implementation of the Program Status pill that lead me to the same bug in Class Status pill where if you click on a status, and then exit out of the modal, you are unable to get the modal to open up again because the state variable is already assigned to that status, so that bug is fixed in class status as well. 