### PR TITLE
Only allow initial status of scheduled or active for new classes

### DIFF
--- a/frontend/src/Pages/ClassManagementForm.tsx
+++ b/frontend/src/Pages/ClassManagementForm.tsx
@@ -122,6 +122,7 @@ export default function ClassManagementForm() {
             navigate(`/program-classes/${class_id}/dashboard`);
         }
     };
+
     useEffect(() => {
         setCanOpenCalendar(!!nameValue && rruleIsValid);
     }, [nameValue, rruleIsValid]);
@@ -146,6 +147,22 @@ export default function ClassManagementForm() {
     }
 
     const isNewClass = class_id === 'new' || !class_id;
+    const filteredEnumType: Record<string, string> = Object.entries(
+        ProgClassStatus
+    )
+        .filter(([, value]) => {
+            if (isNewClass) {
+                return ['Active', 'Scheduled'].includes(value);
+            }
+            return true;
+        })
+        .reduce(
+            (acc, [key, value]) => {
+                acc[key] = value;
+                return acc;
+            },
+            {} as Record<string, string>
+        );
 
     return (
         <div className="p-4 px-5">
@@ -248,7 +265,7 @@ export default function ClassManagementForm() {
                         <DropdownInput
                             label="Status"
                             register={register}
-                            enumType={ProgClassStatus}
+                            enumType={filteredEnumType}
                             interfaceRef="status"
                             required
                             errors={errors}


### PR DESCRIPTION
## Description of the change
Added logic to filter ProgClassStatus based on the isNewClass flag.
The filtered result is passed to the DropdownInput so that only "Scheduled" and "Active" show up during new class creation.


https://github.com/user-attachments/assets/6fa93e60-fbbe-479a-9642-2d3c7ddb284f

#Related to Assna task: https://app.asana.com/1/1201607307149189/project/1209460078641109/task/1210277025715965](url)