### PR TITLE
Toast Bug on Delete Facility

### DIFF
--- a/frontend/src/api/api.ts
+++ b/frontend/src/api/api.ts
@@ -23,7 +23,15 @@ class API {
                 signal: controller.signal
             });
             clearTimeout(timeout);
-
+            //            Use this here to handle a 204 status code as a success in the case of a delete with no content response
+            // if (resp.status === 204) {
+            //     return {
+            //         type: 'one',
+            //         success: true,
+            //         message: 'Request successful',
+            //         data: {} as T
+            //     };
+            // }
             const json = (await resp.json()) as ServerResponse<T>;
 
             if (!resp.ok) {


### PR DESCRIPTION
## Description of the change

Proposed change adds a 204 check to api.ts to handle cases where delete handlers return status of "StatusNoContent" 

**Problem**
handlers return status of "StatusNoContent" and...
an empty body that either becomes null or throws a parse error—so we jump straight into our catch and end up doing success: false even though the HTTP status was 204. That’s why:
```

checkResponseForDelete(
  response.success, // false
  'Error deleting facility',
  'Facility successfully deleted'
);

```
always fires the error toast on a genuine delete.

> A simple fix would be to just change the status in the handler to "Ok" 

but after i decided to look through the other handlers to see statuses returned and how they were handled in their frontend counterparts....

Of our 10 +/- handlers (Delete only):
- ~7 return StatusNoContent
- ~ 3 return StatusOk

Uncertain at this time as `to` why some Delete handlers return SNC and others SOK I assumed adding logic  to  api.ts to handle 204 would be the best way to fix this bug.
