### PR TITLE
fix: unlocked not pulling correct number of libraries and not able to download videos

### DIFF
--- a/config/zims.sh
+++ b/config/zims.sh
@@ -6,9 +6,9 @@ ZIM_COUNT=$(find ./csvs/zims -type f -name "*.zim" | wc -l)
 
 if [ "$ZIM_COUNT" -eq 0 ]; then
     echo "No ZIM files found. Downloading..."
-    wget -q https://download.kiwix.org/zim/devdocs/devdocs_en_go_2025-01.zim -P ./csvs/zims
-    wget -q https://download.kiwix.org/zim/devdocs/devdocs_en_bash_2025-01.zim -P ./csvs/zims
-    wget -q https://download.kiwix.org/zim/devdocs/devdocs_en_c_2025-01.zim -P ./csvs/zims
+    wget -q https://download.kiwix.org/zim/devdocs/devdocs_en_go_2025-04.zim -P ./csvs/zims
+    wget -q https://download.kiwix.org/zim/devdocs/devdocs_en_bash_2025-04.zim -P ./csvs/zims
+    wget -q https://download.kiwix.org/zim/devdocs/devdocs_en_c_2025-04.zim -P ./csvs/zims
 else
     echo "ZIM files already exist. No download needed."
 fi

--- a/provider-middleware/kiwix.go
+++ b/provider-middleware/kiwix.go
@@ -15,7 +15,7 @@ import (
 )
 
 const (
-	KiwixCatalogUrl = "/catalog/v2/entries?lang=eng&start=1&count="
+	KiwixCatalogUrl = "/catalog/v2/entries?lang=eng&start=0&count="
 )
 
 var maxLibraries = sync.OnceValue(func() int {

--- a/provider-middleware/video_dl.go
+++ b/provider-middleware/video_dl.go
@@ -456,7 +456,7 @@ func (yt *VideoService) downloadVideo(ctx context.Context, vidInfo *goutubedl.Re
 		ctx,
 		"yt-dlp",
 		"-f", "bv*+ba/b",
-		"-S ", "res:480,ext:mp4",
+		"-S", "res:480,ext:mp4",
 		"--merge-output-format", "mp4",
 		"--remux-video", "mp4",
 		"--restrict-filenames",


### PR DESCRIPTION
## Description of the change

Fixed the following issues:
- UnlockEd only pulling one less library than Kiwix server contains
    - changed a kiwix api endpoint's start parameter value from 1 to 0. 
- UnlockEd unable to download YT videos
    - removed a space from an argument within the yt-dlp command

- **Related issues**: Link to asana tickets: [UnlockEd only pulling one less library than Kiwix server contains](https://app.asana.com/1/1201607307149189/project/1209460078641109/task/1210756515444541?focus=true) and [UnlockEd unable to download YT videos](https://app.asana.com/1/1201607307149189/project/1209460078641109/task/1210769523245497?focus=true) 

ALSO: Fixed issue with `make init` due to 404 status code returning when attempting to download zim files

Video Issue:
[video-issue.webm](https://github.com/user-attachments/assets/44020f2d-0f92-42d6-a338-b9ebb0584482)

Kiwix Issue:
[libraries.webm](https://github.com/user-attachments/assets/788f4dad-e52d-4e32-b378-0a663e9840b6)
