### PR TITLE
fix: remove validation for allowing past dates per ticket 305

### DIFF
--- a/frontend/src/Components/inputs/RRuleControl.tsx
+++ b/frontend/src/Components/inputs/RRuleControl.tsx
@@ -11,7 +11,6 @@ import { useAuth } from '@/useAuth';
 import {
     formatDuration,
     isEndDtBeforeStartDt,
-    isPastDate,
     timeToMinutes
 } from '../helperFunctions';
 export interface RRuleFormHandle {
@@ -177,8 +176,6 @@ export const RRuleControl = forwardRef<RRuleFormHandle, RRuleControlProp>(
             let startDate = getValues(startDateRef) as string;
             startDate = startDate ? startDate.trim() : '';
             if (startDate === '') errors.startDate = 'Start Date is required.';
-            if (startDate != '' && isPastDate(startDate))
-                errors.startDate = 'Start Date cannot be in the past.';
 
             if (endOption === 'until') {
                 let endDate = getValues(endDateRef) as string;
@@ -293,6 +290,7 @@ export const RRuleControl = forwardRef<RRuleFormHandle, RRuleControlProp>(
             <div className="space-y-5">
                 <div className="-mb-4">
                     <DateInput
+                        allowPastDate={true}
                         defaultValue={startDateVal}
                         label="Start Date"
                         register={register}


### PR DESCRIPTION
## Description of the change

Removed validation from ClassManagementForm that doesn't allow past dates. 

NOTES:  
- BTW: Calendar only displays 3 months in the past 
- Potential Issue Discovered: Daylight savings time causes scheduled times to shift. I think we should fix this and it could be added this to 'Restore Event' ticket

- **Related issues**: Link to Asana tickets [Allow for classes to be created with start dates in the past](https://app.asana.com/1/1201607307149189/project/1209460078641109/task/1210495081491621?focus=true)

