### PR TITLE
fix: fixed last, first for add enrollments

### DIFF
--- a/frontend/src/Pages/AddClassEnrollments.tsx
+++ b/frontend/src/Pages/AddClassEnrollments.tsx
@@ -235,6 +235,7 @@ export default function AddClassEnrollments() {
                                             </td>
                                             <td>
                                                 {user.name_last}
+                                                {', '}
                                                 {user.name_first}
                                             </td>
                                             <td>{user.doc_id}</td>


### PR DESCRIPTION
The name was shown as `lastnamefirstname` with no space between it. Corrected it so that its `lastname, firstname`