### PR TITLE
feat: add Role column, disabled icons w/tooltip to user admin pg

### DIFF
--- a/backend/src/database/users.go
+++ b/backend/src/database/users.go
@@ -19,16 +19,16 @@ func calcOffset(page, perPage int) int {
 }
 
 func (db *DB) GetCurrentUsers(args *models.QueryContext, role string) ([]models.User, error) {
-	tx := db.WithContext(args.Ctx).Model(&models.User{}).Where("facility_id = ?", args.FacilityID)
+	tx := db.WithContext(args.Ctx).Model(&models.User{})
 	switch role {
 	case "system_admin":
-		tx = tx.Where("role IN ('system_admin',  'department_admin', 'facility_admin')")
+		tx = tx.Where("role IN ('system_admin',  'department_admin') OR (role = 'facility_admin' AND facility_id = ?)", args.FacilityID)
 	case "department_admin":
-		tx = tx.Where("role IN ('department_admin', 'facility_admin')")
+		tx = tx.Where("(role = 'department_admin') OR (role = 'facility_admin' AND facility_id = ?)", args.FacilityID)
 	case "facility_admin":
-		tx = tx.Where("role = 'facility_admin'")
+		tx = tx.Where("facility_id = ? and role = 'facility_admin'", args.FacilityID)
 	case "student":
-		tx = tx.Where("role = 'student'")
+		tx = tx.Where("facility_id = ? and role = 'student'", args.FacilityID)
 	}
 	if args.Search != "" {
 		tx = fuzzySearchUsers(tx, args)

--- a/frontend/src/Pages/AdminManagement.tsx
+++ b/frontend/src/Pages/AdminManagement.tsx
@@ -136,6 +136,26 @@ export default function AdminManagement() {
         return;
     };
 
+    function getUserRoleDesc(role: UserRole): string {
+        let roleDescription;
+        switch (role) {
+            case UserRole.SystemAdmin:
+                roleDescription = 'System Admin';
+                break;
+            case UserRole.DepartmentAdmin:
+                roleDescription = 'Department Admin';
+                break;
+            case UserRole.FacilityAdmin:
+                roleDescription = 'Facility Admin';
+                break;
+            case UserRole.Student:
+                roleDescription = 'Student';
+                break;
+            default:
+                roleDescription = 'Unknown';
+        }
+        return roleDescription;
+    }
     return (
         <div>
             <div className="flex flex-col space-y-6 overflow-x-auto rounded-lg p-4 px-5">
@@ -206,6 +226,7 @@ export default function AdminManagement() {
                             <tr className="grid grid-cols-5 px-4">
                                 <th className="justify-self-start">Name</th>
                                 <th>Username</th>
+                                <th>Role</th>
                                 <th>Last Updated</th>
                                 <th>Created At</th>
                                 <th className="justify-self-end pr-4">
@@ -234,6 +255,11 @@ export default function AdminManagement() {
                                                 {targetUser.name_first}
                                             </td>
                                             <td>{targetUser.username}</td>
+                                            <td>
+                                                {getUserRoleDesc(
+                                                    targetUser.role
+                                                )}
+                                            </td>
                                             <td>
                                                 <div
                                                     className="tooltip"
@@ -277,7 +303,7 @@ export default function AdminManagement() {
                                                     {canEdit(
                                                         user!,
                                                         targetUser
-                                                    ) && (
+                                                    ) ? (
                                                         <ULIComponent
                                                             dataTip={
                                                                 'Edit Admin'
@@ -294,11 +320,22 @@ export default function AdminManagement() {
                                                                 PencilSquareIcon
                                                             }
                                                         />
+                                                    ) : (
+                                                        <ULIComponent
+                                                            icon={
+                                                                PencilSquareIcon
+                                                            }
+                                                            dataTip={
+                                                                'Edit not allowed'
+                                                            }
+                                                            tooltipClassName="tooltip-left"
+                                                            iconClassName="text-grey-2"
+                                                        />
                                                     )}
                                                     {canEdit(
                                                         user!,
                                                         targetUser
-                                                    ) && (
+                                                    ) ? (
                                                         <ULIComponent
                                                             dataTip={
                                                                 'Reset Password'
@@ -317,6 +354,17 @@ export default function AdminManagement() {
                                                             icon={
                                                                 ArrowPathRoundedSquareIcon
                                                             }
+                                                        />
+                                                    ) : (
+                                                        <ULIComponent
+                                                            icon={
+                                                                ArrowPathRoundedSquareIcon
+                                                            }
+                                                            dataTip={
+                                                                'Reset password not allowed'
+                                                            }
+                                                            tooltipClassName="tooltip-left"
+                                                            iconClassName="text-grey-2"
                                                         />
                                                     )}
                                                     {canDelete(
@@ -348,7 +396,16 @@ export default function AdminManagement() {
                                                                 LockClosedIcon
                                                             }
                                                         />
-                                                    ) : null}
+                                                    ) : (
+                                                        <ULIComponent
+                                                            icon={TrashIcon}
+                                                            dataTip={
+                                                                'Delete not allowed'
+                                                            }
+                                                            tooltipClassName="tooltip-left"
+                                                            iconClassName="text-grey-2"
+                                                        />
+                                                    )}
                                                 </div>
                                             </td>
                                         </tr>

--- a/frontend/src/Pages/AdminManagement.tsx
+++ b/frontend/src/Pages/AdminManagement.tsx
@@ -223,7 +223,7 @@ export default function AdminManagement() {
                 <div className="relative w-full" style={{ overflowX: 'clip' }}>
                     <table className="table-2 mb-4">
                         <thead>
-                            <tr className="grid grid-cols-5 px-4">
+                            <tr className="grid grid-cols-6 px-4">
                                 <th className="justify-self-start">Name</th>
                                 <th>Username</th>
                                 <th>Role</th>
@@ -247,7 +247,7 @@ export default function AdminManagement() {
                                     return (
                                         <tr
                                             key={targetUser.id}
-                                            className="card p-4 w-full grid-cols-5 justify-items-center"
+                                            className="card p-4 w-full grid-cols-6 justify-items-center"
                                         >
                                             <td className="justify-self-start">
                                                 {targetUser.name_last}


### PR DESCRIPTION
## Description of the change

Added the Role column to user table and added the action icons for delete, edit, and reset password. Also added the tooltips requested when disabled. Modified the SQL query to pull all department admin users no matter the facility selected in the facility dropdown.

- [x] Add new **Role** column to the Admins page
- [x] Implement **Facility switcher** to only affect which Facility Admins are shown (not Department Admins)
- [x] Ensure **Department Admins** are the only users who see the Admins page
- [x] Department Admins should see all **Department Admins** (regardless of selected facility)
- [x] (SuperAdmin also sees all Department Admins, confirm with @jtucholski if this is an issue)
- [x] Add **action buttons** (Edit, Reset Password, Delete) and tooltips on Admins page
    - [x] Disabled Edit: Tooltip — "Edit not allowed"
    - [x] Disabled Reset Password: Tooltip — "Reset password not allowed"
    - [x] Disabled Delete: Tooltip — "Delete not allowed"

- **Related issues**: Link to Asana ticket [Clean up and address confusion on the Administrators Page](https://app.asana.com/1/1201607307149189/project/1209460078641109/task/1210089681287799?focus=true)

## Screenshot(s)

![image](https://github.com/user-attachments/assets/147a5db6-707b-42af-a7b0-40ed52e8f248)
