### PR TITLE
fix: total programs and enrollments for facility admin pull from latest date

### DIFF
--- a/frontend/src/Pages/ProgramManagement.tsx
+++ b/frontend/src/Pages/ProgramManagement.tsx
@@ -244,7 +244,7 @@ export default function ProgramManagement() {
                             : total_programs.toString()
                     }
                     label={'programs'}
-                    tooltip="Count of unique programs offered across all facilities."
+                    tooltip={`Count of unique programs offered ${user?.role === UserRole.FacilityAdmin ? 'at ' + user.facility_name : 'across all facilities'}.`}
                     useToLocaleString={false}
                 />
                 {user?.role !== UserRole.FacilityAdmin && (


### PR DESCRIPTION
## Description of the change
Bug was found where the facility admins total programs was not reflected correctly in their program management page. This was due to a bug that totaled all programs for all days within the time filter. The solution was to extract the total programs and enrollments into its own query, only pulling the most recent date for these numbers.

- **Related issues**: Fixes [Asana Ticket ID-298](https://app.asana.com/1/1201607307149189/project/1209460078641109/task/1210487095566664?focus=true). This should also address the issues we had with [ID-329](https://app.asana.com/1/1201607307149189/project/1209460078641109/task/1210615552064401?focus=true), where the facility admin numbers were off (they are the same bug I believe, but correct if I misinterpreted the ticket(s)).

## Screenshot(s)

Below is what a super admin will see (all totals across all facilities)
![Screenshot 2025-06-30 at 10 51 08 AM](https://github.com/user-attachments/assets/a26acaf1-6c22-47be-8ded-70e087593b8a)

Below is what a facility admin will see (total programs for their facility specifically.
![Screenshot 2025-06-30 at 10 51 25 AM](https://github.com/user-attachments/assets/36e65575-7f49-4f06-96c8-6f60efae0cad)


## Additional context

Bug was originally thought to be displaying the totals of all facilities, but it was actually just over-calculating the number of programs across a greater time frame (rather than just pulling the most recent totals).