### PR TITLE
feat: add resident attendance breakdown on resident overview

### DIFF
--- a/backend/src/database/class_events.go
+++ b/backend/src/database/class_events.go
@@ -730,12 +730,13 @@ func (db *DB) GetClassEventInstancesWithAttendanceForRecurrence(classId int, qry
 			}
 			startTime = rRule.GetDTStart()
 			if enrollment.CreatedAt.After(startTime) {
-				startTime = enrollment.CreatedAt
+				startTime = enrollment.CreatedAt.Truncate(24 * time.Hour)
 			}
 			untilTime = time.Now().AddDate(0, 0, 1).Truncate(24 * time.Hour)
 			if enrollment.EnrollmentStatus != "Enrolled" {
 				untilTime = enrollment.UpdatedAt.AddDate(0, 0, 1).Truncate(24 * time.Hour)
 			}
+			logrus.Printf("start time: %v, until time: %v", startTime, untilTime)
 		} else {
 			startTime = time.Now().Add(time.Hour * 24 * -14)
 			untilTime = startTime.AddDate(0, 1, 0)
@@ -754,6 +755,7 @@ func (db *DB) GetClassEventInstancesWithAttendanceForRecurrence(classId int, qry
 	}
 
 	occurrences := rRule.Between(startTime, untilTime, true)
+	logrus.Printf("occurrences: %v", occurrences)
 	if len(occurrences) == 0 {
 		qryCtx.Total = 0
 		return []models.ClassEventInstance{}, nil

--- a/backend/src/database/class_events.go
+++ b/backend/src/database/class_events.go
@@ -729,6 +729,9 @@ func (db *DB) GetClassEventInstancesWithAttendanceForRecurrence(classId int, qry
 				return nil, newGetRecordsDBError(err, "program_class_enrollments")
 			}
 			startTime = rRule.GetDTStart()
+			if enrollment.CreatedAt.After(startTime) {
+				startTime = enrollment.CreatedAt
+			}
 			untilTime = time.Now().AddDate(0, 0, 1).Truncate(24 * time.Hour)
 			if enrollment.EnrollmentStatus != "Enrolled" {
 				untilTime = enrollment.UpdatedAt.AddDate(0, 0, 1).Truncate(24 * time.Hour)

--- a/backend/src/database/class_events.go
+++ b/backend/src/database/class_events.go
@@ -736,7 +736,6 @@ func (db *DB) GetClassEventInstancesWithAttendanceForRecurrence(classId int, qry
 			if enrollment.EnrollmentStatus != "Enrolled" {
 				untilTime = enrollment.UpdatedAt.AddDate(0, 0, 1).Truncate(24 * time.Hour)
 			}
-			logrus.Printf("start time: %v, until time: %v", startTime, untilTime)
 		} else {
 			startTime = time.Now().Add(time.Hour * 24 * -14)
 			untilTime = startTime.AddDate(0, 1, 0)
@@ -755,7 +754,6 @@ func (db *DB) GetClassEventInstancesWithAttendanceForRecurrence(classId int, qry
 	}
 
 	occurrences := rRule.Between(startTime, untilTime, true)
-	logrus.Printf("occurrences: %v", occurrences)
 	if len(occurrences) == 0 {
 		qryCtx.Total = 0
 		return []models.ClassEventInstance{}, nil

--- a/backend/src/database/class_events.go
+++ b/backend/src/database/class_events.go
@@ -695,7 +695,7 @@ func generateEventInstances(event models.ProgramClassEvent, startDate, endDate t
 // GetClassEventInstancesWithAttendanceForRecurrence returns all occurrences for events
 // for a given class based on each event's recurrence rule (from DTSTART until UNTIL)
 // along with their associated attendance records.
-func (db *DB) GetClassEventInstancesWithAttendanceForRecurrence(classId int, qryCtx *models.QueryContext, month, year string) ([]models.ClassEventInstance, error) {
+func (db *DB) GetClassEventInstancesWithAttendanceForRecurrence(classId int, qryCtx *models.QueryContext, month, year string, userId *int) ([]models.ClassEventInstance, error) {
 	loc, err := time.LoadLocation(qryCtx.Timezone)
 	if err != nil {
 		logrus.Error("failed to load timezone")
@@ -719,8 +719,24 @@ func (db *DB) GetClassEventInstancesWithAttendanceForRecurrence(classId int, qry
 	var startTime, untilTime time.Time
 
 	if month == "" || year == "" {
-		startTime = time.Now().Add(time.Hour * 24 * -14)
-		untilTime = startTime.AddDate(0, 1, 0)
+		if userId != nil {
+			var enrollment models.ProgramClassEnrollment
+			err := db.WithContext(qryCtx.Ctx).
+				Model(&models.ProgramClassEnrollment{}).
+				Where("class_id = ? AND user_id = ?", classId, *userId).
+				First(&enrollment).Error
+			if err != nil {
+				return nil, newGetRecordsDBError(err, "program_class_enrollments")
+			}
+			startTime = rRule.GetDTStart()
+			untilTime = time.Now().AddDate(0, 0, 1).Truncate(24 * time.Hour)
+			if enrollment.EnrollmentStatus != "Enrolled" {
+				untilTime = enrollment.UpdatedAt.AddDate(0, 0, 1).Truncate(24 * time.Hour)
+			}
+		} else {
+			startTime = time.Now().Add(time.Hour * 24 * -14)
+			untilTime = startTime.AddDate(0, 1, 0)
+		}
 	} else {
 		yearInt, err := strconv.Atoi(year)
 		if err != nil {
@@ -755,9 +771,13 @@ func (db *DB) GetClassEventInstancesWithAttendanceForRecurrence(classId int, qry
 	classTime := startTimeStr + "-" + endTimeStr
 	var attendances []models.ProgramClassEventAttendance
 
-	if err := db.WithContext(qryCtx.Ctx).
+	tx := db.WithContext(qryCtx.Ctx).
 		Model(&models.ProgramClassEventAttendance{}).
-		Where("event_id = ? AND date BETWEEN SYMMETRIC ? AND ?", event.ID, occDateStr, lastOccDateStr).
+		Where("event_id = ? AND date BETWEEN SYMMETRIC ? AND ?", event.ID, occDateStr, lastOccDateStr)
+	if userId != nil {
+		tx = tx.Where("user_id = ?", *userId)
+	}
+	if err := tx.
 		Order("date DESC").
 		Find(&attendances).Error; err != nil {
 		return nil, newGetRecordsDBError(err, "program_class_event_attendances")

--- a/backend/src/handlers/class_events.go
+++ b/backend/src/handlers/class_events.go
@@ -142,10 +142,9 @@ func (srv *Server) handleGetProgramClassEvents(w http.ResponseWriter, r *http.Re
 	if err != nil {
 		return newInvalidIdServiceError(err, "class_id")
 	}
-	var userId *int
-	uid, err := strconv.Atoi(r.URL.Query().Get("user_id"))
-	if err == nil {
-		userId = &uid
+	userId, err := strconv.Atoi(r.URL.Query().Get("user_id"))
+	if err != nil {
+		log.errorf("Error parsing user id: %v", err)
 	}
 	log.add("class id", classID)
 	month := r.URL.Query().Get("month")
@@ -161,7 +160,7 @@ func (srv *Server) handleGetProgramClassEvents(w http.ResponseWriter, r *http.Re
 	}
 
 	qryCtx := srv.getQueryContext(r)
-	instances, err := srv.Db.GetClassEventInstancesWithAttendanceForRecurrence(classID, &qryCtx, month, year, userId)
+	instances, err := srv.Db.GetClassEventInstancesWithAttendanceForRecurrence(classID, &qryCtx, month, year, &userId)
 	if err != nil {
 		return newDatabaseServiceError(err)
 	}

--- a/backend/src/handlers/class_events.go
+++ b/backend/src/handlers/class_events.go
@@ -142,6 +142,11 @@ func (srv *Server) handleGetProgramClassEvents(w http.ResponseWriter, r *http.Re
 	if err != nil {
 		return newInvalidIdServiceError(err, "class_id")
 	}
+	var userId *int
+	uid, err := strconv.Atoi(r.URL.Query().Get("user_id"))
+	if err == nil {
+		userId = &uid
+	}
 	log.add("class id", classID)
 	month := r.URL.Query().Get("month")
 	year := r.URL.Query().Get("year")
@@ -156,7 +161,7 @@ func (srv *Server) handleGetProgramClassEvents(w http.ResponseWriter, r *http.Re
 	}
 
 	qryCtx := srv.getQueryContext(r)
-	instances, err := srv.Db.GetClassEventInstancesWithAttendanceForRecurrence(classID, &qryCtx, month, year)
+	instances, err := srv.Db.GetClassEventInstancesWithAttendanceForRecurrence(classID, &qryCtx, month, year, userId)
 	if err != nil {
 		return newDatabaseServiceError(err)
 	}

--- a/backend/src/handlers/user_handler.go
+++ b/backend/src/handlers/user_handler.go
@@ -423,7 +423,7 @@ func (srv *Server) handleGetUserPrograms(w http.ResponseWriter, r *http.Request,
 		total := present + absent
 
 		if total == 0 {
-			userPrograms[i].AttendancePercentage = "0%"
+			userPrograms[i].AttendancePercentage = "--"
 		} else {
 			pct := float64(present) / float64(total) * 100
 			userPrograms[i].AttendancePercentage = fmt.Sprintf("%.0f%%", pct)

--- a/frontend/src/Components/ResidentPrograms.tsx
+++ b/frontend/src/Components/ResidentPrograms.tsx
@@ -78,7 +78,7 @@ export default function ResidentPrograms({ user_id }: { user_id: string }) {
     }
 
     function ResidentProgramRow({ pc }: { pc: ResidentProgramOverview }) {
-        const clickableElement = `cursor-pointer hover:bg-base-100 p-2`;
+        const clickableElement = `cursor-pointer hover:underline p-2`;
         return (
             <tr
                 key={`${pc.class_id}-${pc.start_date}`}

--- a/frontend/src/Components/ResidentPrograms.tsx
+++ b/frontend/src/Components/ResidentPrograms.tsx
@@ -138,7 +138,10 @@ export default function ResidentPrograms({ user_id }: { user_id: string }) {
                                 <>
                                     <ProgramSectionDividerRow type="Active Enrollments" />
                                     {activePrograms.map((pc) => (
-                                        <ResidentProgramRow pc={pc} />
+                                        <ResidentProgramRow
+                                            pc={pc}
+                                            key={pc.class_id}
+                                        />
                                     ))}
                                 </>
                             )}
@@ -149,7 +152,10 @@ export default function ResidentPrograms({ user_id }: { user_id: string }) {
                                     <>
                                         <ProgramSectionDividerRow type="Scheduled Enrollments" />
                                         {scheduledPrograms.map((pc) => (
-                                            <ResidentProgramRow pc={pc} />
+                                            <ResidentProgramRow
+                                                pc={pc}
+                                                key={pc.class_id}
+                                            />
                                         ))}
                                     </>
                                 )}
@@ -160,7 +166,10 @@ export default function ResidentPrograms({ user_id }: { user_id: string }) {
                                     <>
                                         <ProgramSectionDividerRow type="Completed Enrollments" />
                                         {completedPrograms.map((pc) => (
-                                            <ResidentProgramRow pc={pc} />
+                                            <ResidentProgramRow
+                                                pc={pc}
+                                                key={pc.class_id}
+                                            />
                                         ))}
                                     </>
                                 )}
@@ -169,7 +178,10 @@ export default function ResidentPrograms({ user_id }: { user_id: string }) {
                                     <>
                                         <ProgramSectionDividerRow type="Did Not Complete" />
                                         {didNotCompletePrograms.map((pc) => (
-                                            <ResidentProgramRow pc={pc} />
+                                            <ResidentProgramRow
+                                                pc={pc}
+                                                key={pc.class_id}
+                                            />
                                         ))}
                                     </>
                                 )}

--- a/frontend/src/Components/helperFunctions/formatting.tsx
+++ b/frontend/src/Components/helperFunctions/formatting.tsx
@@ -111,3 +111,21 @@ export function parseRRuleUntilDate(rRule: string, timezone: string): string {
     }
     return '';
 }
+
+export function textMonthLocalDate(date: string | Date) {
+    if (typeof date === 'string') {
+        return new Date(date).toLocaleDateString('en-US', {
+            year: 'numeric',
+            month: 'short',
+            day: 'numeric',
+            timeZone: 'UTC'
+        });
+    } else {
+        return date.toLocaleDateString('en-US', {
+            year: 'numeric',
+            month: 'short',
+            day: 'numeric',
+            timeZone: 'UTC'
+        });
+    }
+}

--- a/frontend/src/Components/modals/ResidentAttendanceModal.tsx
+++ b/frontend/src/Components/modals/ResidentAttendanceModal.tsx
@@ -27,8 +27,6 @@ export const ResidentAttendanceModal = forwardRef(function (
         `/api/program-classes/${selectedClass?.class_id}/events?&page=${page}&per_page=10&order_by=created_at&order=desc&user_id=${residentId}`
     );
     const meta = attendance?.meta;
-    console.log(selectedClass);
-    console.log(attendance?.data);
     function AttendanceTable() {
         return (
             <>

--- a/frontend/src/Components/modals/ResidentAttendanceModal.tsx
+++ b/frontend/src/Components/modals/ResidentAttendanceModal.tsx
@@ -49,51 +49,37 @@ export const ResidentAttendanceModal = forwardRef(function (
                             <tbody>
                                 {attendance && attendance?.data.length > 0 ? (
                                     attendance?.data.map((event) => {
-                                        if (event.attendance_records != null) {
-                                            const attendanceRecord =
-                                                event.attendance_records[0];
-                                            return (
-                                                <tr
-                                                    key={attendanceRecord.id}
-                                                    className="grid-cols-3 text-center"
-                                                >
-                                                    <td className="justify-self-start">
-                                                        {textMonthLocalDate(
-                                                            event.date
-                                                        )}
-                                                    </td>
-                                                    <td>
-                                                        {
-                                                            attendanceLabelMap[
-                                                                attendanceRecord
-                                                                    .attendance_status
-                                                            ]
-                                                        }
-                                                    </td>
-                                                    <td className="justify-self-end">
-                                                        {attendanceRecord.note}
-                                                    </td>
-                                                </tr>
-                                            );
-                                        } else {
-                                            return (
-                                                <tr
-                                                    key={event.date}
-                                                    className="grid-cols-3 text-center"
-                                                >
-                                                    <td className="justify-self-start">
-                                                        {textMonthLocalDate(
-                                                            event.date
-                                                        )}
-                                                    </td>
-                                                    <td>
-                                                        No attendance data
-                                                        available yet.
-                                                    </td>
-                                                    <td></td>
-                                                </tr>
-                                            );
-                                        }
+                                        const attendanceRecord =
+                                            event.attendance_records?.[0];
+                                        return (
+                                            <tr
+                                                key={
+                                                    attendanceRecord
+                                                        ? attendanceRecord.id
+                                                        : event.date
+                                                }
+                                                className="grid-cols-3 text-center"
+                                            >
+                                                <td className="justify-self-start">
+                                                    {textMonthLocalDate(
+                                                        event.date
+                                                    )}
+                                                </td>
+                                                <td>
+                                                    {attendanceRecord
+                                                        ? attendanceLabelMap[
+                                                              attendanceRecord
+                                                                  .attendance_status
+                                                          ]
+                                                        : 'No attendance data available yet.'}
+                                                </td>
+                                                <td className="justify-self-end">
+                                                    {attendanceRecord
+                                                        ? attendanceRecord.note
+                                                        : ''}
+                                                </td>
+                                            </tr>
+                                        );
                                     })
                                 ) : (
                                     <tr>
@@ -117,8 +103,8 @@ export const ResidentAttendanceModal = forwardRef(function (
             ref={ref}
             width="max-w-4xl"
             text={<AttendanceTable />}
-            onSubmit={() => void console.log('submit')}
-            onClose={() => void console.log('close')}
+            onSubmit={() => {}} //eslint-disable-line
+            onClose={() => {}} //eslint-disable-line
         />
     );
 });

--- a/frontend/src/Components/modals/ResidentAttendanceModal.tsx
+++ b/frontend/src/Components/modals/ResidentAttendanceModal.tsx
@@ -1,0 +1,126 @@
+import { forwardRef, useState } from 'react';
+import { TextOnlyModal } from './TextOnlyModal';
+import { TextModalType } from '.';
+import useSWR from 'swr';
+import {
+    attendanceLabelMap,
+    ClassEventInstance,
+    ResidentProgramOverview,
+    ServerResponseMany
+} from '@/common';
+import Pagination from '../Pagination';
+import Loading from '../Loading';
+import { useParams } from 'react-router-dom';
+import { textMonthLocalDate } from '../helperFunctions/formatting';
+
+export const ResidentAttendanceModal = forwardRef(function (
+    { selectedClass }: { selectedClass: ResidentProgramOverview | null },
+    ref: React.ForwardedRef<HTMLDialogElement>
+) {
+    const [page, setPage] = useState(1);
+    const { user_id: residentId } = useParams<{ user_id: string }>();
+    const {
+        data: attendance,
+        error,
+        isLoading
+    } = useSWR<ServerResponseMany<ClassEventInstance>, Error>(
+        `/api/program-classes/${selectedClass?.class_id}/events?&page=${page}&per_page=10&order_by=created_at&order=desc&user_id=${residentId}`
+    );
+    const meta = attendance?.meta;
+    console.log(selectedClass);
+    console.log(attendance?.data);
+    function AttendanceTable() {
+        return (
+            <>
+                {error ? (
+                    <p className="text-error">
+                        Error loading attendance records
+                    </p>
+                ) : isLoading ? (
+                    <Loading />
+                ) : (
+                    <>
+                        <table className="table-2">
+                            <thead>
+                                <tr className="grid-cols-3 px-4">
+                                    <th className="justify-self-start">Date</th>
+                                    <th>Status</th>
+                                    <th className="justify-self-end">Note</th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                {attendance && attendance?.data.length > 0 ? (
+                                    attendance?.data.map((event) => {
+                                        if (event.attendance_records != null) {
+                                            const attendanceRecord =
+                                                event.attendance_records[0];
+                                            return (
+                                                <tr
+                                                    key={attendanceRecord.id}
+                                                    className="grid-cols-3 text-center"
+                                                >
+                                                    <td className="justify-self-start">
+                                                        {textMonthLocalDate(
+                                                            event.date
+                                                        )}
+                                                    </td>
+                                                    <td>
+                                                        {
+                                                            attendanceLabelMap[
+                                                                attendanceRecord
+                                                                    .attendance_status
+                                                            ]
+                                                        }
+                                                    </td>
+                                                    <td className="justify-self-end">
+                                                        {attendanceRecord.note}
+                                                    </td>
+                                                </tr>
+                                            );
+                                        } else {
+                                            return (
+                                                <tr
+                                                    key={event.date}
+                                                    className="grid-cols-3 text-center"
+                                                >
+                                                    <td className="justify-self-start">
+                                                        {textMonthLocalDate(
+                                                            event.date
+                                                        )}
+                                                    </td>
+                                                    <td>
+                                                        No attendance data
+                                                        available yet.
+                                                    </td>
+                                                    <td></td>
+                                                </tr>
+                                            );
+                                        }
+                                    })
+                                ) : (
+                                    <tr>
+                                        <td colSpan={6}>
+                                            <p>No attendance records found.</p>
+                                        </td>
+                                    </tr>
+                                )}
+                            </tbody>
+                        </table>
+                        {meta && <Pagination meta={meta} setPage={setPage} />}
+                    </>
+                )}
+            </>
+        );
+    }
+    return (
+        <TextOnlyModal
+            type={TextModalType.Information}
+            title={`Attendance Details for ${selectedClass?.class_name}`}
+            ref={ref}
+            width="max-w-4xl"
+            text={<AttendanceTable />}
+            onSubmit={() => void console.log('submit')}
+            onClose={() => void console.log('close')}
+        />
+    );
+});

--- a/frontend/src/Components/modals/ResidentAttendanceModal.tsx
+++ b/frontend/src/Components/modals/ResidentAttendanceModal.tsx
@@ -24,7 +24,9 @@ export const ResidentAttendanceModal = forwardRef(function (
         error,
         isLoading
     } = useSWR<ServerResponseMany<ClassEventInstance>, Error>(
-        `/api/program-classes/${selectedClass?.class_id}/events?&page=${page}&per_page=10&order_by=created_at&order=desc&user_id=${residentId}`
+        selectedClass?.class_id
+            ? `/api/program-classes/${selectedClass?.class_id}/events?&page=${page}&per_page=10&order_by=created_at&order=desc&user_id=${residentId}`
+            : null
     );
     const meta = attendance?.meta;
     function AttendanceTable() {

--- a/frontend/src/Components/modals/index.ts
+++ b/frontend/src/Components/modals/index.ts
@@ -347,3 +347,5 @@ export const requestContentInputs: Input[] = [
 ];
 
 export { RequestContentModal } from './RequestContentModal';
+
+export { ResidentAttendanceModal } from './ResidentAttendanceModal';

--- a/frontend/src/Pages/EventAttendance.tsx
+++ b/frontend/src/Pages/EventAttendance.tsx
@@ -183,7 +183,7 @@ export default function EventAttendance() {
                 ...currentRow,
                 selected: newSelected,
                 attendance_status: newSelected
-                    ? currentRow?.attendance_status
+                    ? currentRow?.attendance_status ?? Attendance.Present
                     : undefined
             }
         }));

--- a/frontend/src/common.ts
+++ b/frontend/src/common.ts
@@ -895,6 +895,12 @@ export enum Attendance {
     Absent_Unexcused = 'absent_unexcused'
 }
 
+export const attendanceLabelMap: Record<Attendance, string> = {
+    [Attendance.Absent_Excused]: 'Excused Absence',
+    [Attendance.Absent_Unexcused]: 'Unexcused Absence',
+    [Attendance.Present]: 'Present'
+};
+
 export enum SelectedClassStatus {
     Scheduled = 'Scheduled',
     Active = 'Active',


### PR DESCRIPTION
## Description of the change

### ✅ **Feature Implementation Checklist**

- [x]  Show **all class dates** in the modal, in **reverse chronological order**.
- [x]  For each date:
    - [x]  Show whether the resident **attended** or not.
    - [x]  If **absent**, show the **reason for absence** (if provided).
    - [x]  If the date is **past** and **no attendance data recorded**, show: `"No attendance data available yet."`
- [x]  Only show events that fall **within the resident's enrollment period** (i.e., exclude dates **after a drop** or **before enrollment**).
- [x]  Only the **class name** and **attendance status** in each row are clickable.
    - [x]  Clicking **class name** navigates to the **Class Overview page**.
    - [x]  Clicking **attendance percent** opens the attendance details modal
    - [X] Fixes a bug where present attendance was not being recorded when the row was selected and present was default selected.

- **Related issues**: [Ticket 294](https://app.asana.com/1/1201607307149189/project/1209460078641109/task/1210481100839428?focus=true)

## Screenshot(s)
![Screenshot 2025-06-13 at 12 23 14 PM](https://github.com/user-attachments/assets/0477ab0f-6825-4df2-b50c-0ac7555a94d9)
![Screenshot 2025-06-13 at 12 23 35 PM](https://github.com/user-attachments/assets/f57055ea-2d2c-4706-9a26-703237e3b73c)
![Screenshot 2025-06-13 at 12 23 23 PM](https://github.com/user-attachments/assets/c73f416e-ee73-4331-8c8b-4651a0323f26)
![Screenshot 2025-06-13 at 12 24 24 PM](https://github.com/user-attachments/assets/8ca5490c-a2b4-4129-a159-abce6394af26)
