### PR TITLE
feat: add restore logic used for restoring rescheduled and cancelled events per ticket 198

### DIFF
--- a/backend/migrations/00052_alter_program_class_event_overrides.sql
+++ b/backend/migrations/00052_alter_program_class_event_overrides.sql
@@ -1,0 +1,15 @@
+-- +goose Up
+-- +goose StatementBegin
+ALTER TABLE public.program_class_event_overrides ADD COLUMN linked_override_event_id INTEGER REFERENCES public.program_class_event_overrides(id);
+ALTER TABLE program_class_event_overrides DROP CONSTRAINT unique_event_id_rrule;
+CREATE UNIQUE INDEX unique_event_id_rrule_idx ON program_class_event_overrides (event_id, override_rrule) WHERE deleted_at IS NULL;
+-- +goose StatementEnd
+
+-- +goose Down
+-- +goose StatementBegin
+ALTER TABLE public.program_class_event_overrides DROP COLUMN linked_override_event_id;
+DROP INDEX IF EXISTS unique_event_id_rrule_idx;
+--delete all records that have deleted_at 
+delete from public.program_class_event_overrides where deleted_at IS NOT NULL;
+ALTER TABLE public.program_class_event_overrides ADD CONSTRAINT unique_event_id_rrule UNIQUE (event_id, override_rrule);
+-- +goose StatementEnd

--- a/backend/src/models/class_event.go
+++ b/backend/src/models/class_event.go
@@ -96,13 +96,14 @@ func (event *ProgramClassEvent) RRuleUntil() (time.Time, error) {
 /** Overrides are used to cancel or reschedule events **/
 type ProgramClassEventOverride struct {
 	DatabaseFields
-	EventID       uint   `json:"event_id" gorm:"not null"`
-	Duration      string `json:"duration" gorm:"not null"`
-	OverrideRrule string `json:"override_rrule" gorm:"not null"`
-	ClassID       uint   `json:"class_id" gorm:"->" `
-	IsCancelled   bool   `json:"is_cancelled"`
-	Room          string `json:"room"`
-	Reason        string `json:"reason"`
+	EventID               uint   `json:"event_id" gorm:"not null"`
+	Duration              string `json:"duration" gorm:"not null"`
+	OverrideRrule         string `json:"override_rrule" gorm:"not null"`
+	ClassID               uint   `json:"class_id" gorm:"->" `
+	IsCancelled           bool   `json:"is_cancelled"`
+	Room                  string `json:"room"`
+	Reason                string `json:"reason"`
+	LinkedOverrideEventID *uint  `json:"linked_override_event_id"`
 
 	/* Foreign keys */
 	Event *ProgramClassEvent `json:"event" gorm:"foreignKey:EventID;references:ID"`
@@ -111,10 +112,7 @@ type ProgramClassEventOverride struct {
 func (ProgramClassEventOverride) TableName() string { return "program_class_event_overrides" }
 
 // format argument will take a string in the format of "2006-01-02", "1/02/2006", ect
-func (pce *ProgramClassEventOverride) GetFormattedCancelledDate(format string) (*string, error) {
-	if !pce.IsCancelled {
-		return StringPtr(""), nil
-	}
+func (pce *ProgramClassEventOverride) GetFormattedOverrideDate(format string) (*string, error) {
 	rRule, err := rrule.StrToRRule(pce.OverrideRrule)
 	if err != nil {
 		return nil, err
@@ -211,13 +209,15 @@ type EventDates struct {
 
 type FacilityProgramClassEvent struct {
 	ProgramClassEvent
-	InstructorName string     `json:"instructor_name"`
-	ProgramName    string     `json:"program_name"`
-	ClassName      string     `json:"title"`
-	IsCancelled    bool       `json:"is_cancelled"`
-	IsOverride     bool       `json:"is_override"`
-	EnrolledUsers  string     `json:"enrolled_users"`
-	StartTime      *time.Time `json:"start"`
-	EndTime        *time.Time `json:"end"`
-	Frequency      string     `json:"frequency"`
+	InstructorName      string                     `json:"instructor_name"`
+	ProgramName         string                     `json:"program_name"`
+	ClassName           string                     `json:"title"`
+	IsCancelled         bool                       `json:"is_cancelled"`
+	IsOverride          bool                       `json:"is_override"`
+	EnrolledUsers       string                     `json:"enrolled_users"`
+	StartTime           *time.Time                 `json:"start"`
+	EndTime             *time.Time                 `json:"end"`
+	Frequency           string                     `json:"frequency"`
+	OverrideID          uint                       `json:"override_id"`
+	LinkedOverrideEvent *FacilityProgramClassEvent `json:"linked_override_event" gorm:"-"`
 }

--- a/frontend/src/Components/cards/ActivityHistoryRowCard.tsx
+++ b/frontend/src/Components/cards/ActivityHistoryRowCard.tsx
@@ -66,6 +66,8 @@ function ActivityHistoryRowCard({
             case 'event_rescheduled_series':
                 text = `All future sessions rescheduled starting ${parseRRule(activity.new_value, user.timezone, true)} by ${activity.admin_username}`;
                 break;
+            case 'event_restored':
+                text = `${activity.admin_username} restored event on ${parseRRule(activity.old_value, user.timezone)}`;
         }
         return text;
     };

--- a/frontend/src/Components/helperFunctions/formatting.tsx
+++ b/frontend/src/Components/helperFunctions/formatting.tsx
@@ -121,3 +121,19 @@ export function textMonthLocalDate(date: string | Date) {
         });
     }
 }
+
+export function fromLocalDateToTime(date: Date) {
+    return date.toLocaleTimeString([], {
+        hour: '2-digit',
+        minute: '2-digit'
+    });
+}
+
+export function fromLocalDateToNumericDateFormat(date: Date, timezone: string) {
+    return date.toLocaleDateString('en-US', {
+        year: 'numeric',
+        month: 'numeric',
+        day: 'numeric',
+        timeZone: timezone
+    });
+}

--- a/frontend/src/Components/helperFunctions/index.ts
+++ b/frontend/src/Components/helperFunctions/index.ts
@@ -5,5 +5,7 @@ export {
     timeToMinutes,
     isEndDtBeforeStartDt,
     parseRRule,
-    parseRRuleUntilDate
+    parseRRuleUntilDate,
+    fromLocalDateToTime,
+    fromLocalDateToNumericDateFormat
 } from './formatting';

--- a/frontend/src/Components/modals/CancelClassEventModal.tsx
+++ b/frontend/src/Components/modals/CancelClassEventModal.tsx
@@ -24,6 +24,11 @@ export function createCancelledEvent(
             .slice(0, 15) + 'Z';
     const overrideRule = `DTSTART:${eventDtStart}\nRRULE:FREQ=DAILY;COUNT=1`;
     const formattedJson = {
+        ...(calendarEvent.linked_override_event && {
+            linked_override_event_id:
+                calendarEvent.linked_override_event.override_id
+        }),
+        ...(calendarEvent.is_override && { id: calendarEvent.override_id }),
         event_id: calendarEvent.id,
         class_id: calendarEvent.class_id,
         override_rrule: overrideRule,
@@ -38,10 +43,12 @@ export function createCancelledEvent(
 export const CancelClassEventModal = forwardRef(function (
     {
         calendarEvent,
-        mutate
+        mutate,
+        handleCallback
     }: {
         calendarEvent?: FacilityProgramClassEvent;
         mutate: KeyedMutator<ServerResponseMany<FacilityProgramClassEvent>>;
+        handleCallback?: () => void;
     },
     ref: React.ForwardedRef<HTMLDialogElement>
 ) {
@@ -77,6 +84,10 @@ export const CancelClassEventModal = forwardRef(function (
             'Failed to cancel event',
             'Successfully cancelled event'
         );
+
+        if (response.success && handleCallback) {
+            handleCallback();
+        }
     };
 
     useEffect(() => {

--- a/frontend/src/Components/modals/RescheduleClassEventSeriesModal.tsx
+++ b/frontend/src/Components/modals/RescheduleClassEventSeriesModal.tsx
@@ -28,10 +28,12 @@ import { parseRRuleUntilDate } from '../helperFunctions';
 export const RescheduleClassEventSeriesModal = forwardRef(function (
     {
         calendarEvent,
-        mutate
+        mutate,
+        handleCallback
     }: {
         calendarEvent?: FacilityProgramClassEvent;
         mutate: KeyedMutator<ServerResponseMany<FacilityProgramClassEvent>>;
+        handleCallback?: () => void;
     },
     ref: React.ForwardedRef<HTMLDialogElement>
 ) {
@@ -95,6 +97,10 @@ export const RescheduleClassEventSeriesModal = forwardRef(function (
             'The event series could not be updated',
             'The events in this series have been updated'
         );
+
+        if (response.success && handleCallback) {
+            handleCallback();
+        }
     };
 
     const rescheduleClassEventSeriesInputs: Input[] = [

--- a/frontend/src/Components/modals/RestoreClassEventModal.tsx
+++ b/frontend/src/Components/modals/RestoreClassEventModal.tsx
@@ -1,0 +1,180 @@
+import { forwardRef } from 'react';
+import { closeModal, TextModalType, TextOnlyModal } from '.';
+import { FacilityProgramClassEvent, ServerResponseMany } from '@/common';
+import API from '@/api/api';
+import { KeyedMutator } from 'swr';
+import { useCheckResponse } from '@/Hooks/useCheckResponse';
+// import { fromZonedTime } from 'date-fns-tz';
+import { useAuth } from '@/useAuth';
+import {
+    fromLocalDateToNumericDateFormat,
+    fromLocalDateToTime
+} from '../helperFunctions';
+import { toZonedTime } from 'date-fns-tz';
+
+export const RestoreClassEventModal = forwardRef(function (
+    {
+        calendarEvent,
+        mutate,
+        handleCallback
+    }: {
+        calendarEvent?: FacilityProgramClassEvent;
+        mutate: KeyedMutator<ServerResponseMany<FacilityProgramClassEvent>>;
+        handleCallback?: () => void;
+    },
+    ref: React.ForwardedRef<HTMLDialogElement>
+) {
+    const { user } = useAuth();
+    if (!user) {
+        return null;
+    }
+    const checkResponse = useCheckResponse({
+        mutate: mutate,
+        refModal: ref
+    });
+
+    function buildRestoreEventMessage(): string {
+        let scheduledDate = '';
+        let startTime = '';
+        let endTime = '';
+        let frequency = '';
+        let recurrencePhrase = '';
+        const timezone = user ? user.timezone : '';
+        if (calendarEvent) {
+            const isLinkedEvent = calendarEvent.linked_override_event
+                ? true
+                : false;
+            scheduledDate = isLinkedEvent
+                ? fromLocalDateToNumericDateFormat(
+                      toZonedTime(
+                          calendarEvent.linked_override_event.start,
+                          timezone
+                      ),
+                      timezone
+                  )
+                : fromLocalDateToNumericDateFormat(
+                      calendarEvent.start,
+                      timezone
+                  );
+            frequency = calendarEvent.frequency;
+            startTime = fromLocalDateToTime(
+                isLinkedEvent
+                    ? toZonedTime(
+                          calendarEvent.linked_override_event.start,
+                          timezone
+                      )
+                    : calendarEvent.start
+            );
+            endTime = fromLocalDateToTime(
+                isLinkedEvent
+                    ? toZonedTime(
+                          calendarEvent.linked_override_event.end,
+                          timezone
+                      )
+                    : calendarEvent.end
+            );
+            const rulePartMap = parseRRule(calendarEvent.recurrence_rule);
+            recurrencePhrase = buildRecurrencePhrase(rulePartMap);
+        }
+        const message = `This event was originally scheduled for ${scheduledDate} as part of a ${frequency} series that meets every ${recurrencePhrase} at ${startTime} - ${endTime}`;
+        return message;
+    }
+
+    function parseRRule(rRule: string) {
+        const ruleSplit = rRule.split('\n');
+        const rRuleOnly =
+            ruleSplit.length > 1
+                ? rRule.split('\n')[1].replace('RRULE:', '')
+                : '';
+        const rruleParts: Record<string, string> = {};
+        rRuleOnly.split(';').forEach((part) => {
+            const [key, value] = part.split('=');
+            rruleParts[key] = value;
+        });
+        return rruleParts;
+    }
+
+    function getDayNames(bydayStr: string): string[] {
+        if (!bydayStr) return [];
+        const dayMap: Record<string, string> = {
+            MO: 'Monday',
+            TU: 'Tuesday',
+            WE: 'Wednesday',
+            TH: 'Thursday',
+            FR: 'Friday',
+            SA: 'Saturday',
+            SU: 'Sunday'
+        };
+        return bydayStr.split(',').map((d) => dayMap[d]);
+    }
+
+    function buildRecurrencePhrase(rrule: Record<string, string>) {
+        const freq = rrule.FREQ;
+        const interval = Number(rrule.INTERVAL || '1');
+        const byday = getDayNames(rrule.BYDAY);
+        const freqMap: Record<string, string> = {
+            DAILY: 'day',
+            WEEKLY: 'week',
+            MONTHLY: 'month',
+            YEARLY: 'year'
+        };
+
+        const byUnit = freqMap[freq] || 'period';
+        let rRulePhrase = '';
+        if (interval === 1) {
+            rRulePhrase = `every ${byUnit}`;
+        } else if (interval === 2) {
+            rRulePhrase = `every other ${byUnit}`;
+        } else {
+            rRulePhrase = `every ${interval} ${interval === 1 ? byUnit : byUnit + 's'}`;
+        }
+
+        if ((freq === 'WEEKLY' || freq === 'MONTHLY') && byday.length) {
+            rRulePhrase +=
+                ' on ' +
+                (byday.length > 1
+                    ? byday.join(', ').replace(/, ([^,]*)$/, ' and $1')
+                    : byday[0]);
+        }
+        return rRulePhrase;
+    }
+
+    async function onConfirm() {
+        if (!calendarEvent) return;
+        const response = await API.delete(
+            `program-classes/${calendarEvent.class_id}/events/${calendarEvent.override_id}`
+        );
+        checkResponse(
+            response.success,
+            'Failed to restore event',
+            'Successfully restored event'
+        );
+        if (response.success && handleCallback) {
+            handleCallback();
+        }
+    }
+
+    return (
+        <TextOnlyModal
+            ref={ref}
+            type={TextModalType.Confirm}
+            title={'Restore Event'}
+            text={
+                <div>
+                    <p className="mb-4">
+                        {calendarEvent?.is_cancelled ||
+                        calendarEvent?.is_override
+                            ? buildRestoreEventMessage()
+                            : ''}
+                    </p>
+                    <p>
+                        Restoring will move this event back to its original time
+                        on the schedule.
+                    </p>
+                </div>
+            }
+            onSubmit={() => void onConfirm()}
+            onClose={() => closeModal(ref)}
+        />
+    );
+});

--- a/frontend/src/Components/modals/index.ts
+++ b/frontend/src/Components/modals/index.ts
@@ -349,3 +349,11 @@ export const requestContentInputs: Input[] = [
 export { RequestContentModal } from './RequestContentModal';
 
 export { ResidentAttendanceModal } from './ResidentAttendanceModal';
+
+export { RestoreClassEventModal } from './RestoreClassEventModal';
+
+export { CancelClassEventModal } from './CancelClassEventModal';
+
+export { RescheduleClassEventModal } from './RescheduleClassEventModal';
+
+export { RescheduleClassEventSeriesModal } from './RescheduleClassEventSeriesModal';

--- a/frontend/src/common.ts
+++ b/frontend/src/common.ts
@@ -816,6 +816,8 @@ export interface FacilityProgramClassEvent extends ProgramClassEvent {
     start: Date;
     end: Date;
     frequency: string;
+    override_id: number;
+    linked_override_event: FacilityProgramClassEvent;
 }
 
 export interface CalendarEvent {


### PR DESCRIPTION
## Description of the change

Added the necessary logic for being able to restore rescheduled/cancelled events. This consisted of many backend api additions and modifications as well as some frontend CSS/HTML/JS work.

NOTE: Still working out the DST issue, so if anyone has any inside knowledge of DST and javascript Date objects please feel free to reach out. I'm researching how to disable DST for events shown on the calendar so the times do not shift during daylight savings time.

- [x] Restoring cancelled events.
- [x] Restoring rescheduled one-off events (e.g., originally Tuesday, moved to Monday).
- [x] "Restore Event" button shows in the Event Details panel for cancelled or edited events.
- [x] Canceled events do not show "Cancel Event" or "Edit Series" button.
- [x] Fixing the "Edit Event" button for stand-alone events that are rescheduled as part of a series.
- [x] Updating the side details pane after editing/restoring an event (series).
- [x] Update the tooltips to reflect the correct messaging if actions are disabled.
- [x] Change log history reflects restored events
- [ ] Fix DST

- **Related issues**: Link to related issue(s) this PR addresses, asana: [Restore Rescheduled / Cancelled Event (Feature + Fix)](https://app.asana.com/1/1201607307149189/project/1209460078641109/task/1210197345470691?focus=true) .