### PR TITLE
fix: update url tampering on front and backend

### DIFF
--- a/backend/src/handlers/class_events.go
+++ b/backend/src/handlers/class_events.go
@@ -94,6 +94,15 @@ func (srv *Server) handleGetProgramClassEvents(w http.ResponseWriter, r *http.Re
 	log.add("class id", classID)
 	month := r.URL.Query().Get("month")
 	year := r.URL.Query().Get("year")
+	justDates := r.URL.Query().Get("dates")
+	if justDates == "true" {
+		timezone := srv.getQueryContext(r).Timezone
+		dates, err := srv.Db.GetClassEventDatesForRecurrence(classID, timezone, month, year)
+		if err != nil {
+			return newDatabaseServiceError(err)
+		}
+		return writeJsonResponse(w, http.StatusOK, dates)
+	}
 
 	qryCtx := srv.getQueryContext(r)
 	instances, err := srv.Db.GetClassEventInstancesWithAttendanceForRecurrence(classID, &qryCtx, month, year)

--- a/backend/src/handlers/events_attendance_handler.go
+++ b/backend/src/handlers/events_attendance_handler.go
@@ -44,9 +44,7 @@ func (srv *Server) handleAddAttendanceForEvent(w http.ResponseWriter, r *http.Re
 		if parsed.After(today) {
 			return writeJsonResponse(w, http.StatusUnprocessableEntity, "attempted attendance date in future")
 		}
-		if attendances[i].EventID == 0 {
-			attendances[i].EventID = uint(eventID)
-		}
+		attendances[i].EventID = uint(eventID)
 	}
 	if err := srv.Db.LogUserAttendance(&attendances); err != nil {
 		return newDatabaseServiceError(err)

--- a/backend/src/models/class_event.go
+++ b/backend/src/models/class_event.go
@@ -159,3 +159,8 @@ type AttendanceFlag struct {
 	DocID     string             `json:"doc_id"`
 	FlagType  AttendanceFlagType `json:"flag_type"`
 }
+
+type EventDates struct {
+	EventID uint   `json:"event_id"`
+	Date    string `json:"date"`
+}

--- a/backend/src/models/class_event.go
+++ b/backend/src/models/class_event.go
@@ -67,6 +67,17 @@ func (e *ProgramClassEvent) GetRRule() (*rrule.RRule, error) {
 		return nil, fmt.Errorf("failed to parse event recurrence rule: %w", err)
 	}
 	rruleOptions.Dtstart = rruleOptions.Dtstart.In(time.UTC)
+	if !rruleOptions.Until.IsZero() {
+		loc := rruleOptions.Until.Location()
+
+		endOfDay := time.Date(
+			rruleOptions.Until.Year(),
+			rruleOptions.Until.Month(),
+			rruleOptions.Until.Day(),
+			23, 59, 59, int(time.Second-time.Nanosecond), loc)
+
+		rruleOptions.Until = endOfDay.In(time.UTC)
+	}
 	rule, err := rrule.NewRRule(*rruleOptions)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create event recurrence rule: %w", err)

--- a/frontend/src/Components/helperFunctions/formatting.tsx
+++ b/frontend/src/Components/helperFunctions/formatting.tsx
@@ -11,3 +11,8 @@ export function transformStringToArray(input: string): string | string[] {
     }
     return transformed.split(',').map((s) => s.trim());
 }
+
+export function parseLocalDay(isoDate: string): Date {
+    const [year, month, day] = isoDate.split('-').map(Number);
+    return new Date(year, month - 1, day);
+}

--- a/frontend/src/Pages/ClassEvents.tsx
+++ b/frontend/src/Pages/ClassEvents.tsx
@@ -78,7 +78,6 @@ export default function ClassEvents() {
 
     function getStatus(event: ClassEventInstance): string {
         const eventDate = toLocalMidnight(event.date).getTime();
-        //const eventDate = new Date(event.date).setHours(0, 0, 0, 0);
         const today = new Date().setHours(0, 0, 0, 0);
         return eventDate > today
             ? 'Scheduled'

--- a/frontend/src/Pages/ClassEvents.tsx
+++ b/frontend/src/Pages/ClassEvents.tsx
@@ -15,7 +15,7 @@ import { DateInput } from '@/Components/inputs/DateInput';
 
 function toLocalMidnight(dateOnly: string): Date {
     const [y, m, d] = dateOnly.split('-').map(Number);
-    return new Date(y, m - 1, d); // safe in every browser
+    return new Date(y, m - 1, d);
 }
 
 export default function ClassEvents() {

--- a/frontend/src/Pages/ClassEvents.tsx
+++ b/frontend/src/Pages/ClassEvents.tsx
@@ -13,6 +13,11 @@ import Pagination from '@/Components/Pagination';
 import { useForm } from 'react-hook-form';
 import { DateInput } from '@/Components/inputs/DateInput';
 
+function toLocalMidnight(dateOnly: string): Date {
+    const [y, m, d] = dateOnly.split('-').map(Number);
+    return new Date(y, m - 1, d); // safe in every browser
+}
+
 export default function ClassEvents() {
     const { class_id } = useParams<{ class_id: string }>();
     const navigate = useNavigate();
@@ -72,7 +77,8 @@ export default function ClassEvents() {
     }
 
     function getStatus(event: ClassEventInstance): string {
-        const eventDate = new Date(event.date).setHours(0, 0, 0, 0);
+        const eventDate = toLocalMidnight(event.date).getTime();
+        //const eventDate = new Date(event.date).setHours(0, 0, 0, 0);
         const today = new Date().setHours(0, 0, 0, 0);
         return eventDate > today
             ? 'Scheduled'
@@ -117,9 +123,12 @@ export default function ClassEvents() {
                                     className="card grid-cols-5 justify-items-center"
                                 >
                                     <td className="justify-self-start px-4">
-                                        {new Date(
+                                        {toLocalMidnight(
                                             event.date
-                                        ).toLocaleDateString()}
+                                        ).toLocaleDateString('en-US', {
+                                            month: '2-digit',
+                                            day: '2-digit'
+                                        })}
                                     </td>
                                     <td className="px-4">
                                         {formatClassTime(

--- a/frontend/src/Pages/Error.tsx
+++ b/frontend/src/Pages/Error.tsx
@@ -30,6 +30,7 @@ const errorMap: Record<
         onClick: () => (window.location.href = AUTHCALLBACK)
     }
 };
+
 export default function Error({
     type = 'server-error',
     back = false,

--- a/frontend/src/Pages/EventAttendance.tsx
+++ b/frontend/src/Pages/EventAttendance.tsx
@@ -16,7 +16,7 @@ import Pagination from '@/Components/Pagination';
 import DropdownControl from '@/Components/inputs/DropdownControl';
 import Error from '@/Pages/Error';
 
-export function isFutureYyyyMmDd(dateStr: string): boolean | string {
+export function isFutureIsoDate(dateStr: string): boolean | string {
     const m = /^(\d{4})-(\d{2})-(\d{2})$/.exec(dateStr);
     if (!m) {
         return 'Date must be in YYYY‑MM‑DD format';
@@ -62,7 +62,7 @@ export default function EventAttendance() {
         class_id: string;
     }>();
     if (typeof date === 'string') {
-        const future = isFutureYyyyMmDd(date);
+        const future = isFutureIsoDate(date);
         if (typeof future === 'string') {
             return <Error back message={future} type="unauthorized" />;
         } else if (future) {

--- a/frontend/src/Pages/EventAttendance.tsx
+++ b/frontend/src/Pages/EventAttendance.tsx
@@ -70,7 +70,7 @@ export default function EventAttendance() {
                 <Error
                     back
                     type="unauthorized"
-                    message={`Attendance is unable to be recorded for ${date}`}
+                    message={`Attendance is unable to be recorded for dates in the future`}
                 />
             );
         }

--- a/frontend/src/Pages/EventAttendance.tsx
+++ b/frontend/src/Pages/EventAttendance.tsx
@@ -16,12 +16,9 @@ import API from '@/api/api';
 import Pagination from '@/Components/Pagination';
 import DropdownControl from '@/Components/inputs/DropdownControl';
 import Error from '@/Pages/Error';
+import { parseLocalDay } from '@/Components/helperFunctions/formatting';
 
 const isoRE = /^\d{4}-\d{2}-\d{2}$/;
-function parseLocalDay(isoDate: string): Date {
-    const [year, month, day] = isoDate.split('-').map(Number);
-    return new Date(year, month - 1, day);
-}
 
 interface LocalRowData {
     selected: boolean;

--- a/frontend/src/Pages/EventAttendance.tsx
+++ b/frontend/src/Pages/EventAttendance.tsx
@@ -14,6 +14,34 @@ import SearchBar from '@/Components/inputs/SearchBar';
 import API from '@/api/api';
 import Pagination from '@/Components/Pagination';
 import DropdownControl from '@/Components/inputs/DropdownControl';
+import Error from '@/Pages/Error';
+
+export function isFutureYyyyMmDd(dateStr: string): boolean | string {
+    const m = /^(\d{4})-(\d{2})-(\d{2})$/.exec(dateStr);
+    if (!m) {
+        return 'Date must be in YYYY‑MM‑DD format';
+    }
+    const [, yStr, moStr, dStr] = m;
+    const y = Number(yStr);
+    const mo = Number(moStr);
+    const d = Number(dStr);
+
+    const dt = new Date(y, mo - 1, d);
+    if (
+        dt.getFullYear() !== y ||
+        dt.getMonth() !== mo - 1 ||
+        dt.getDate() !== d
+    ) {
+        return 'Invalid calendar date';
+    }
+
+    dt.setHours(0, 0, 0, 0);
+
+    const today = new Date();
+    today.setHours(0, 0, 0, 0);
+
+    return dt > today;
+}
 
 interface LocalRowData {
     selected: boolean;
@@ -33,6 +61,20 @@ export default function EventAttendance() {
         date: string;
         class_id: string;
     }>();
+    if (typeof date === 'string') {
+        const future = isFutureYyyyMmDd(date);
+        if (typeof future === 'string') {
+            return <Error back message={future} type="unauthorized" />;
+        } else if (future) {
+            return (
+                <Error
+                    back
+                    type="unauthorized"
+                    message={`Attendance is unable to be recorded for ${date}`}
+                />
+            );
+        }
+    }
     const navigate = useNavigate();
     const {
         page: pageQuery,

--- a/frontend/src/common.ts
+++ b/frontend/src/common.ts
@@ -1128,3 +1128,8 @@ export type ProgramAction =
     | 'set_inactive'
     | 'archive'
     | 'reactivate';
+
+export interface EventDate {
+    event_id: number;
+    date: string;
+}


### PR DESCRIPTION
## Description of the change
1. Makes sure that you can't update the date in the URL and get away with it. 
2. Make sure the date in the ClassEvents table matches the date in the url when you click on an event
3. Fix the backend GetRRule from truncating the final day. 

- **Related issues**: Asana id 186

## Screenshot(s)
![image](https://github.com/user-attachments/assets/4c2713c8-4b70-471e-854c-3b1ac4f0109f)



## Additional context
The ticket only required that we make sure that users are unable to update attendance for future dates, but I noticed a couple more bugs while working on it. The date's weren't matching up because of a timezone issue with the date that the user clicks on in the attendance table it was a day ahead. Also, the backend was truncating the last day of class because it was stopping at 00:00, so I fixed how the rrule is gotten so that the 24 hours of the final day is included. 

Asana: 
https://app.asana.com/1/1201607307149189/project/1209460078641109/task/1210129036130407?focus=true