### PR TITLE
feat: add table prefix argument to OrderClause method on QueryContext

### DIFF
--- a/backend/src/database/DB.go
+++ b/backend/src/database/DB.go
@@ -128,6 +128,7 @@ func MigrateTesting(db *gorm.DB) {
 		&models.UserCourseActivityTotals{},
 		&models.ProgramClassesHistory{},
 		&models.UserAccountHistory{},
+		&models.FacilitiesPrograms{},
 	}
 	for _, table := range TableList {
 		logrus.Printf("Migrating %T table...", table)

--- a/backend/src/database/class_enrollments.go
+++ b/backend/src/database/class_enrollments.go
@@ -232,7 +232,7 @@ func (db *DB) GetProgramClassEnrollmentsForProgram(args *models.QueryContext, cl
 		return nil, newNotFoundDBError(err, "program class enrollments")
 	}
 	if err := tx.Limit(args.PerPage).
-		Offset(args.CalcOffset()).Order(args.OrderClause()).
+		Offset(args.CalcOffset()).Order(args.OrderClause("pse")).
 		Find(&content).Error; err != nil {
 		return nil, newNotFoundDBError(err, "program class enrollments")
 	}

--- a/backend/src/database/events_attendance.go
+++ b/backend/src/database/events_attendance.go
@@ -108,7 +108,7 @@ func (db *DB) GetEnrollmentsWithAttendanceForEvent(qryCtx *models.QueryContext, 
 	finalQuery := selectClause + baseQuery
 
 	if slices.Contains([]string{"name_first", "name_last"}, qryCtx.OrderBy) {
-		finalQuery += " ORDER BY " + qryCtx.OrderClause()
+		finalQuery += " ORDER BY " + qryCtx.OrderClause("e")
 	} else {
 		finalQuery += " ORDER BY e.id ASC"
 	}

--- a/backend/src/database/helpful_links.go
+++ b/backend/src/database/helpful_links.go
@@ -35,7 +35,7 @@ func (db *DB) GetHelpfulLinks(args *models.QueryContext, onlyVisible bool) ([]He
 		tx = tx.Joins("LEFT JOIN open_content_favorites f ON f.content_id = helpful_links.id AND f.open_content_provider_id = helpful_links.open_content_provider_id").
 			Group("helpful_links.id").Order("COUNT(f.id) DESC")
 	default:
-		tx = tx.Order(args.OrderClause())
+		tx = tx.Order(args.OrderClause("f"))
 	}
 
 	if err := tx.Count(&args.Total).Error; err != nil {

--- a/backend/src/database/libraries.go
+++ b/backend/src/database/libraries.go
@@ -106,7 +106,7 @@ func (db *DB) GetAllLibraries(args *models.QueryContext, visibility string) ([]L
 		}
 		tx = tx.Group("libraries.id, fvs.visibility_status").Order("favorite_count DESC")
 	default:
-		tx = tx.Order(args.OrderClause())
+		tx = tx.Order(args.OrderClause("libraries"))
 	}
 	if !args.All {
 		tx = tx.Limit(args.PerPage).Offset(args.CalcOffset())

--- a/backend/src/database/open_content.go
+++ b/backend/src/database/open_content.go
@@ -288,7 +288,7 @@ func (db *DB) GetUserFavorites(args *models.QueryContext) ([]models.OpenContentI
         WHERE f.user_id = ? %s
     ) AS all_favorites
     ORDER BY %s
-	LIMIT ? OFFSET ?`, libSearchCond, videoSearchCond, hlSearchCond, args.OrderClause())
+	LIMIT ? OFFSET ?`, libSearchCond, videoSearchCond, hlSearchCond, args.OrderClause("f"))
 
 	var favorites []models.OpenContentItem
 	if err := db.WithContext(args.Ctx).Raw(favoritesQuery, queryArgs...).Scan(&favorites).Error; err != nil {

--- a/backend/src/database/outcomes.go
+++ b/backend/src/database/outcomes.go
@@ -21,5 +21,5 @@ func (db *DB) GetOutcomesForUser(args *models.QueryContext, outcomeType models.O
 	if err := query.Count(&args.Total).Error; err != nil {
 		return nil, newGetRecordsDBError(err, "outcomes")
 	}
-	return outcomes, query.Order(args.OrderClause()).Offset(args.CalcOffset()).Limit(args.PerPage).Find(&outcomes).Error
+	return outcomes, query.Order(args.OrderClause("outcomes")).Offset(args.CalcOffset()).Limit(args.PerPage).Find(&outcomes).Error
 }

--- a/backend/src/database/program_classes.go
+++ b/backend/src/database/program_classes.go
@@ -81,7 +81,7 @@ func (db *DB) GetProgramClassDetailsByID(id int, args *models.QueryContext) ([]m
 	if err := query.Count(&args.Total).Error; err != nil {
 		return nil, newGetRecordsDBError(err, "programs")
 	}
-	if err := query.Limit(args.PerPage).Offset(args.CalcOffset()).Order(args.OrderClause()).Find(&classDetails).Error; err != nil {
+	if err := query.Limit(args.PerPage).Offset(args.CalcOffset()).Order(args.OrderClause("ps")).Find(&classDetails).Error; err != nil {
 		return nil, newGetRecordsDBError(err, "programs")
 	}
 	return classDetails, nil
@@ -89,7 +89,7 @@ func (db *DB) GetProgramClassDetailsByID(id int, args *models.QueryContext) ([]m
 
 func (db *DB) GetClassHistory(id int, args *models.QueryContext) ([]models.ProgramClassesHistory, error) {
 	history := []models.ProgramClassesHistory{}
-	if err := db.WithContext(args.Ctx).Order(args.OrderClause()).Find(&history, "parent_ref_id = ? and table_name = ?", id, "program_classes").Error; err != nil {
+	if err := db.WithContext(args.Ctx).Order(args.OrderClause("")).Find(&history, "parent_ref_id = ? and table_name = ?", id, "program_classes").Error; err != nil {
 		return nil, newGetRecordsDBError(err, "program_classes_history")
 	}
 	return history, nil

--- a/backend/src/database/programs.go
+++ b/backend/src/database/programs.go
@@ -58,10 +58,7 @@ func (db *DB) GetPrograms(args *models.QueryContext) ([]models.Program, error) {
 	if len(args.Tags) > 0 {
 		tx = tx.Joins("JOIN program_types t ON t.program_id = programs.id").Where("t.id IN (?)", args.Tags)
 	}
-
-	if args.OrderBy != "" {
-		tx = tx.Order(args.OrderClause())
-	}
+	tx = tx.Order(args.OrderClause("programs"))
 
 	if args.Search != "" {
 		tx = tx.Where("LOWER(name) LIKE ? OR LOWER(description) LIKE ? ", args.SearchQuery(), args.SearchQuery())
@@ -233,9 +230,7 @@ func (db *DB) GetProgramsOverviewTable(args *models.QueryContext, timeFilter int
 	if len(args.Tags) > 0 {
 		tx = tx.Where("pt.program_id IN (?)", args.Tags)
 	}
-	if args.OrderBy != "" {
-		tx = tx.Order(args.OrderClause())
-	}
+	tx = tx.Order(args.OrderClause("programs"))
 	if args.Search != "" {
 		tx = tx.Where("LOWER(name) LIKE ? OR LOWER(description) LIKE ? ", args.SearchQuery(), args.SearchQuery())
 	}

--- a/backend/src/database/users.go
+++ b/backend/src/database/users.go
@@ -35,7 +35,7 @@ func (db *DB) GetCurrentUsers(args *models.QueryContext, role string) ([]models.
 		return nil, newGetRecordsDBError(err, "users")
 	}
 	users := make([]models.User, 0, args.PerPage)
-	if err := tx.Order(args.OrderClause()).
+	if err := tx.Order(args.OrderClause("")).
 		Offset(args.CalcOffset()).
 		Limit(args.PerPage).
 		Find(&users).
@@ -124,7 +124,7 @@ func (db *DB) GetEligibleResidentsForClass(args *models.QueryContext, classId in
 		return nil, newGetRecordsDBError(err, "users")
 	}
 	users := make([]models.User, 0, args.PerPage)
-	if err := tx.Order(args.OrderClause()).
+	if err := tx.Order(args.OrderClause("users")).
 		Offset(args.CalcOffset()).
 		Limit(args.PerPage).
 		Find(&users).

--- a/backend/src/database/videos.go
+++ b/backend/src/database/videos.go
@@ -98,7 +98,7 @@ func (db *DB) GetAllVideos(args *models.QueryContext, onlyVisible bool) ([]Video
 		tx = tx.Joins("LEFT JOIN open_content_favorites f ON f.content_id = videos.id AND f.open_content_provider_id = videos.open_content_provider_id").
 			Group("videos.id, fvs.visibility_status").Order("COUNT(f.id) DESC")
 	default:
-		tx = tx.Order(args.OrderClause())
+		tx = tx.Order(args.OrderClause("f"))
 	}
 	if err := tx.Count(&args.Total).Error; err != nil {
 		return nil, newGetRecordsDBError(err, "videos")

--- a/backend/src/handlers/utils.go
+++ b/backend/src/handlers/utils.go
@@ -82,12 +82,6 @@ func (srv *Server) getQueryContext(r *http.Request) models.QueryContext {
 			order = orderBySplit[1]
 		}
 	}
-	if orderBy == "" {
-		orderBy = "created_at"
-	}
-	if order != "asc" && order != "desc" {
-		order = "desc"
-	}
 	search := strings.TrimSpace(strings.ToLower(r.URL.Query().Get("search")))
 	tags := r.URL.Query()["tags"]
 	all := r.URL.Query().Get("all") == "true"

--- a/backend/src/models/resource.go
+++ b/backend/src/models/resource.go
@@ -94,10 +94,25 @@ func (q QueryContext) CalcOffset() int {
 	return (q.Page - 1) * q.PerPage
 }
 
-func (q QueryContext) OrderClause() string {
+// fallbackPrefix is the table name or alias used in the relevant query,
+// which will be used with 'created_at' if there is no 'order_by' + 'order'
+// present in the query string. Can be an empty string if there is only 1 table
+// referenced in the query. Since created_at is usually present on every table,
+// we have to prevent an ambiguous column error when using a join.
+//
+// Example: "select users.*, f.id from users join favorites f on f.user_id = users.id....."
+// we would use:
+//
+//	tx.Order(args.OrderClause("f")).Find(&whatever)
+//
+// because we want it to fall-back to favorites.created_at
+func (q QueryContext) OrderClause(fallbackPrefix string) string {
 	val := fmt.Sprintf("%s %s", q.OrderBy, q.Order)
 	if val == " " {
-		return "created_at desc"
+		if fallbackPrefix != "" {
+			fallbackPrefix += "."
+		}
+		return fallbackPrefix + "created_at desc"
 	}
 	return val
 }


### PR DESCRIPTION
This PR fixes cases where the client does not add `order_by` & `order` to the query string. Previously, we would fall back to `created_at desc`, which is at least on 99% of our tables. However this is problematic for queries with multiple joins, that fallback becomes an ambiguous argument to the query and can fail.

This adds the `fallbackPrefix` argument to `queryContext.OrderClause()`, so the caller can specify _which_ table they would like it to reference.

e.g.
```sql
select users.*, e.* from users join enrollments e on u.id = e.user_id
```
or:
```go
tx := db.Model(&models.User{}).Select("users.*, e.*).Joins("enrollments e on e.user_id = users.id")
```

Now the caller can provide:
```go
tx = tx.Order(args.OrderClause("e")).Find(&result)
```

and it will default to using the enrollments `created_at` field if the query context doesn't contain an OrderBy.
 