### PR TITLE
Fix:Submit Button text for User and Facility modals

### DIFF
--- a/frontend/src/Components/modals/AddFacilityModal.tsx
+++ b/frontend/src/Components/modals/AddFacilityModal.tsx
@@ -23,11 +23,13 @@ export const AddFacilityModal = forwardRef(function (
     };
 
     return (
-        <FormModal
-            title="Add Facility"
-            inputs={facilityInputs}
-            onSubmit={addFacility}
-            ref={addFacilityModal}
+       <FormModal
+         title="Add Facility"
+         inputs={facilityInputs}
+         onSubmit={addFacility}
+         ref={addFacilityModal}
+         showCancel={true}
+         submitText="Create Facility "
         />
     );
 });

--- a/frontend/src/Components/modals/AddUserModal.tsx
+++ b/frontend/src/Components/modals/AddUserModal.tsx
@@ -98,6 +98,8 @@ export const AddUserModal = forwardRef(function (
             onSubmit={addUser}
             error={formError}
             ref={addUserModal}
+            showCancel={true}
+            submitText="Create User  "
         />
     );
 });

--- a/frontend/src/Components/modals/EditFacilityModal.tsx
+++ b/frontend/src/Components/modals/EditFacilityModal.tsx
@@ -22,12 +22,14 @@ export const EditFacilityModal = forwardRef(function (
         );
     };
     return (
-        <FormModal
+       <FormModal
             title="Edit Facility"
             inputs={facilityInputs}
             defaultValues={target ? target : undefined}
             onSubmit={updateFacility}
             ref={editFacilityModal}
+            showCancel={true}
+            submitText="Save Changes "
         />
     );
 });

--- a/frontend/src/Components/modals/EditUserModal.tsx
+++ b/frontend/src/Components/modals/EditUserModal.tsx
@@ -24,11 +24,13 @@ export const EditUserModal = forwardRef(function (
     };
     return (
         <FormModal
-            title={'Edit User'}
-            inputs={getUserInputs(target.role, CRUDActions.Edit)}
-            defaultValues={target}
-            onSubmit={editUser}
-            ref={editUserModal}
+                title={'Edit User'}
+                inputs={getUserInputs(target.role, CRUDActions.Edit)}
+                defaultValues={target}
+                onSubmit={editUser}
+                ref={editUserModal}
+                showCancel={true}
+                submitText="Save Changes "
         />
     );
 });


### PR DESCRIPTION
## Submit Button text for User and Facility modals reflects state



## Screenshot(s)
<img width="219" alt="image" src="https://github.com/user-attachments/assets/bd06b358-c14a-44f8-b300-e95b4fcd07f9" />
                                                                                                                    

<img width="182" alt="image" src="https://github.com/user-attachments/assets/60f9a868-ddd7-4a41-bdca-9503db6962dd" />


If the PR includes changes to the UI, please add screenshots or a brief screengrab to demonstrate the changes.

## Additional context

Future PR's will not be from fork and I will reference the ticket number.

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1210608461992709