### PR TITLE
fix: lock users out after 5 failed login attempts within 15 mins

### DIFF
--- a/backend/migrations/00050_add_failed_login_attempts_table.sql
+++ b/backend/migrations/00050_add_failed_login_attempts_table.sql
@@ -1,0 +1,17 @@
+-- +goose Up
+-- +goose StatementBegin
+CREATE TABLE public.failed_login_attempts (
+    user_id INTEGER NOT NULL PRIMARY KEY, 
+    first_attempt_at timestamptz NOT NULL DEFAULT NOW(),
+    last_attempt_at timestamptz NOT NULL DEFAULT NOW(),
+    attempt_count integer NOT NULL DEFAULT 0, 
+    locked_until timestamptz NULL,
+    FOREIGN KEY (user_id) REFERENCES public.users(id) ON DELETE CASCADE ON UPDATE CASCADE
+);
+CREATE INDEX user_failed_login_attempts_user_id_idx ON public.failed_login_attempts(user_id);
+-- +goose StatementEnd
+
+-- +goose Down
+-- +goose StatementBegin
+DROP TABLE public.failed_login_attempts CASCADE;
+-- +goose StatementEnd

--- a/backend/migrations/00050_add_failed_login_attempts_table.sql
+++ b/backend/migrations/00050_add_failed_login_attempts_table.sql
@@ -1,6 +1,6 @@
 -- +goose Up
 -- +goose StatementBegin
-CREATE TABLE public.failed_login_attempts (
+CREATE TABLE IF NOT EXISTS public.failed_login_attempts (
     user_id INTEGER NOT NULL PRIMARY KEY, 
     first_attempt_at timestamptz NOT NULL DEFAULT NOW(),
     last_attempt_at timestamptz NOT NULL DEFAULT NOW(),
@@ -8,10 +8,10 @@ CREATE TABLE public.failed_login_attempts (
     locked_until timestamptz NULL,
     FOREIGN KEY (user_id) REFERENCES public.users(id) ON DELETE CASCADE ON UPDATE CASCADE
 );
-CREATE INDEX user_failed_login_attempts_user_id_idx ON public.failed_login_attempts(user_id);
+CREATE INDEX IF NOT EXISTS user_failed_login_attempts_user_id_idx ON public.failed_login_attempts(user_id);
 -- +goose StatementEnd
 
 -- +goose Down
 -- +goose StatementBegin
-DROP TABLE public.failed_login_attempts CASCADE;
+DROP TABLE IF EXISTS public.failed_login_attempts CASCADE;
 -- +goose StatementEnd

--- a/backend/src/handlers/login_flow.go
+++ b/backend/src/handlers/login_flow.go
@@ -100,7 +100,11 @@ func (s *Server) handleLogin(w http.ResponseWriter, r *http.Request, log sLog) e
 		return NewServiceError(err, resp.StatusCode, "Invalid login")
 	}
 	if attempts > 0 {
-		s.Db.ResetFailedLoginAttempts(user.ID)
+		err = s.Db.ResetFailedLoginAttempts(user.ID)
+		if err != nil {
+			log.error("error resetting failed login attempts", err)
+			return newDatabaseServiceError(err)
+		}
 	}
 	totalLogins, err := s.Db.IncrementUserLogin(user)
 	if err != nil {

--- a/backend/src/handlers/login_flow.go
+++ b/backend/src/handlers/login_flow.go
@@ -62,7 +62,7 @@ func (s *Server) handleLogin(w http.ResponseWriter, r *http.Request, log sLog) e
 	}
 	if isLockedOut {
 		log.infof("User %d locked out", user.ID)
-		w.Header().Set("Retry-After", strconv.Itoa(int(howLong.Minutes())))
+		w.Header().Set("Retry-After", strconv.Itoa(int(howLong.Seconds())))
 		msg := fmt.Sprintf("Account locked. Try again in %d minutes.", int(howLong.Minutes()))
 		s.errorResponse(w, int(http.StatusTooManyRequests), msg)
 		return nil

--- a/backend/src/handlers/user_handler.go
+++ b/backend/src/handlers/user_handler.go
@@ -260,11 +260,11 @@ func (srv *Server) handleResetStudentPassword(w http.ResponseWriter, r *http.Req
 	if err != nil {
 		return newDatabaseServiceError(err)
 	}
-	isLockedOut, _, _, err := srv.Db.IsAccountLocked(user.ID)
+	lockedStatus, err := srv.Db.IsAccountLocked(user.ID)
 	if err != nil {
 		return newDatabaseServiceError(err)
 	}
-	if isLockedOut {
+	if lockedStatus.IsLocked {
 		log.infof("Resetting failed login attempts for user %d due to password reset", user.ID)
 		err = srv.Db.ResetFailedLoginAttempts(user.ID)
 		if err != nil {

--- a/backend/src/handlers/user_handler.go
+++ b/backend/src/handlers/user_handler.go
@@ -252,7 +252,7 @@ func (srv *Server) handleResetStudentPassword(w http.ResponseWriter, r *http.Req
 	claims := r.Context().Value(ClaimsKey).(*Claims)
 	id, err := strconv.Atoi(r.PathValue("id"))
 	if err != nil {
-		return newInvalidIdServiceError(err, "user ID")
+		return newInternalServerServiceError(err, "id")
 	}
 	response := make(map[string]string)
 	user, err := srv.Db.GetUserByID(uint(id))

--- a/backend/src/handlers/user_handler.go
+++ b/backend/src/handlers/user_handler.go
@@ -260,6 +260,17 @@ func (srv *Server) handleResetStudentPassword(w http.ResponseWriter, r *http.Req
 	if err != nil {
 		return newDatabaseServiceError(err)
 	}
+	isLockedOut, _, _, err := srv.Db.IsAccountLocked(user.ID)
+	if err != nil {
+		return newDatabaseServiceError(err)
+	}
+	if isLockedOut {
+		log.infof("Resetting failed login attempts for user %d due to password reset", user.ID)
+		err = srv.Db.ResetFailedLoginAttempts(user.ID)
+		if err != nil {
+			return newDatabaseServiceError(err)
+		}
+	}
 	newPass := user.CreateTempPassword()
 	response["temp_password"] = newPass
 	response["message"] = "Temporary password assigned"

--- a/backend/src/handlers/utils.go
+++ b/backend/src/handlers/utils.go
@@ -214,19 +214,17 @@ func featureRoute(method string, handler HttpFunc, features ...models.FeatureAcc
 	}
 }
 
-// commented this out due to it not being used, could be used in the future?
-//
-//	func deptAdminFeatureRoute(method string, handler HttpFunc, features ...models.FeatureAccess) routeDef {
-//		return routeDef{
-//			routeMethod: method,
-//			handler:     handler,
-//			admin:       true,
-//			features:    features,
-//			resolver: func(tx *database.DB, r *http.Request) bool {
-//				return r.Context().Value(ClaimsKey).(*Claims).canSwitchFacility()
-//			},
-//		}
-//	}
+func deptAdminFeatureRoute(method string, handler HttpFunc, features ...models.FeatureAccess) routeDef {
+	return routeDef{
+		routeMethod: method,
+		handler:     handler,
+		admin:       true,
+		features:    features,
+		resolver: func(tx *database.DB, r *http.Request) bool {
+			return r.Context().Value(ClaimsKey).(*Claims).canSwitchFacility()
+		},
+	}
+}
 func adminFeatureRoute(method string, handler HttpFunc, features ...models.FeatureAccess) routeDef {
 	return routeDef{
 		routeMethod: method,

--- a/backend/src/handlers/utils.go
+++ b/backend/src/handlers/utils.go
@@ -214,17 +214,6 @@ func featureRoute(method string, handler HttpFunc, features ...models.FeatureAcc
 	}
 }
 
-func deptAdminFeatureRoute(method string, handler HttpFunc, features ...models.FeatureAccess) routeDef {
-	return routeDef{
-		routeMethod: method,
-		handler:     handler,
-		admin:       true,
-		features:    features,
-		resolver: func(tx *database.DB, r *http.Request) bool {
-			return r.Context().Value(ClaimsKey).(*Claims).canSwitchFacility()
-		},
-	}
-}
 func adminFeatureRoute(method string, handler HttpFunc, features ...models.FeatureAccess) routeDef {
 	return routeDef{
 		routeMethod: method,

--- a/backend/src/models/logins.go
+++ b/backend/src/models/logins.go
@@ -35,6 +35,24 @@ type UserSessionTracking struct {
 
 func (UserSessionTracking) TableName() string { return "user_session_tracking" }
 
+const (
+	MaxFailures    = 5
+	WindowDuration = 15 * time.Minute
+	LockDuration   = 15 * time.Minute
+)
+
+type FailedLoginAttempts struct {
+	UserID         uint       `json:"user_id" gorm:"primaryKey"`
+	FirstAttemptAt *time.Time `json:"first_attempt_at" gorm:""`
+	LastAttemptAt  time.Time  `json:"last_attempt_at" gorm:""`
+	AttemptCount   int        `json:"attempt_count" gorm:"default:0"`
+	LockedUntil    *time.Time `json:"locked_until" gorm:""`
+
+	User *User `json:"user,omitempty" gorm:"foreignKey:UserID;constraint:OnDelete CASCADE"`
+}
+
+func (FailedLoginAttempts) TableName() string { return "failed_login_attempts" }
+
 type SessionEngagement struct {
 	UserId       int64   `json:"user_id"`
 	TimeInterval string  `json:"time_interval"`

--- a/frontend/src/Components/forms/LoginForm.tsx
+++ b/frontend/src/Components/forms/LoginForm.tsx
@@ -28,6 +28,9 @@ export default function LoginForm() {
     const processing = navigation.state === 'submitting';
     const [user, setUser] = useState<string | undefined>(undefined);
     const [errorMessage, setErrorMessage] = useState(false);
+    const [lockedOutValue, setLockedOutValue] = useState<string | undefined>(
+        undefined
+    );
     const {
         register,
         handleSubmit,
@@ -54,6 +57,8 @@ export default function LoginForm() {
                 window.location.href = resp.data.redirect_to;
             }
             return;
+        } else if (resp.status && resp.status === 429) {
+            setLockedOutValue(resp.message);
         }
         setErrorMessage(true);
     };
@@ -118,7 +123,7 @@ export default function LoginForm() {
             {errorMessage && (
                 <div className="block">
                     <InputError
-                        message={'incorrect username or password'}
+                        message={`${lockedOutValue ? lockedOutValue : 'incorrect username or password'}`}
                         className="pt-2"
                     />
                 </div>

--- a/frontend/src/Components/forms/LoginForm.tsx
+++ b/frontend/src/Components/forms/LoginForm.tsx
@@ -28,19 +28,73 @@ export default function LoginForm() {
     const processing = navigation.state === 'submitting';
     const [user, setUser] = useState<string | undefined>(undefined);
     const [errorMessage, setErrorMessage] = useState(false);
-    const [lockedOutValue, setLockedOutValue] = useState<string | undefined>(
-        undefined
+
+    const [lockedOutSeconds, setLockedOutSeconds] = useState<number | null>(
+        null
     );
+    const [countdownDisplay, setCountdownDisplay] = useState<string>('');
     const {
         register,
         handleSubmit,
+        setValue,
         formState: { errors }
     } = useForm<Inputs>();
+
+    useEffect(() => {
+        if (lockedOutSeconds === null) {
+            setCountdownDisplay('');
+            return;
+        }
+
+        if (lockedOutSeconds <= 0) {
+            setLockedOutSeconds(null);
+            setCountdownDisplay('');
+            return;
+        }
+
+        const timer = setInterval(() => {
+            setLockedOutSeconds((prev) => {
+                if (prev === null || prev <= 1) {
+                    clearInterval(timer);
+                    return null;
+                }
+                return prev - 1;
+            });
+        }, 1000);
+
+        const minutes = Math.floor(lockedOutSeconds / 60);
+        const seconds = lockedOutSeconds % 60;
+        setCountdownDisplay(
+            minutes > 0
+                ? `${minutes} minute${minutes > 1 ? 's' : ''} and ${seconds} second${
+                      seconds !== 1 ? 's' : ''
+                  }`
+                : `${seconds} second${seconds !== 1 ? 's' : ''}`
+        );
+        return () => clearInterval(timer);
+    }, [lockedOutSeconds]);
+
+    useEffect(() => {
+        if (lockedOutSeconds === null) {
+            return;
+        }
+        const minutes = Math.floor(lockedOutSeconds / 60);
+        const seconds = lockedOutSeconds % 60;
+        setCountdownDisplay(
+            minutes > 0
+                ? `${minutes} minute${minutes > 1 ? 's' : ''} and ${seconds} second${
+                      seconds !== 1 ? 's' : ''
+                  }`
+                : `${seconds} second${seconds !== 1 ? 's' : ''}`
+        );
+    }, [lockedOutSeconds]);
 
     const onSubmit: SubmitHandler<Inputs> = async (data) => {
         if (user) {
             data.identifier = user;
         }
+
+        setValue('password', '');
         const resp = (await API.post<AuthResponse, Inputs>(
             'login',
             data
@@ -58,10 +112,23 @@ export default function LoginForm() {
             }
             return;
         } else if (resp.status && resp.status === 429) {
-            setLockedOutValue(resp.message);
+            const retryAfterHeader = resp.headers?.['retry-after'];
+            const secs = retryAfterHeader
+                ? parseInt(retryAfterHeader, 10)
+                : NaN;
+
+            if (!isNaN(secs) && secs > 0) {
+                setLockedOutSeconds(secs);
+            } else {
+                setLockedOutSeconds(null);
+            }
+            setErrorMessage(true);
+            return;
         }
+
         setErrorMessage(true);
     };
+
     useEffect(() => {
         if (loaderData.redirect_to) {
             window.location.href = loaderData.redirect_to;
@@ -71,6 +138,7 @@ export default function LoginForm() {
             setUser(loaderData.identifier);
         }
     }, [loaderData]);
+
     return (
         <Form
             method="post"
@@ -122,10 +190,13 @@ export default function LoginForm() {
 
             {errorMessage && (
                 <div className="block">
-                    <InputError
-                        message={`${lockedOutValue ? lockedOutValue : 'incorrect username or password'}`}
-                        className="pt-2"
-                    />
+                    {lockedOutSeconds !== null && lockedOutSeconds > 0 ? (
+                        <InputError
+                            message={`Currently locked out. Try again in ${countdownDisplay}.`}
+                        />
+                    ) : (
+                        <InputError message="Incorrect username or password." />
+                    )}
                 </div>
             )}
 

--- a/frontend/src/api/api.ts
+++ b/frontend/src/api/api.ts
@@ -33,6 +33,10 @@ class API {
                 };
             }
             const contentType = resp.headers.get('Content-Type') ?? '';
+            const responseHeaders: Record<string, string> = {};
+            resp.headers.forEach((val, key) => {
+                responseHeaders[key] = val;
+            });
             let data: ServerResponse<T>;
 
             const raw = await resp.text();
@@ -46,7 +50,8 @@ class API {
                         message: raw,
                         data: {} as T,
                         success: false,
-                        status: resp.status
+                        status: resp.status,
+                        headers: responseHeaders
                     };
                 }
             } else {
@@ -55,7 +60,8 @@ class API {
                     message: raw,
                     data: {} as T,
                     success: false,
-                    status: resp.status
+                    status: resp.status,
+                    headers: responseHeaders
                 };
             }
             if (!resp.ok) {
@@ -74,7 +80,8 @@ class API {
                     success: false,
                     data: null,
                     message,
-                    status: resp.status
+                    status: resp.status,
+                    headers: responseHeaders
                 };
                 throw error;
             }
@@ -90,7 +97,8 @@ class API {
                 success: false,
                 message: error.message || 'An error occurred',
                 data: {} as T,
-                status: errCode ?? 0
+                status: errCode ?? 0,
+                headers: error.response?.headers ?? {}
             };
         }
     }

--- a/frontend/src/api/api.ts
+++ b/frontend/src/api/api.ts
@@ -45,7 +45,8 @@ class API {
                         type: 'one',
                         message: raw,
                         data: {} as T,
-                        success: false
+                        success: false,
+                        status: resp.status
                     };
                 }
             } else {
@@ -53,7 +54,8 @@ class API {
                     type: 'one',
                     message: raw,
                     data: {} as T,
-                    success: false
+                    success: false,
+                    status: resp.status
                 };
             }
             if (!resp.ok) {

--- a/frontend/src/common.ts
+++ b/frontend/src/common.ts
@@ -346,6 +346,7 @@ export interface ServerResponseBase {
     success: boolean;
     message: string;
     status?: number;
+    headers?: Record<string, string>;
 }
 
 export interface ServerResponseOne<T> extends ServerResponseBase {


### PR DESCRIPTION
## Description of the change
This pull request locks a user "out" if they have failed to login 5 times within a 15 minute period. 

The current implementation logs the first failed login attempt, and then the most recent logged in attempt, upon each attempted login the handler checks if the user is locked out, during that check we check to see if the first login was 15 minutes prior to our window duration (15 minutes) if it has been over 15 minutes then we reset the failed login attempts, if the user is locked out we render the amount of time left before they can attempt again and don't pass through the login attempt so no more counters get incremented. If a password is reset, we check if that user has any entries in the database table, and if they do, we reset the failed attempts object for that user in the table.

- **Related issues**: https://app.asana.com/1/1201607307149189/project/1209460078641109/task/1209478698507743?focus=true

## Screenshot(s)

![image](https://github.com/user-attachments/assets/5dfa7aaa-2b0e-4211-b152-7b8c3bc19578)
