### PR TITLE
fix: eliminate possibility for facility admin not of same facility to…

### DIFF
--- a/backend/src/database/facilities.go
+++ b/backend/src/database/facilities.go
@@ -56,3 +56,9 @@ func (db *DB) DeleteFacility(id int) error {
 	}
 	return nil
 }
+
+func (db *DB) GetResourceFacilityID(tableName any, resourceID any) (uint, error) {
+	var facilityID uint
+	err := db.Model(&tableName).Select("facility_id").Where("id = ?", resourceID).Scan(&facilityID).Error
+	return facilityID, err
+}

--- a/backend/src/handlers/auth.go
+++ b/backend/src/handlers/auth.go
@@ -158,6 +158,20 @@ func (srv *Server) adminMiddleware(next http.Handler) http.Handler {
 		next.ServeHTTP(w, r)
 	})
 }
+func (srv *Server) UserCanEditResource(r *http.Request, resourceType any, resourceID any) (bool, error) {
+	claims := r.Context().Value(ClaimsKey).(*Claims)
+	if claims.canSwitchFacility() {
+		return true, nil
+	}
+	resourceFacilityID, err := srv.Db.GetResourceFacilityID(resourceType, resourceID)
+	if err != nil {
+		return false, err
+	}
+	if resourceFacilityID != claims.FacilityID {
+		return false, nil
+	}
+	return true, nil
+}
 
 // Auth endpoint that is called from the client before each <AuthenticatedLayout /> is rendered
 func (srv *Server) handleCheckAuth(w http.ResponseWriter, r *http.Request, log sLog) error {

--- a/backend/src/handlers/classes_handler.go
+++ b/backend/src/handlers/classes_handler.go
@@ -97,6 +97,13 @@ func (srv *Server) handleUpdateClass(w http.ResponseWriter, r *http.Request, log
 	if err := json.NewDecoder(r.Body).Decode(&class); err != nil {
 		return newJSONReqBodyServiceError(err)
 	}
+	canUpdate, err := srv.UserCanEditResource(r, models.ProgramClass{}, id)
+	if err != nil {
+		return newInternalServerServiceError(err, "facility check to edit resource")
+	}
+	if !canUpdate {
+		return newUnauthorizedServiceError()
+	}
 	enrolled, err := srv.Db.GetTotalEnrollmentsByClassID(id)
 	if err != nil {
 		return newDatabaseServiceError(err)
@@ -119,6 +126,13 @@ func (srv *Server) handleUpdateClasses(w http.ResponseWriter, r *http.Request, l
 	for _, id := range ids {
 		if classID, err := strconv.Atoi(id); err == nil {
 			classIDs = append(classIDs, classID)
+		}
+		canUpdate, err := srv.UserCanEditResource(r, models.ProgramClass{}, classIDs)
+		if err != nil {
+			return newInternalServerServiceError(err, "facility check to edit resource")
+		}
+		if !canUpdate {
+			return newUnauthorizedServiceError()
 		}
 	}
 	defer r.Body.Close()


### PR DESCRIPTION
## Description of the change
This pull request provides a solution to the issue of a facility admin being able to update a class for a facility they have no admin privileges in. 

- **Related issues**: Asana ticket 184 
- Asana: https://app.asana.com/1/1201607307149189/project/1209460078641109/task/1210129030386867?focus=true


## Additional context
This is a smaller solution to the ticket, this is the same essential logic that the other pull request utilizes, but is only implemented here. 