### PR TITLE
fix: add helper func to format timezone string

### DIFF
--- a/frontend/src/Components/FacilityCard.tsx
+++ b/frontend/src/Components/FacilityCard.tsx
@@ -6,6 +6,7 @@ import {
     LockClosedIcon
 } from '@heroicons/react/24/outline';
 import { isSysAdmin, useAuth } from '@/useAuth';
+import { toTimezoneString } from './helperFunctions/formatting';
 
 export default function FacilityCard({
     facility,
@@ -20,7 +21,7 @@ export default function FacilityCard({
     return (
         <tr className="bg-base-teal card p-4 w-full grid-cols-3 justify-items-center">
             <td className="justify-self-start">{facility.name}</td>
-            <td className="">{facility.timezone}</td>
+            <td className="">{toTimezoneString(facility.timezone)}</td>
             <td className="flex flex-row gap-3 justify-self-end cursor-pointer">
                 {user && !isSysAdmin(user) ? (
                     <ULIComponent

--- a/frontend/src/Components/helperFunctions/formatting.tsx
+++ b/frontend/src/Components/helperFunctions/formatting.tsx
@@ -1,3 +1,5 @@
+import { Timezones } from '@/common';
+
 export function formatPercent(value?: number | string): string {
     if (typeof value === 'string') return value;
     if (typeof value === 'number') return `${Math.round(value * 100) / 100}`;
@@ -15,4 +17,12 @@ export function transformStringToArray(input: string): string | string[] {
 export function parseLocalDay(isoDate: string): Date {
     const [year, month, day] = isoDate.split('-').map(Number);
     return new Date(year, month - 1, day);
+}
+
+export function toTimezoneString(timezoneValue: string) {
+    return (
+        Object.keys(Timezones).find(
+            (key) => Timezones[key as keyof typeof Timezones] === timezoneValue // eslint-disable-line
+        ) ?? timezoneValue
+    );
 }

--- a/frontend/src/Components/helperFunctions/formatting.tsx
+++ b/frontend/src/Components/helperFunctions/formatting.tsx
@@ -19,7 +19,7 @@ export function parseLocalDay(isoDate: string): Date {
     return new Date(year, month - 1, day);
 }
 
-export function toTimezoneString(timezoneValue: string) {
+export function toTimezoneString(timezoneValue: string): string {
     return (
         Object.keys(Timezones).find(
             (key) => Timezones[key as keyof typeof Timezones] === timezoneValue // eslint-disable-line


### PR DESCRIPTION
## Description of the change

Adds a helper function so facility timezone can display correctly (in case we need to use this in another page in the future). 

[Asana task 210](https://app.asana.com/1/1201607307149189/project/1209460078641109/task/1210255593728311?focus=true)