### PR TITLE
fix: remove loader call and replace logic with facilities per ticket 310

### DIFF
--- a/frontend/src/Components/OperationalInsightsCharts.tsx
+++ b/frontend/src/Components/OperationalInsightsCharts.tsx
@@ -1,21 +1,13 @@
 import { useEffect, useState } from 'react';
 import useSWR from 'swr';
-import {
-    Facility,
-    FilterPastTime,
-    LoginMetrics,
-    ServerResponseOne
-} from '@/common';
+import { FilterPastTime, LoginMetrics, ServerResponseOne } from '@/common';
 import StatsCard from './StatsCard';
 import { ResponsiveContainer } from 'recharts';
 import EngagementRateGraph from './EngagementRateGraph';
 import { useAuth, canSwitchFacility } from '@/useAuth';
 import DropdownControl from './inputs/DropdownControl';
-interface Props {
-    facilities: Facility[];
-}
 
-const OperationalInsights = ({ facilities }: Props) => {
+const OperationalInsights = () => {
     const [facility, setFacility] = useState('all');
     const [timeFilter, setTimeFilter] = useState<FilterPastTime>(
         FilterPastTime['Past 30 days']
@@ -86,7 +78,7 @@ const OperationalInsights = ({ facilities }: Props) => {
                                         <option key={'all'} value={'all'}>
                                             All
                                         </option>
-                                        {facilities?.map((facility) => (
+                                        {user?.facilities?.map((facility) => (
                                             <option
                                                 key={facility.name}
                                                 value={facility.id}

--- a/frontend/src/Pages/OperationalInsights.tsx
+++ b/frontend/src/Pages/OperationalInsights.tsx
@@ -1,14 +1,10 @@
-import { Facility } from '@/common';
 import OperationalInsights from '@/Components/OperationalInsightsCharts';
-import { useLoaderData } from 'react-router-dom';
 
 export default function OperationalInsightsPage() {
-    const facilities = useLoaderData() as Facility[];
-
     return (
         <div>
             <div className="w-full flex flex-col gap-6 px-5 pb-4">
-                <OperationalInsights facilities={facilities} />
+                <OperationalInsights />
             </div>
         </div>
     );


### PR DESCRIPTION
## Description of the change

Fixed operation insights bug so that facilities display in dropdown and also made sure that switching between the facilities was working. This required removing the useLoaderData call along with a bit of frontend refactor.

- **Related issues**: Link to Asana tickets [BUG: Operational Insights Doesn't Update When Switching Facilities](https://app.asana.com/1/1201607307149189/project/1209460078641109/task/1210535405607307?focus=true)