### PR TITLE
fix: add coalesce function to SQL query for to fix operational insights issue per ticket 321

### DIFF
--- a/backend/src/database/users.go
+++ b/backend/src/database/users.go
@@ -281,7 +281,7 @@ func (db *DB) NewUsersInTimePeriod(days int, facilityId *uint) (int64, int64, er
 func (db *DB) GetTotalLogins(days int, facilityId *uint) (int64, error) {
 	var total int64
 	daysAgo := time.Now().AddDate(0, 0, -days)
-	tx := db.Model(&models.LoginActivity{}).Select("SUM(total_logins)").Where("time_interval >= ?", daysAgo)
+	tx := db.Model(&models.LoginActivity{}).Select("COALESCE(SUM(total_logins), 0)").Where("time_interval >= ?", daysAgo)
 	if facilityId != nil {
 		tx = tx.Where("facility_id = ?", *facilityId)
 	}

--- a/frontend/src/Components/LibraryLayout.tsx
+++ b/frontend/src/Components/LibraryLayout.tsx
@@ -114,6 +114,7 @@ export default function LibaryLayout({
                 </div>
                 {isAdministrator(user) && !adminWithStudentView() && (
                     <DropdownControl
+                        value={filterVisibilityAdmin}
                         enumType={LibraryAdminVisibility}
                         setState={setFilterVisibilityAdmin}
                     />

--- a/frontend/src/Components/VideoContent.tsx
+++ b/frontend/src/Components/VideoContent.tsx
@@ -85,7 +85,7 @@ export default function VideoContent() {
                             />
                         </div>
                         <DropdownControl
-                            label="Order by"
+                            value={sortQuery}
                             setState={setSortQuery}
                             enumType={{
                                 'Title (A-Z)': 'title ASC',

--- a/frontend/src/Components/inputs/DropdownControl.tsx
+++ b/frontend/src/Components/inputs/DropdownControl.tsx
@@ -1,7 +1,7 @@
 import { Dispatch, SetStateAction } from 'react';
 
 interface DropdownControlProps {
-    label?: string;
+    value?: any; // eslint-disable-line
     setState?: Dispatch<SetStateAction<string>>;
     customCallback?: (value: string) => void;
     enumType: Record<string, string>;
@@ -9,7 +9,7 @@ interface DropdownControlProps {
 
 /* a dropdown that executes a callback function on change */
 export default function DropdownControl({
-    label,
+    value,
     setState: callback,
     customCallback,
     enumType
@@ -17,7 +17,7 @@ export default function DropdownControl({
     return (
         <label className="form-control">
             <select
-                defaultValue={label}
+                value={value} // eslint-disable-line
                 className="select select-bordered"
                 onChange={(e) => {
                     if (callback) {
@@ -28,13 +28,6 @@ export default function DropdownControl({
                     }
                 }}
             >
-                {label ? (
-                    <option value="" disabled>
-                        {label}
-                    </option>
-                ) : (
-                    ''
-                )}
                 {Object.entries(enumType).map(([key, value]) => (
                     <option key={key} value={value}>
                         {key}

--- a/frontend/src/Pages/AdminLayer1.tsx
+++ b/frontend/src/Pages/AdminLayer1.tsx
@@ -51,6 +51,7 @@ export default function AdminLayer1() {
             <div className="flex flex-row justify-between items-center">
                 <h2>Insights</h2>
                 <DropdownControl
+                    value={timeFilter}
                     enumType={FilterPastTime}
                     setState={setTimeFilter}
                 />

--- a/frontend/src/Pages/AdminManagement.tsx
+++ b/frontend/src/Pages/AdminManagement.tsx
@@ -153,7 +153,7 @@ export default function AdminManagement() {
                             changeCallback={handleChange}
                         />
                         <DropdownControl
-                            label="order by"
+                            value={sortQuery}
                             setState={setSortQuery}
                             enumType={{
                                 'Name (A-Z)': 'name_last asc',

--- a/frontend/src/Pages/CourseCatalog.tsx
+++ b/frontend/src/Pages/CourseCatalog.tsx
@@ -42,7 +42,7 @@ export default function CourseCatalog() {
                     changeCallback={handleSearch}
                 />
                 <DropdownControl
-                    label="order"
+                    value={order}
                     setState={setOrder}
                     enumType={{
                         Ascending: 'asc',

--- a/frontend/src/Pages/Favorites.tsx
+++ b/frontend/src/Pages/Favorites.tsx
@@ -54,7 +54,7 @@ export default function FavoritesPage() {
                         changeCallback={handleChange}
                     />
                     <DropdownControl
-                        label="Order by"
+                        value={sortQuery}
                         setState={setSortQuery}
                         enumType={FilterLibrariesVidsandHelpfulLinksResident}
                     />

--- a/frontend/src/Pages/HelpfulLinks.tsx
+++ b/frontend/src/Pages/HelpfulLinks.tsx
@@ -61,7 +61,7 @@ export default function HelpfulLinks() {
                         changeCallback={handleChange}
                     />
                     <DropdownControl
-                        label="Order by"
+                        value={sortQuery}
                         setState={setSortQuery}
                         enumType={FilterLibrariesVidsandHelpfulLinksResident}
                     />

--- a/frontend/src/Pages/HelpfulLinksManagement.tsx
+++ b/frontend/src/Pages/HelpfulLinksManagement.tsx
@@ -109,7 +109,7 @@ export default function HelpfulLinksManagement() {
                         changeCallback={handleChange}
                     />
                     <DropdownControl
-                        label="Order by"
+                        value={sortQuery}
                         setState={setSortQuery}
                         enumType={FilterLibrariesVidsandHelpfulLinksResident}
                     />

--- a/frontend/src/Pages/MyCourses.tsx
+++ b/frontend/src/Pages/MyCourses.tsx
@@ -67,7 +67,7 @@ export default function MyCourses() {
                         changeCallback={handleChange}
                     />
                     <DropdownControl
-                        label="Sort by"
+                        value={sort}
                         setState={setSort}
                         enumType={{
                             'Name (A-Z)': 'order=asc&order_by=course_name',

--- a/frontend/src/Pages/MyProgress.tsx
+++ b/frontend/src/Pages/MyProgress.tsx
@@ -76,7 +76,7 @@ export default function MyProgress() {
                             <div className="flex flex-row justify-between">
                                 <h2 className="mt-2">All Courses</h2>
                                 <DropdownControl
-                                    label="Sort by"
+                                    value={sortCourses}
                                     customCallback={handleSortCourses}
                                     enumType={{
                                         Name: 'order=asc&order_by=course_name',

--- a/frontend/src/Pages/ProgramOverviewDashboard.tsx
+++ b/frontend/src/Pages/ProgramOverviewDashboard.tsx
@@ -152,7 +152,7 @@ export default function ProgramOverview() {
                         changeCallback={handleChange}
                     />
                     <DropdownControl
-                        label="order by"
+                        value={sortQuery}
                         setState={setSortQuery}
                         enumType={{
                             'Facility (A-Z)': 'facility_name asc',

--- a/frontend/src/Pages/StudentManagement.tsx
+++ b/frontend/src/Pages/StudentManagement.tsx
@@ -152,7 +152,7 @@ export default function StudentManagement() {
                             changeCallback={handleChange}
                         />
                         <DropdownControl
-                            label="order by"
+                            value={sortQuery}
                             setState={setSortQuery}
                             enumType={{
                                 'Name (A-Z)': 'name_last asc',

--- a/frontend/src/Pages/VideoManagement.tsx
+++ b/frontend/src/Pages/VideoManagement.tsx
@@ -137,7 +137,7 @@ export default function VideoManagement() {
                                 />
                             </div>
                             <DropdownControl
-                                label="Order by"
+                                value={sortQuery}
                                 setState={setSortQuery}
                                 enumType={
                                     FilterLibrariesVidsandHelpfulLinksAdmin


### PR DESCRIPTION
## Description of the change

1. Modified the SQL query used to pull data for the operational insights page. I wrapped the `SUM` function within a `COALESCE` function to handle null values that cause the page to error.
2. Fixed DropdownControl component bug. Removed the label feature and added the value to be used/set per load of page or user selection.

**NOTE** This is to fix an issue within the **maine** deployment

- **Related issues**: Link to Asana tickets 
- [Error viewing operational insights for 2nd facility](https://app.asana.com/0/home/1209552816160104/1210603280485519)
- [BUG: Video Filter Dropdown Glitch on https://maine.unlockedlabs.org](https://app.asana.com/1/1201607307149189/project/1207681524569251/task/1210346392552612?focus=true)


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1210603280485519