### PR TITLE
Fix: Class Status Pill Issue on Program Overview Dashboard 

### DIFF
--- a/frontend/src/Components/modals/TextOnlyModal.tsx
+++ b/frontend/src/Components/modals/TextOnlyModal.tsx
@@ -34,7 +34,13 @@ export const TextOnlyModal = forwardRef(function TextModal(
     ref: React.ForwardedRef<HTMLDialogElement>
 ) {
     return (
-        <dialog ref={ref} className="modal">
+        <dialog
+            ref={ref}
+            className="modal"
+            onKeyDown={(event) => {
+                if (event.key === 'Escape') onClose();
+            }}
+        >
             <div className={`modal-box ` + (width ? width : '')}>
                 <CloseX close={onClose} />
                 <div className="flex flex-col gap-6">


### PR DESCRIPTION
A bug was identified where the Class Status pill would not render the ModifyClassModal after cancelling by esc and attempting to switch the status again.

Solution:

Added an event listener to close the modal when the escape key is pressed, ensuring the modal can be properly dismissed.
## Screenshot(s)

https://github.com/user-attachments/assets/fca8ceda-a50b-421a-ab75-be065e5ed1ae

 Related to: https://app.asana.com/1/1201607307149189/inbox/1209552815576329/item/1210272664885957/story/1210390032326801

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1210272664885957