### PR TITLE
fix: refactored attendance page ux

### DIFF
--- a/frontend/src/Components/AttendanceStatusToggle.tsx
+++ b/frontend/src/Components/AttendanceStatusToggle.tsx
@@ -15,14 +15,19 @@ export default function AttendanceStatusToggle({
     value,
     onChange
 }: AttendanceStatusToggleProps) {
+    const buttonClass = `flex flex-1 items-center justify-center gap-2 rounded-md px-4 py-2 text-base`;
+
     return (
         <div className="inline-flex w-fit gap-3">
             <button
-                className={`flex flex-1 items-center justify-center gap-2 rounded-md bg-grey-1 px-4 py-2 text-base ${
-                    value === Attendance.Present
-                        ? 'bg-teal-3 opacity-70 hover:shadow-md text-white'
-                        : 'bg-grey-1 hover:bg-grey-2'
-                }`}
+                className={
+                    buttonClass +
+                    ` ${
+                        value === Attendance.Present
+                            ? 'bg-teal-3 opacity-70 hover:shadow-md text-white'
+                            : 'bg-grey-1 hover:bg-grey-2'
+                    }`
+                }
                 onClick={() => onChange(Attendance.Present)}
                 type="button"
             >
@@ -30,11 +35,14 @@ export default function AttendanceStatusToggle({
                 <label className="body-small cursor-pointer">Present</label>
             </button>
             <button
-                className={`flex flex-1 items-center justify-center gap-2 rounded-md px-4 py-2 text-base ${
-                    value === Attendance.Absent_Excused
-                        ? 'bg-pale-yellow hover:shadow-md text-base'
-                        : 'bg-grey-1 hover:bg-grey-2'
-                }`}
+                className={
+                    buttonClass +
+                    ` ${
+                        value === Attendance.Absent_Excused
+                            ? 'bg-pale-yellow hover:shadow-md text-base'
+                            : 'bg-grey-1 hover:bg-grey-2'
+                    }`
+                }
                 onClick={() => onChange(Attendance.Absent_Excused)}
                 type="button"
             >
@@ -42,11 +50,14 @@ export default function AttendanceStatusToggle({
                 <label className="body-small cursor-pointer">Excused</label>
             </button>
             <button
-                className={`flex flex-1 items-center justify-center gap-2 rounded-md bg-grey-1 px-4 py-2 text-base ${
-                    value === Attendance.Absent_Unexcused
-                        ? 'bg-red-2 opacity-80 hover:shadow-md text-white'
-                        : 'bg-grey-1 hover:bg-grey-2'
-                }`}
+                className={
+                    buttonClass +
+                    ` ${
+                        value === Attendance.Absent_Unexcused
+                            ? 'bg-red-2 opacity-80 hover:shadow-md text-white'
+                            : 'bg-grey-1 hover:bg-grey-2'
+                    }`
+                }
                 onClick={() => onChange(Attendance.Absent_Unexcused)}
                 type="button"
             >

--- a/frontend/src/Components/AttendanceStatusToggle.tsx
+++ b/frontend/src/Components/AttendanceStatusToggle.tsx
@@ -1,0 +1,58 @@
+import {
+    CheckIcon,
+    ShieldCheckIcon,
+    XMarkIcon
+} from '@heroicons/react/24/outline';
+import ULIComponent from './ULIComponent';
+import { Attendance } from '@/common';
+
+interface AttendanceStatusToggleProps {
+    value?: Attendance;
+    onChange: (value: Attendance) => void;
+}
+
+export default function AttendanceStatusToggle({
+    value,
+    onChange
+}: AttendanceStatusToggleProps) {
+    return (
+        <div className="inline-flex w-fit gap-3">
+            <button
+                className={`flex flex-1 items-center justify-center gap-2 rounded-md bg-grey-1 px-4 py-2 text-base ${
+                    value === Attendance.Present
+                        ? 'bg-teal-3 opacity-70 text-white'
+                        : 'bg-grey-1 hover:bg-grey-2'
+                }`}
+                onClick={() => onChange(Attendance.Present)}
+                type="button"
+            >
+                <ULIComponent icon={CheckIcon} />
+                <label className="body-small cursor-pointer">Present</label>
+            </button>
+            <button
+                className={`flex flex-1 items-center justify-center gap-2 rounded-md px-4 py-2 text-base ${
+                    value === Attendance.Absent_Excused
+                        ? 'bg-pale-yellow text-base'
+                        : 'bg-grey-1 hover:bg-grey-2'
+                }`}
+                onClick={() => onChange(Attendance.Absent_Excused)}
+                type="button"
+            >
+                <ULIComponent icon={ShieldCheckIcon} />
+                <label className="body-small cursor-pointer">Excused</label>
+            </button>
+            <button
+                className={`flex flex-1 items-center justify-center gap-2 rounded-md bg-grey-1 px-4 py-2 text-base ${
+                    value === Attendance.Absent_Unexcused
+                        ? 'bg-red-2 opacity-80 text-white'
+                        : 'bg-grey-1 hover:bg-grey-2'
+                }`}
+                onClick={() => onChange(Attendance.Absent_Unexcused)}
+                type="button"
+            >
+                <ULIComponent icon={XMarkIcon} />
+                <label className="body-small cursor-pointer">Unexcused</label>
+            </button>
+        </div>
+    );
+}

--- a/frontend/src/Components/AttendanceStatusToggle.tsx
+++ b/frontend/src/Components/AttendanceStatusToggle.tsx
@@ -20,7 +20,7 @@ export default function AttendanceStatusToggle({
             <button
                 className={`flex flex-1 items-center justify-center gap-2 rounded-md bg-grey-1 px-4 py-2 text-base ${
                     value === Attendance.Present
-                        ? 'bg-teal-3 opacity-70 text-white'
+                        ? 'bg-teal-3 opacity-70 hover:shadow-md text-white'
                         : 'bg-grey-1 hover:bg-grey-2'
                 }`}
                 onClick={() => onChange(Attendance.Present)}
@@ -32,7 +32,7 @@ export default function AttendanceStatusToggle({
             <button
                 className={`flex flex-1 items-center justify-center gap-2 rounded-md px-4 py-2 text-base ${
                     value === Attendance.Absent_Excused
-                        ? 'bg-pale-yellow text-base'
+                        ? 'bg-pale-yellow hover:shadow-md text-base'
                         : 'bg-grey-1 hover:bg-grey-2'
                 }`}
                 onClick={() => onChange(Attendance.Absent_Excused)}
@@ -44,7 +44,7 @@ export default function AttendanceStatusToggle({
             <button
                 className={`flex flex-1 items-center justify-center gap-2 rounded-md bg-grey-1 px-4 py-2 text-base ${
                     value === Attendance.Absent_Unexcused
-                        ? 'bg-red-2 opacity-80 text-white'
+                        ? 'bg-red-2 opacity-80 hover:shadow-md text-white'
                         : 'bg-grey-1 hover:bg-grey-2'
                 }`}
                 onClick={() => onChange(Attendance.Absent_Unexcused)}

--- a/frontend/src/Components/inputs/TextInput.tsx
+++ b/frontend/src/Components/inputs/TextInput.tsx
@@ -19,6 +19,7 @@ interface TextProps {
     defaultValue?: string;
     onChange?: React.ChangeEventHandler<HTMLInputElement>;
     placeholder?: string;
+    inputClassName?: string;
 }
 export function TextInput({
     label,
@@ -35,7 +36,8 @@ export function TextInput({
     disabled = false,
     defaultValue,
     onChange,
-    placeholder
+    placeholder,
+    inputClassName
 }: TextProps) {
     const options = {
         required: {
@@ -63,7 +65,7 @@ export function TextInput({
 
             <input
                 type={`${password ? 'password' : 'text'}`}
-                className={`input input-bordered w-full`}
+                className={`input input-bordered w-full ${inputClassName}`}
                 {...restRegisterProps}
                 autoComplete={autoComplete}
                 defaultValue={defaultValue}

--- a/frontend/src/Pages/EventAttendance.tsx
+++ b/frontend/src/Pages/EventAttendance.tsx
@@ -188,8 +188,7 @@ export default function EventAttendance() {
             doc_id: '',
             name_last: '',
             name_first: '',
-            attendance_status: newStatus,
-            note: ''
+            attendance_status: newStatus
         };
         setModifiedRows((prev) => ({
             ...prev,
@@ -197,7 +196,9 @@ export default function EventAttendance() {
                 ...currentRow,
                 ...prev[user_id],
                 selected: true,
-                attendance_status: newStatus
+                attendance_status: newStatus,
+                note:
+                    newStatus === Attendance.Present ? '' : prev[user_id]?.note
             }
         }));
     }
@@ -295,19 +296,12 @@ export default function EventAttendance() {
                         void handleSubmit(onSubmit)(e);
                     }}
                 >
-                    <div
-                        className="relative w-full"
-                        style={{ overflowX: 'clip' }}
-                    >
+                    <div className="relative w-full">
                         <table className="table-2 mb-5">
                             <thead>
-                                <tr className="grid-cols-[1fr_1fr_350px_1fr] grid gap-2">
-                                    <th className="justify-self-start px-3">
-                                        Name
-                                    </th>
-                                    <th className="justify-self-start">
-                                        Resident ID
-                                    </th>
+                                <tr className="grid-cols-[1fr_1fr_350px_1fr] grid gap-2 px-2">
+                                    <th>Name</th>
+                                    <th>Resident ID</th>
                                     <th className="">Status</th>
                                     <th className="">Note</th>
                                 </tr>
@@ -316,18 +310,18 @@ export default function EventAttendance() {
                                 {rows.map((row) => (
                                     <tr
                                         key={row.user_id}
-                                        className="card w-full justify-items-center grid-cols-[1fr_1fr_350px_1fr] grid cursor-pointer p-2 gap-2"
+                                        className="card w-full justify-items-center grid-cols-[1fr_1fr_350px_1fr] grid p-2 gap-2"
                                     >
-                                        <td className="justify-self-start">
+                                        <td>
                                             {row.name_last}, {row.name_first}
                                         </td>
-                                        <td className="justify-self-start">
+                                        <td>
                                             {' '}
                                             {row.doc_id == ''
                                                 ? ' '
                                                 : `${row.doc_id}`}
                                         </td>
-                                        <td className="flex justify-center">
+                                        <td className="flex">
                                             <AttendanceStatusToggle
                                                 value={
                                                     row.attendance_status ??
@@ -343,11 +337,26 @@ export default function EventAttendance() {
                                                 }
                                             />
                                         </td>
-
-                                        <td className="justify-self-end align-middle">
+                                        <td className="">
                                             <TextInput
                                                 label=""
                                                 defaultValue={row.note}
+                                                disabled={
+                                                    !(
+                                                        row.attendance_status &&
+                                                        row.attendance_status !==
+                                                            Attendance.Present
+                                                    )
+                                                }
+                                                inputClassName={
+                                                    !(
+                                                        row.attendance_status &&
+                                                        row.attendance_status !==
+                                                            Attendance.Present
+                                                    )
+                                                        ? 'opacity-40'
+                                                        : ''
+                                                }
                                                 interfaceRef={`note_${row.user_id}`}
                                                 required={false}
                                                 length={500}
@@ -399,7 +408,7 @@ export default function EventAttendance() {
                 ref={markAllPresentModal}
                 type={TextModalType.Confirm}
                 title="Mark All Present"
-                text={`Are you sure you want to mark all ${rows.length} residents on this page as Present? This action will override any existing attendance status.`}
+                text={`Are you sure you want to mark all ${rows.length} residents on this page as "Present"? This will override any existing attendance status.`}
                 onSubmit={() => void handleMarkAllPresent()}
                 onClose={() => void closeModal(markAllPresentModal)}
             />

--- a/frontend/src/Pages/EventAttendance.tsx
+++ b/frontend/src/Pages/EventAttendance.tsx
@@ -26,6 +26,7 @@ import Error from '@/Pages/Error';
 import { parseLocalDay } from '@/Components/helperFunctions/formatting';
 import { useToast } from '@/Context/ToastCtx';
 import { isCompletedCancelledOrArchived } from './ProgramOverviewDashboard';
+import { CancelButton } from '@/Components/inputs';
 
 interface LocalRowData {
     selected: boolean;
@@ -454,16 +455,13 @@ export default function EventAttendance() {
                         </table>
                     </div>
                     <div className="flex gap-4 justify-end pt-4 ">
-                        <button
-                            className="button bg-grey"
+                        <CancelButton
                             onClick={() =>
                                 navigate(
                                     `/program-classes/${class_id}/attendance`
                                 )
                             }
-                        >
-                            Cancel
-                        </button>
+                        />
                         <button
                             type="submit"
                             className={`button ${tooltip}`}

--- a/frontend/src/Pages/EventAttendance.tsx
+++ b/frontend/src/Pages/EventAttendance.tsx
@@ -302,16 +302,7 @@ export default function EventAttendance() {
                         <table className="table-2 mb-5">
                             <thead>
                                 <tr className="grid-cols-[1fr_1fr_350px_1fr] grid gap-2">
-                                    <th className="justify-self-start space-x-2 px-3">
-                                        {/* <input
-                                            type="checkbox"
-                                            checked={
-                                                rows.length > 0 &&
-                                                rows.every((r) => r.selected)
-                                            }
-                                            onChange={handleSelectAll}
-                                            className="checkbox cursor-pointer"
-                                        /> */}
+                                    <th className="justify-self-start px-3">
                                         Name
                                     </th>
                                     <th className="justify-self-start">
@@ -327,18 +318,8 @@ export default function EventAttendance() {
                                         key={row.user_id}
                                         className="card w-full justify-items-center grid-cols-[1fr_1fr_350px_1fr] grid cursor-pointer p-2 gap-2"
                                     >
-                                        <td className="justify-self-start space-x-2">
-                                            {/* <input
-                                                type="checkbox"
-                                                checked={row.selected}
-                                                onChange={() =>
-                                                    handleToggleSelect(
-                                                        row.user_id
-                                                    )
-                                                }
-                                                className="checkbox cursor-pointer"
-                                            /> */}
-                                            {row.name_last}, {row.name_first}{' '}
+                                        <td className="justify-self-start">
+                                            {row.name_last}, {row.name_first}
                                         </td>
                                         <td className="justify-self-start">
                                             {' '}

--- a/frontend/src/Pages/EventAttendance.tsx
+++ b/frontend/src/Pages/EventAttendance.tsx
@@ -1,4 +1,4 @@
-import { startTransition, useEffect, useState } from 'react';
+import { startTransition, useEffect, useState, useRef } from 'react';
 import {
     useParams,
     useNavigate,
@@ -27,6 +27,13 @@ import { parseLocalDay } from '@/Components/helperFunctions/formatting';
 import { useToast } from '@/Context/ToastCtx';
 import { isCompletedCancelledOrArchived } from './ProgramOverviewDashboard';
 import { CancelButton } from '@/Components/inputs';
+import AttendanceStatusToggle from '@/Components/AttendanceStatusToggle';
+import {
+    TextOnlyModal,
+    TextModalType,
+    showModal,
+    closeModal
+} from '@/Components/modals';
 
 interface LocalRowData {
     selected: boolean;
@@ -81,6 +88,7 @@ export default function EventAttendance() {
         Record<number, LocalRowData>
     >({});
     const { toaster } = useToast();
+    const markAllPresentModal = useRef<HTMLDialogElement>(null);
     const {
         data: dates,
         error: datesError,
@@ -173,39 +181,6 @@ export default function EventAttendance() {
         }));
     }
 
-    function handleToggleSelect(user_id: number) {
-        const currentRow =
-            modifiedRows[user_id] || rows.find((r) => r.user_id === user_id);
-        const newSelected = !(currentRow?.selected ?? false);
-
-        setModifiedRows((prev) => ({
-            ...prev,
-            [user_id]: {
-                ...currentRow,
-                selected: newSelected,
-                attendance_status: newSelected
-                    ? currentRow?.attendance_status ?? Attendance.Present
-                    : undefined
-            }
-        }));
-    }
-    function handleSelectAll() {
-        const allSelected = rows.every((row) => row.selected);
-        setModifiedRows((prev) => {
-            const newModifications = { ...prev };
-            rows.forEach((row) => {
-                newModifications[row.user_id] = {
-                    ...(prev[row.user_id] || row),
-                    selected: !allSelected,
-                    attendance_status: !allSelected
-                        ? Attendance.Present
-                        : undefined
-                };
-            });
-            return newModifications;
-        });
-    }
-
     function handleAttendanceChange(user_id: number, newStatus: Attendance) {
         const currentRow = rows.find((r) => r.user_id === user_id) ?? {
             selected: false,
@@ -260,7 +235,9 @@ export default function EventAttendance() {
 
             return newMods;
         });
+        closeModal(markAllPresentModal);
     }
+
     async function onSubmit() {
         if (blockEdits) {
             toaster(
@@ -289,9 +266,9 @@ export default function EventAttendance() {
                     />
                 </div>
                 <button
-                    onClick={() => void handleMarkAllPresent()}
-                    disabled={anyRowSelected || blockEdits}
-                    className={`button ${tooltip} ${anyRowSelected ? `bg-grey-4 cursor-not-allowed` : ``}`}
+                    onClick={() => showModal(markAllPresentModal)}
+                    disabled={blockEdits}
+                    className={`button ${tooltip}`}
                     data-tip={
                         blockEdits
                             ? `This class is ${clsInfo?.status.toLowerCase()} and cannot be modified.`
@@ -324,9 +301,9 @@ export default function EventAttendance() {
                     >
                         <table className="table-2 mb-5">
                             <thead>
-                                <tr className="grid-cols-4 grid ">
+                                <tr className="grid-cols-[1fr_1fr_350px_1fr] grid gap-2">
                                     <th className="justify-self-start space-x-2 px-3">
-                                        <input
+                                        {/* <input
                                             type="checkbox"
                                             checked={
                                                 rows.length > 0 &&
@@ -334,11 +311,13 @@ export default function EventAttendance() {
                                             }
                                             onChange={handleSelectAll}
                                             className="checkbox cursor-pointer"
-                                        />
-                                        <span>Last, First</span>
+                                        /> */}
+                                        Name
                                     </th>
-                                    <th>Resident ID</th>
-                                    <th className="">Attendance</th>
+                                    <th className="justify-self-start">
+                                        Resident ID
+                                    </th>
+                                    <th className="">Status</th>
                                     <th className="">Note</th>
                                 </tr>
                             </thead>
@@ -346,10 +325,10 @@ export default function EventAttendance() {
                                 {rows.map((row) => (
                                     <tr
                                         key={row.user_id}
-                                        className="card w-full justify-items-center grid-cols-4 cursor-pointer p-2"
+                                        className="card w-full justify-items-center grid-cols-[1fr_1fr_350px_1fr] grid cursor-pointer p-2 gap-2"
                                     >
                                         <td className="justify-self-start space-x-2">
-                                            <input
+                                            {/* <input
                                                 type="checkbox"
                                                 checked={row.selected}
                                                 onChange={() =>
@@ -358,78 +337,30 @@ export default function EventAttendance() {
                                                     )
                                                 }
                                                 className="checkbox cursor-pointer"
-                                            />
-                                            <span>
-                                                {row.name_last},{' '}
-                                                {row.name_first}{' '}
-                                            </span>
+                                            /> */}
+                                            {row.name_last}, {row.name_first}{' '}
                                         </td>
-                                        <td className="items-center">
+                                        <td className="justify-self-start">
                                             {' '}
                                             {row.doc_id == ''
                                                 ? ' '
                                                 : `${row.doc_id}`}
                                         </td>
-                                        <td className="flex justify-center space-x-2">
-                                            <label className="flex items-center space-x-1 cursor-pointer">
-                                                <input
-                                                    type="radio"
-                                                    name={`attendance_${row.user_id}`}
-                                                    disabled={!row.selected}
-                                                    checked={
-                                                        row.attendance_status ===
-                                                            Attendance.Present ||
-                                                        (!row.attendance_status && // default to present when selected row
-                                                            row.selected)
-                                                    }
-                                                    onChange={() =>
-                                                        handleAttendanceChange(
-                                                            row.user_id,
-                                                            Attendance.Present
-                                                        )
-                                                    }
-                                                    className="radio cursor-pointer"
-                                                />
-                                                <span>Present</span>
-                                            </label>
-                                            <label className="flex items-center space-x-1 cursor-pointer">
-                                                <input
-                                                    type="radio"
-                                                    name={`attendance_${row.user_id}`}
-                                                    disabled={!row.selected}
-                                                    checked={
-                                                        row.attendance_status ===
-                                                        Attendance.Absent_Excused
-                                                    }
-                                                    onChange={() =>
-                                                        handleAttendanceChange(
-                                                            row.user_id,
-                                                            Attendance.Absent_Excused
-                                                        )
-                                                    }
-                                                    className="radio cursor-pointer"
-                                                />
-                                                <span>Absent - excused</span>
-                                            </label>
-                                            <label className="flex items-center space-x-1 cursor-pointer">
-                                                <input
-                                                    type="radio"
-                                                    name={`attendance_${row.user_id}`}
-                                                    disabled={!row.selected}
-                                                    checked={
-                                                        row.attendance_status ===
-                                                        Attendance.Absent_Unexcused
-                                                    }
-                                                    onChange={() =>
-                                                        handleAttendanceChange(
-                                                            row.user_id,
-                                                            Attendance.Absent_Unexcused
-                                                        )
-                                                    }
-                                                    className="radio cursor-pointer"
-                                                />
-                                                <span>Absent - unexcused</span>
-                                            </label>
+                                        <td className="flex justify-center">
+                                            <AttendanceStatusToggle
+                                                value={
+                                                    row.attendance_status ??
+                                                    (row.selected
+                                                        ? Attendance.Present
+                                                        : undefined)
+                                                }
+                                                onChange={(newStatus) =>
+                                                    handleAttendanceChange(
+                                                        row.user_id,
+                                                        newStatus
+                                                    )
+                                                }
+                                            />
                                         </td>
 
                                         <td className="justify-self-end align-middle">
@@ -483,6 +414,14 @@ export default function EventAttendance() {
                     />
                 </div>
             )}
+            <TextOnlyModal
+                ref={markAllPresentModal}
+                type={TextModalType.Confirm}
+                title="Mark All Present"
+                text={`Are you sure you want to mark all ${rows.length} residents on this page as Present? This action will override any existing attendance status.`}
+                onSubmit={() => void handleMarkAllPresent()}
+                onClose={() => void closeModal(markAllPresentModal)}
+            />
         </div>
     );
 }


### PR DESCRIPTION
## Description of the change

This PR isn't attached to an open ticket. 

The Attendance page (`EventAttendance`) was improved to provide a better user experience while recording attendance. No new functionality was added. All focus was on visual feedback and a more intuitive UI. The user no longer needs to check rows before editing them or look through a column of radio buttons.

### Changes

**UI Improvements**
- New `AttendanceStatusToggle` component to replace the radio buttons with an easier to use toggle button interface for three states: Present, Excused, and Unexcused.
  - The values have color-coded buttons (used some opacity so the teal and red weren't as strong) and icons to go with them, along with hover states for interactivity.
- Improved the table layout. The table layout has some better spacing, more accurate column headings, and only one fixed-width column for the toggle buttons.

**UX Enhancehemtns**
- Added a confirmation modal when the user clicks "Mark All Present" to prevent accidental bulk updates.
  - This was a conflicting UX with the Select All checkbox, so I removed that and the checkbox for each row.
- Confirmation modal shows a clear message indicating how many residents will be affected and warns the user about overriding the existing status.
- Removed hard-coded cancel button and added `<CancelButton />` component.

**Considerations**
- I considered disabling the notes field until the user selected Excused/Unexcused but found that all of the color on the page from teal/yellow/red and disabled/enabled text boxes to be a bit much. **This could be better.**
- The page could show a better empty state when there aren't any students enrolled 


## Screenshot(s)

**After**
<img width="2218" height="1276" alt="image" src="https://github.com/user-attachments/assets/d94afbfe-6215-4907-8c52-f3e024a9ccdc" />
<img width="1162" height="641" alt="image" src="https://github.com/user-attachments/assets/fc5bc6a9-23a7-428f-bc2e-6fd098cc8f80" />


**Before**
<img width="2230" height="1188" alt="image" src="https://github.com/user-attachments/assets/5155dc54-0ff2-4a57-8823-4dcef7f3a570" />




## Additional context

**Known Bugs**
- I discovered a different bug while working on this that is dependent on a future task. Right now if you Cancel or Complete a class and try to view the recorded attendance, the page doesn't show any of the recorded data. This is because the query on the backend looks for users with `Enrolled` status and we update their status to `Cancelled` or `Completed` when we change the class status. **Fix:** The fix for this will be to look at their enrollment window date. A future migration will include `enrolled_at` and `enrollment_ended_at` columns to support this.

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1210803595216573