### PR TITLE
fix: user circle icon wasn't centered on resident profile

### DIFF
--- a/frontend/src/Pages/ResidentProfile.tsx
+++ b/frontend/src/Pages/ResidentProfile.tsx
@@ -190,7 +190,7 @@ const ResidentProfile = () => {
                 <div className="space-y-6">
                     <div className="flex flex-row gap-6">
                         <div className="card card-row-padding flex flex-col justify-center flex-[0_0_340px]">
-                            <div className="justify-items-center">
+                            <div className="flex justify-center">
                                 <UserCircleIcon className="w-24" />
                             </div>
                             <h1 className="text-center mb-2">


### PR DESCRIPTION
## Description of the change

This change centers the user profile icon on the resident profile page

**Screenshots:**
Before
![image](https://github.com/user-attachments/assets/0fa7d456-eb5e-48ae-8a63-453955015b92)

After
![image](https://github.com/user-attachments/assets/9a28df21-1af3-4554-a7c9-6c81ab475214)
