### PR TITLE
fix: facility admins can't add or edit programs

### DIFF
--- a/backend/src/handlers/classes_handler.go
+++ b/backend/src/handlers/classes_handler.go
@@ -24,7 +24,14 @@ func (srv *Server) registerClassesRoutes() []routeDef {
 				Count(&count).Error == nil && count > 0
 		}),
 		validatedFeatureRoute("GET /api/program-classes/{class_id}", srv.handleGetClass, axx, resolver),
-		adminValidatedFeatureRoute("GET /api/programs/{id}/classes/outcomes", srv.handleGetProgramClassOutcomes, axx, resolver),
+		adminValidatedFeatureRoute("GET /api/programs/{id}/classes/outcomes", srv.handleGetProgramClassOutcomes, axx, func(tx *database.DB, r *http.Request) bool {
+			var count int64
+			return tx.WithContext(r.Context()).
+				Table("programs").
+				Where("id = ? AND id IN (SELECT program_id FROM facilities_programs WHERE facility_id = ?)",
+					r.PathValue("id"), r.Context().Value(ClaimsKey).(*Claims).FacilityID).
+				Count(&count).Error == nil && count > 0
+		}),
 		adminValidatedFeatureRoute("GET /api/program-classes/{class_id}/attendance-flags", srv.handleGetAttendanceFlagsForClass, axx, resolver),
 		adminValidatedFeatureRoute("GET /api/program-classes/{class_id}/history", srv.handleGetClassHistory, axx, resolver),
 		adminValidatedFeatureRoute("PATCH /api/program-classes", srv.handleUpdateClasses, axx, func(tx *database.DB, r *http.Request) bool {

--- a/backend/src/handlers/classes_handler.go
+++ b/backend/src/handlers/classes_handler.go
@@ -192,7 +192,7 @@ func (srv *Server) handleGetAttendanceFlagsForClass(w http.ResponseWriter, r *ht
 }
 
 func (srv *Server) handleGetProgramClassOutcomes(w http.ResponseWriter, r *http.Request, log sLog) error {
-	id, err := strconv.Atoi(r.PathValue("id"))
+	id, err := strconv.Atoi(r.PathValue("program_id"))
 	if err != nil {
 		return newInvalidIdServiceError(err, "program ID")
 	}

--- a/frontend/src/Pages/ProgramManagement.tsx
+++ b/frontend/src/Pages/ProgramManagement.tsx
@@ -1,4 +1,4 @@
-import { isAdministrator, useAuth } from '@/useAuth';
+import { canSwitchFacility, isAdministrator, useAuth } from '@/useAuth';
 import { useMemo, useState } from 'react';
 import SearchBar from '@/Components/inputs/SearchBar';
 import {
@@ -261,12 +261,14 @@ export default function ProgramManagement() {
                     </div>
                 </div>
                 <div className="flex items-center space-x-4">
-                    <AddButton
-                        label="Add Program"
-                        onClick={() => {
-                            navigate('detail');
-                        }}
-                    />
+                    {canSwitchFacility(user!) && (
+                        <AddButton
+                            label="Add Program"
+                            onClick={() => {
+                                navigate('detail');
+                            }}
+                        />
+                    )}
                 </div>
             </div>
             <div className="card px-6 pb-6 space-y-4">

--- a/frontend/src/Pages/ProgramManagementForm.tsx
+++ b/frontend/src/Pages/ProgramManagementForm.tsx
@@ -88,7 +88,6 @@ export default function ProgramManagementForm() {
         label: fac.name
     }));
     const facilityOptionsSelectAll = [selectAllOption, ...facilityOptions];
-    const canSwitch = user && canSwitchFacility(user);
     const onSubmit: SubmitHandler<ProgramInputs> = async (
         data: ProgramInputs
     ) => {
@@ -108,9 +107,7 @@ export default function ProgramManagementForm() {
             funding_type: data.funding_type
                 ? data.funding_type.value
                 : FundingType.OTHER,
-            facilities: canSwitch
-                ? data.facilities.map((fac) => Number(fac.value))
-                : [user!.facility_id]
+            facilities: data.facilities.map((fac) => Number(fac.value))
         };
 
         const response = program_id
@@ -298,7 +295,7 @@ export default function ProgramManagementForm() {
                             <ULIComponent
                                 icon={InformationCircleIcon}
                                 dataTip={
-                                    'Available programs appear in the admin view of selected facilities and can be scheduled. Inactive programs remain hidden until activated.'
+                                    " Set to 'Available' to let facility admins schedule classes. 'Inactive' programs stay hidden."
                                 }
                                 iconClassName="tooltip absolute  mt-[2px] ml-[2px]"
                             />

--- a/frontend/src/Pages/ProgramManagementForm.tsx
+++ b/frontend/src/Pages/ProgramManagementForm.tsx
@@ -295,7 +295,7 @@ export default function ProgramManagementForm() {
                             <ULIComponent
                                 icon={InformationCircleIcon}
                                 dataTip={
-                                    " Set to 'Available' to let facility admins schedule classes. 'Inactive' programs stay hidden."
+                                    "Set to 'Available' to let facility admins schedule classes. 'Inactive' programs stay hidden."
                                 }
                                 iconClassName="tooltip absolute  mt-[2px] ml-[2px]"
                             />

--- a/frontend/src/Pages/ProgramOverviewDashboard.tsx
+++ b/frontend/src/Pages/ProgramOverviewDashboard.tsx
@@ -205,23 +205,27 @@ export default function ProgramOverviewDashboard() {
                     <div className="card card-row-padding col-span-3">
                         <h1 className="mb-2">
                             {program?.name}
-                            <span
-                                className="font-normal"
-                                onClick={(e) => {
-                                    e?.stopPropagation();
-                                    navigate(`/programs/detail/${program?.id}`);
-                                }}
-                            >
-                                <ULIComponent
-                                    dataTip={'Edit Program'}
-                                    iconClassName="ml-2 mr-1"
-                                    tooltipClassName="tooltip-left cursor-pointer"
-                                    icon={PencilSquareIcon}
-                                />
-                                <span className="body text-teal-3 cursor-pointer relative -top-[2px] hover:underline">
-                                    Edit Program
+                            {canSwitchFacility(user.user!) && (
+                                <span
+                                    className="font-normal"
+                                    onClick={(e) => {
+                                        e?.stopPropagation();
+                                        navigate(
+                                            `/programs/detail/${program?.id}`
+                                        );
+                                    }}
+                                >
+                                    <ULIComponent
+                                        dataTip={'Edit Program'}
+                                        iconClassName="ml-2 mr-1"
+                                        tooltipClassName="tooltip-left cursor-pointer"
+                                        icon={PencilSquareIcon}
+                                    />
+                                    <span className="body text-teal-3 cursor-pointer relative -top-[2px] hover:underline">
+                                        Edit Program
+                                    </span>
                                 </span>
-                            </span>
+                            )}
                         </h1>
                         <p className="mb-4 body body-small">
                             {program?.description}

--- a/frontend/src/Routes/Programs.tsx
+++ b/frontend/src/Routes/Programs.tsx
@@ -37,6 +37,22 @@ export const ProgramRoutes = DeclareAuthenticatedRoutes(
     [FeatureAccess.ProgramAccess]
 );
 
+export const DeptAdminProgramRoutes = DeclareAuthenticatedRoutes(
+    [
+        {
+            path: 'programs/detail/:program_id?',
+            loader: getProgramData,
+            element: <ProgramManagementForm />,
+            handle: {
+                title: 'Program Details',
+                path: ['programs', 'detail']
+            }
+        }
+    ],
+    [UserRole.DepartmentAdmin, UserRole.SystemAdmin],
+    [FeatureAccess.ProgramAccess]
+);
+
 export const AdminProgramRoutes = DeclareAuthenticatedRoutes(
     [
         {
@@ -47,15 +63,6 @@ export const AdminProgramRoutes = DeclareAuthenticatedRoutes(
             handle: {
                 title: 'Programs Management',
                 path: ['programs']
-            }
-        },
-        {
-            path: 'programs/detail/:program_id?',
-            loader: getProgramData,
-            element: <ProgramManagementForm />,
-            handle: {
-                title: 'Program Details',
-                path: ['programs', 'detail']
             }
         },
         {

--- a/frontend/src/app.tsx
+++ b/frontend/src/app.tsx
@@ -4,7 +4,11 @@ import {
 } from './Routes/KnowledgeCenterRoutes.tsx';
 import { ProviderPlatformRoutes } from './Routes/ProviderRoutes.tsx';
 import { AdminRoutes, NonAdminRoutes } from './Routes/App.tsx';
-import { AdminProgramRoutes, ProgramRoutes } from './Routes/Programs.tsx';
+import {
+    AdminProgramRoutes,
+    ProgramRoutes,
+    DeptAdminProgramRoutes
+} from './Routes/Programs.tsx';
 import { createBrowserRouter, RouterProvider } from 'react-router-dom';
 import Loading from './Components/Loading.tsx';
 
@@ -15,7 +19,8 @@ const router = createBrowserRouter([
     KnowledgeCenterAdminRoutes,
     ProviderPlatformRoutes,
     ProgramRoutes,
-    AdminProgramRoutes
+    AdminProgramRoutes,
+    DeptAdminProgramRoutes
 ]);
 
 export default function App() {


### PR DESCRIPTION
## Description of the change
This PR does
1. Stops facility admins from getting to the create and or edit program page. 
2. Updates the tooltip on the program management form
3. Removes the "Edit program" in the program overview dashboard for facility admins
4. Updates the route with a new DeptAdminProgramRoutes making sure even if a facility admin navigates to the respective URI they are redirected
5. Fixes a bug on the program overview dashboard page that was stopping the program outcomes chart from being populated for facility admins
6. Removes the "Add Program" button for facility admins 

- **Related issues**: https://app.asana.com/1/1201607307149189/project/1209460078641109/task/1210481100839376?focus=true


## Screenshot(s)
![image](https://github.com/user-attachments/assets/b121e605-fecb-4cf0-aa49-347cdf7d53e9)
![image](https://github.com/user-attachments/assets/c665ccc8-761b-4302-a88a-f5e71a3119fe)


