### PR TITLE
feat: add schedule tab to class dashboard with calendar view

### DIFF
--- a/backend/src/handlers/class_events.go
+++ b/backend/src/handlers/class_events.go
@@ -28,8 +28,16 @@ func (srv *Server) handleGetAdminCalendar(w http.ResponseWriter, r *http.Request
 	if err != nil {
 		return newInvalidQueryParamServiceError(err, "start_dt")
 	}
+	id := r.URL.Query().Get("class_id")
+	var classID int
+	if id != "" {
+		classID, err = strconv.Atoi(id)
+		if err != nil {
+			return newInvalidIdServiceError(err, "class_id")
+		}
+	}
 	args := srv.getQueryContext(r)
-	events, err := srv.Db.GetFacilityCalendar(&args, dtRng)
+	events, err := srv.Db.GetFacilityCalendar(&args, dtRng, classID)
 	if err != nil {
 		return newDatabaseServiceError(err)
 	}

--- a/frontend/src/Components/EventCalendar.tsx
+++ b/frontend/src/Components/EventCalendar.tsx
@@ -8,12 +8,14 @@ const localizer = momentLocalizer(moment);
 interface EventCalendarProps {
     events: FacilityProgramClassEvent[] | ShortCalendarEvent[];
     view?: View;
+    classId?: string;
     handleDateClick?: (event: FacilityProgramClassEvent) => void;
 }
 
 export default function EventCalendar({
     events,
     view = 'month',
+    classId,
     handleDateClick
 }: EventCalendarProps) {
     const eventPropGetter = (event: FacilityProgramClassEvent) => {
@@ -22,6 +24,12 @@ export default function EventCalendar({
                 className: 'rbc-event-cancelled'
             };
         }
+        if (classId && event.class_id.toString() != classId) {
+            return {
+                className: 'rbc-event-lighter'
+            };
+        }
+
         return {};
     };
     const scrollTime = new Date();

--- a/frontend/src/Components/inputs/CancelButton.tsx
+++ b/frontend/src/Components/inputs/CancelButton.tsx
@@ -1,12 +1,15 @@
 export function CancelButton({
     label = 'Cancel',
+    disabled = false,
     onClick
 }: {
     label?: string;
+    disabled?: boolean;
     onClick: () => void;
 }) {
     return (
         <input
+            disabled={disabled}
             type="button"
             className="button-grey"
             onClick={onClick}

--- a/frontend/src/Pages/ProgramClassManagement.tsx
+++ b/frontend/src/Pages/ProgramClassManagement.tsx
@@ -10,9 +10,9 @@ export default function ProgramClassManagement() {
     const tab = route.pathname.split('/')[3] ?? 'dashboard';
     const tabOptions: Tab[] = [
         { name: ClassMgmtTabs.CLASS, value: 'dashboard' },
+        { name: ClassMgmtTabs.SCHEDULE, value: 'schedule' },
         { name: ClassMgmtTabs.ENROLLMENT, value: 'enrollments' },
-        { name: ClassMgmtTabs.ATTENDANCE, value: 'attendance' },
-        { name: ClassMgmtTabs.SCHEDULE, value: 'schedule' }
+        { name: ClassMgmtTabs.ATTENDANCE, value: 'attendance' }
     ];
     const [activeTab, setActiveTab] = useState<Tab>(
         tabOptions.find((t) => t.value === tab) ?? tabOptions[0]

--- a/frontend/src/Pages/ProgramClassManagement.tsx
+++ b/frontend/src/Pages/ProgramClassManagement.tsx
@@ -11,7 +11,8 @@ export default function ProgramClassManagement() {
     const tabOptions: Tab[] = [
         { name: ClassMgmtTabs.CLASS, value: 'dashboard' },
         { name: ClassMgmtTabs.ENROLLMENT, value: 'enrollments' },
-        { name: ClassMgmtTabs.ATTENDANCE, value: 'attendance' }
+        { name: ClassMgmtTabs.ATTENDANCE, value: 'attendance' },
+        { name: ClassMgmtTabs.SCHEDULE, value: 'schedule' }
     ];
     const [activeTab, setActiveTab] = useState<Tab>(
         tabOptions.find((t) => t.value === tab) ?? tabOptions[0]

--- a/frontend/src/Pages/Schedule.tsx
+++ b/frontend/src/Pages/Schedule.tsx
@@ -26,6 +26,9 @@ export default function Schedule() {
     if (clsLoader?.redirect) {
         navigate(clsLoader.redirect);
     }
+    const toolTip = clsLoader
+        ? `This event is from another class and cannot be edited on the ${clsLoader.class?.name} schedule.`
+        : '';
     const { class_id } = useParams<{ class_id?: string }>();
     const rescheduleClassEventSeriesModal = useRef<HTMLDialogElement>(null);
     const cancelClassEventModal = useRef<HTMLDialogElement>(null);
@@ -154,29 +157,29 @@ export default function Schedule() {
                             <div className="space-y-2 flex flex-col w-full">
                                 <button
                                     disabled={!canUpdateEvent()}
-                                    className={`button${!canUpdateEvent() ? ' tooltip' : ''}`}
+                                    className={`button${!canUpdateEvent() && toolTip != '' ? ' tooltip' : ''}`}
                                     onClick={() => {
                                         showModal(rescheduleClassEventModal);
                                     }}
-                                    data-tip={`This event is from another class and cannot be edited on the ${selectedEvent.title} schedule.`}
+                                    data-tip={toolTip}
                                 >
                                     Edit Event
                                 </button>
                                 <button
                                     disabled={!canUpdateEvent()}
-                                    className={`button-outline${!canUpdateEvent() ? ' tooltip' : ''}`}
+                                    className={`button-outline${!canUpdateEvent() && toolTip != '' ? ' tooltip' : ''}`}
                                     onClick={() => {
                                         showModal(
                                             rescheduleClassEventSeriesModal
                                         );
                                     }}
-                                    data-tip={`This event is from another class and cannot be edited on the ${selectedEvent.title} schedule.`}
+                                    data-tip={toolTip}
                                 >
                                     Edit Series
                                 </button>
                                 <div
-                                    className={`flex flex-col w-full${!canUpdateEvent() ? ' tooltip' : ''}`}
-                                    data-tip={`This event is from another class and cannot be edited on the ${selectedEvent.title} schedule.`}
+                                    className={`flex flex-col w-full${!canUpdateEvent() && toolTip != '' ? ' tooltip' : ''}`}
+                                    data-tip={toolTip}
                                 >
                                     <CancelButton
                                         disabled={!canUpdateEvent()}

--- a/frontend/src/Pages/Schedule.tsx
+++ b/frontend/src/Pages/Schedule.tsx
@@ -153,37 +153,38 @@ export default function Schedule() {
                             </div>
                             <div className="space-y-2 flex flex-col w-full">
                                 <button
-                                    className="button"
+                                    disabled={!canUpdateEvent()}
+                                    className={`button${!canUpdateEvent() ? ' tooltip' : ''}`}
                                     onClick={() => {
-                                        if (!canUpdateEvent()) {
-                                            return;
-                                        }
                                         showModal(rescheduleClassEventModal);
                                     }}
+                                    data-tip={`This event is from another class and cannot be edited on the ${selectedEvent.title} schedule.`}
                                 >
                                     Edit Event
                                 </button>
                                 <button
-                                    className="button-outline"
+                                    disabled={!canUpdateEvent()}
+                                    className={`button-outline${!canUpdateEvent() ? ' tooltip' : ''}`}
                                     onClick={() => {
-                                        if (!canUpdateEvent()) {
-                                            return;
-                                        }
                                         showModal(
                                             rescheduleClassEventSeriesModal
                                         );
                                     }}
+                                    data-tip={`This event is from another class and cannot be edited on the ${selectedEvent.title} schedule.`}
                                 >
                                     Edit Series
                                 </button>
-                                <CancelButton
-                                    onClick={() => {
-                                        if (!canUpdateEvent()) {
-                                            return;
-                                        }
-                                        showModal(cancelClassEventModal);
-                                    }}
-                                />
+                                <div
+                                    className={`flex flex-col w-full${!canUpdateEvent() ? ' tooltip' : ''}`}
+                                    data-tip={`This event is from another class and cannot be edited on the ${selectedEvent.title} schedule.`}
+                                >
+                                    <CancelButton
+                                        disabled={!canUpdateEvent()}
+                                        onClick={() => {
+                                            showModal(cancelClassEventModal);
+                                        }}
+                                    />
+                                </div>
                             </div>
                         </div>
                     ) : (

--- a/frontend/src/Pages/Schedule.tsx
+++ b/frontend/src/Pages/Schedule.tsx
@@ -1,4 +1,8 @@
-import { FacilityProgramClassEvent, ServerResponseMany } from '@/common';
+import {
+    ClassLoaderData,
+    FacilityProgramClassEvent,
+    ServerResponseMany
+} from '@/common';
 import EventCalendar from '@/Components/EventCalendar';
 import { CancelButton, CloseX } from '@/Components/inputs';
 import { showModal } from '@/Components/modals';
@@ -8,6 +12,7 @@ import { RescheduleClassEventSeriesModal } from '@/Components/modals/RescheduleC
 import { useAuth } from '@/useAuth';
 import { toZonedTime } from 'date-fns-tz';
 import { useMemo, useRef, useState } from 'react';
+import { useLoaderData, useNavigate, useParams } from 'react-router-dom';
 import useSWR from 'swr';
 
 export default function Schedule() {
@@ -15,6 +20,13 @@ export default function Schedule() {
     if (!user) {
         return null;
     }
+    const [showAllClasses, setShowAllClasses] = useState(false);
+    const navigate = useNavigate();
+    const clsLoader = useLoaderData() as ClassLoaderData;
+    if (clsLoader?.redirect) {
+        navigate(clsLoader.redirect);
+    }
+    const { class_id } = useParams<{ class_id?: string }>();
     const rescheduleClassEventSeriesModal = useRef<HTMLDialogElement>(null);
     const cancelClassEventModal = useRef<HTMLDialogElement>(null);
     const rescheduleClassEventModal = useRef<HTMLDialogElement>(null);
@@ -27,7 +39,7 @@ export default function Schedule() {
         ServerResponseMany<FacilityProgramClassEvent>,
         Error
     >(
-        `/api/admin-calendar?start_dt=${startDate.toISOString()}&end_dt=${endDate.toISOString()}`
+        `/api/admin-calendar?start_dt=${startDate.toISOString()}&end_dt=${endDate.toISOString()}${class_id && !showAllClasses ? '&class_id=' + class_id : ''}`
     );
     const events = eventsResp?.data;
     const [selectedEvent, setSelectedEvent] =
@@ -65,96 +77,122 @@ export default function Schedule() {
         setSelectedEvent(null);
     }
 
+    function canUpdateEvent(): boolean {
+        if (!selectedEvent || selectedEvent.is_override) {
+            return false;
+        }
+        if (class_id && selectedEvent.class_id.toString() != class_id)
+            return false;
+        return true;
+    }
+
     return (
-        <div className="flex flex-col-2 gap-2 px-2">
+        <div className={`flex flex-col-2 gap-2${!class_id ? ' px-2' : ''}`}>
             <div className="w-3/4 card">
                 <EventCalendar
+                    classId={class_id}
                     events={formattedEvents}
                     view="week"
                     handleDateClick={(event) => setSelectedEvent(event)}
                 />
             </div>
-            <div className="w-1/4 card p-4">
-                {selectedEvent ? (
-                    <div className="flex flex-col justify-between gap-2 h-[600px]">
+            <div className="w-1/4 flex flex-col gap-2">
+                {class_id && (
+                    <>
+                        {' '}
                         <div>
-                            <h2 className="text-lg">Event Details</h2>
-                            <CloseX close={() => clearSelectedEvent()} />
-                        </div>
-                        <div className="space-y-2 overflow-y-scroll">
-                            <h3>Program Name</h3>
-                            <p>{selectedEvent.program_name}</p>
-                            <h3>Class Name</h3>
-                            <p>{selectedEvent.title}</p>
-                            <h3>Instructor</h3>
-                            <p>{selectedEvent.instructor_name}</p>
-                            <h3>Room</h3>
-                            <p>{selectedEvent.room}</p>
-                            <h3>Time</h3>
-                            <p>
-                                {selectedEvent.start.toLocaleTimeString([], {
-                                    hour: '2-digit',
-                                    minute: '2-digit'
-                                })}{' '}
-                                -{' '}
-                                {selectedEvent.end.toLocaleTimeString([], {
-                                    hour: '2-digit',
-                                    minute: '2-digit'
-                                })}
-                            </p>
-                            <h3>Frequency</h3>
-                            <p>{selectedEvent.frequency}</p>
-                            <h3>Enrolled Residents</h3>
-                            {parseEnrolledNames(selectedEvent.enrolled_users)}
-                        </div>
-                        <div className="space-y-2 flex flex-col w-full">
-                            <button
-                                className="button"
-                                onClick={() => {
-                                    if (
-                                        !selectedEvent ||
-                                        selectedEvent.is_override
-                                    ) {
-                                        return;
-                                    }
-                                    showModal(rescheduleClassEventModal);
-                                }}
-                            >
-                                Edit Event
-                            </button>
-                            <button
-                                className="button-outline"
-                                onClick={() => {
-                                    if (
-                                        !selectedEvent ||
-                                        selectedEvent.is_override
-                                    ) {
-                                        return;
-                                    }
-                                    showModal(rescheduleClassEventSeriesModal);
-                                }}
-                            >
-                                Edit Series
-                            </button>
-                            <CancelButton
-                                onClick={() => {
-                                    if (
-                                        !selectedEvent ||
-                                        selectedEvent.is_override
-                                    ) {
-                                        return;
-                                    }
-                                    showModal(cancelClassEventModal);
+                            <input
+                                type="checkbox"
+                                checked={showAllClasses}
+                                className="checkbox checkbox-sm mr-2"
+                                onChange={(e) => {
+                                    setShowAllClasses(e.target.checked);
                                 }}
                             />
+                            <label className="body">Show other classes</label>
                         </div>
-                    </div>
-                ) : (
-                    <p className="my-auto body text-center">
-                        Select an event to view details, make changes, or cancel
-                        a session.
-                    </p>
+                    </>
                 )}
+                <div className="card p-4 h-full">
+                    {selectedEvent ? (
+                        <div className="flex flex-col justify-between gap-2 h-[600px]">
+                            <div>
+                                <h2 className="text-lg">Event Details</h2>
+                                <CloseX close={() => clearSelectedEvent()} />
+                            </div>
+                            <div className="space-y-2 overflow-y-scroll">
+                                <h3>Program Name</h3>
+                                <p>{selectedEvent.program_name}</p>
+                                <h3>Class Name</h3>
+                                <p>{selectedEvent.title}</p>
+                                <h3>Instructor</h3>
+                                <p>{selectedEvent.instructor_name}</p>
+                                <h3>Room</h3>
+                                <p>{selectedEvent.room}</p>
+                                <h3>Time</h3>
+                                <p>
+                                    {selectedEvent.start.toLocaleTimeString(
+                                        [],
+                                        {
+                                            hour: '2-digit',
+                                            minute: '2-digit'
+                                        }
+                                    )}{' '}
+                                    -{' '}
+                                    {selectedEvent.end.toLocaleTimeString([], {
+                                        hour: '2-digit',
+                                        minute: '2-digit'
+                                    })}
+                                </p>
+                                <h3>Frequency</h3>
+                                <p>{selectedEvent.frequency}</p>
+                                <h3>Enrolled Residents</h3>
+                                {parseEnrolledNames(
+                                    selectedEvent.enrolled_users
+                                )}
+                            </div>
+                            <div className="space-y-2 flex flex-col w-full">
+                                <button
+                                    className="button"
+                                    onClick={() => {
+                                        if (!canUpdateEvent()) {
+                                            return;
+                                        }
+                                        showModal(rescheduleClassEventModal);
+                                    }}
+                                >
+                                    Edit Event
+                                </button>
+                                <button
+                                    className="button-outline"
+                                    onClick={() => {
+                                        if (!canUpdateEvent()) {
+                                            return;
+                                        }
+                                        showModal(
+                                            rescheduleClassEventSeriesModal
+                                        );
+                                    }}
+                                >
+                                    Edit Series
+                                </button>
+                                <CancelButton
+                                    onClick={() => {
+                                        if (!canUpdateEvent()) {
+                                            return;
+                                        }
+                                        showModal(cancelClassEventModal);
+                                    }}
+                                />
+                            </div>
+                        </div>
+                    ) : (
+                        <p className="my-auto body text-center">
+                            Select an event to view details, make changes, or
+                            cancel a session.
+                        </p>
+                    )}
+                </div>
             </div>
             {selectedEvent && (
                 <CancelClassEventModal

--- a/frontend/src/Routes/Programs.tsx
+++ b/frontend/src/Routes/Programs.tsx
@@ -20,6 +20,7 @@ import ClassLayout from '@/Components/ClassLayout';
 import Error from '@/Pages/Error';
 import { Navigate } from 'react-router-dom';
 import ResidentOverview from '@/Pages/ResidentOverview';
+import Schedule from '@/Pages/Schedule';
 
 export const ProgramRoutes = DeclareAuthenticatedRoutes(
     [
@@ -106,6 +107,14 @@ export const AdminProgramRoutes = DeclareAuthenticatedRoutes(
                     loader: getClassTitle,
                     element: <ClassEvents />,
                     errorElement: <Error />,
+                    handle: {
+                        title: (data: TitleHandler) => data.title
+                    }
+                },
+                {
+                    path: ':class_id/schedule',
+                    loader: getClassTitle,
+                    element: <Schedule />,
                     handle: {
                         title: (data: TitleHandler) => data.title
                     }

--- a/frontend/src/css/app.css
+++ b/frontend/src/css/app.css
@@ -86,7 +86,7 @@
     }
 
     .button-outline {
-        @apply border border-teal-3 bg-transparent body text-body-text py-3 px-3 button-core hover:bg-teal-1 disabled:bg-grey-2 disabled:text-grey-3 disabled:cursor-auto;
+        @apply border border-teal-3 bg-transparent body text-body-text py-3 px-3 button-core hover:bg-teal-1 disabled:bg-grey-2 disabled:text-grey-3 disabled:border-grey-2 disabled:cursor-auto;
     }
 
     .button-red {
@@ -94,7 +94,7 @@
     }
 
     .button-grey {
-        @apply button bg-grey-2 text-body-text hover:bg-grey-3;
+        @apply button bg-grey-2 text-body-text hover:bg-grey-3 disabled:hover:bg-grey-2;
     }
 
     .button-grey-sm {

--- a/frontend/src/css/app.css
+++ b/frontend/src/css/app.css
@@ -290,10 +290,13 @@ html[data-theme='dark'] input[type='time']::-webkit-calendar-picker-indicator {
     @apply bg-transparent border-2 border-teal-3 text-header-text line-through;
 }
 
+.rbc-event.rbc-event-lighter {
+    @apply bg-teal-1 border border-teal-2 text-teal-4 rounded-md body-small flex;
+}
+
 .rbc-current-time-indicator {
     @apply bg-primary-yellow;
 }
-
 
 html[data-theme='dark'] .rbc-event.rbc-selected {
     @apply text-black bg-teal-5;
@@ -306,7 +309,7 @@ html[data-theme='dark'] .rbc-event.rbc-selected {
 }
 
 .rbc-row-content {
-    @apply z-0
+    @apply z-0;
 }
 
 .rbc-timeslot-group {

--- a/frontend/src/routeLoaders.ts
+++ b/frontend/src/routeLoaders.ts
@@ -188,13 +188,12 @@ export const getClassTitle: LoaderFunction = async ({
     params
 }): Promise<ClassLoaderData | Response> => {
     const { class_id } = params;
-    const className = 'Class Management';
     const classResp = (await API.get(
         `program-classes/${class_id}`
     )) as ServerResponseOne<Class>;
     if (classResp.success) {
         return {
-            title: className,
+            title: classResp.data.name,
             class: classResp.data
         };
     } else {


### PR DESCRIPTION
## Description of the change

Added schedule tab in the Class Overview Page which contains a calendar view allowing admins to reschedule or cancel sessions for the specific class selected. 

- [x] New Schedule tab appears in Class Overview Page.
- [x] Calendar UI matches Facility Schedule view.
- [x] Events filtered by default to current class.
- [x] Editable only if event belongs to the current class.
- [x] Conflict-aware visibility of other events.
- [x] Direct rescheduling/cancellation from view.

DEPENDENT ON PR #901

 **The changes for this PR are located within this COMMIT:** [[feat: add schedule tab to class dashboard with cal view per ticket 265](https://github.com/UnlockedLabs/UnlockEdv2/commit/de8bed958fcee299d976505eb83ad9ce297954eb)]

- **Related issues**: Link to Asana tickets [Add Schedule Tab to Class Dashboard with Calendar View](https://app.asana.com/1/1201607307149189/project/1209460078641109/task/1210354107888964?focus=true)

## Screenshot(s)
![image](https://github.com/user-attachments/assets/476d116f-7691-43a7-9b91-f7283e6ce824)


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1210487095566651