### PR TITLE
Add Timestamps for Enrollment Start and End in Resident Program Status

### DIFF
--- a/backend/migrations/00053_add_timestamps_program_classes.sql
+++ b/backend/migrations/00053_add_timestamps_program_classes.sql
@@ -1,0 +1,14 @@
+-- +goose Up
+-- +goose StatementBegin
+ALTER TABLE program_class_enrollments
+ADD COLUMN enrolled_at TIMESTAMP,
+ADD COLUMN enrollment_ended_at TIMESTAMP;
+-- +goose StatementEnd
+
+
+-- +goose Down
+-- +goose StatementBegin
+ALTER TABLE program_class_enrollments
+DROP COLUMN IF EXISTS enrolled_at,
+DROP COLUMN IF EXISTS enrollment_ended_at;
+-- +goose StatementEnd

--- a/backend/migrations/00053_add_timestamps_program_classes.sql
+++ b/backend/migrations/00053_add_timestamps_program_classes.sql
@@ -3,6 +3,15 @@
 ALTER TABLE program_class_enrollments
 ADD COLUMN enrolled_at TIMESTAMP,
 ADD COLUMN enrollment_ended_at TIMESTAMP;
+UPDATE program_class_enrollments SET enrolled_at = created_at 
+WHERE (enrollment_status = 'Enrolled' OR enrollment_status = 'Cancelled' OR enrollment_status = 'Completed' 
+OR enrollment_status LIKE 'Incomplete:%')
+AND enrolled_at IS NULL;
+
+UPDATE program_class_enrollments SET enrollment_ended_at = updated_at
+WHERE (enrollment_status = 'Cancelled' OR enrollment_status = 'Completed' 
+OR enrollment_status LIKE 'Incomplete:%')
+AND enrollment_ended_at IS NULL;
 -- +goose StatementEnd
 
 

--- a/backend/src/models/program_classes.go
+++ b/backend/src/models/program_classes.go
@@ -2,9 +2,10 @@ package models
 
 import (
 	"encoding/json"
-	"gorm.io/gorm"
 	"strings"
 	"time"
+
+	"gorm.io/gorm"
 )
 
 type ClassStatus string
@@ -75,16 +76,15 @@ func (e *ProgramClassEnrollment) BeforeCreate(tx *gorm.DB) (err error) {
 }
 
 func (e *ProgramClassEnrollment) BeforeUpdate(tx *gorm.DB) (err error) {
-	if tx.Statement.Changed("EnrollmentStatus") {
-
-		t := time.Now()
-		if e.EnrollmentStatus == "Enrolled" {
-			e.EnrolledAt = &t
-		} else if e.EnrollmentStatus == "Cancelled" ||
-			e.EnrollmentStatus == "Completed" ||
-			strings.HasPrefix(string(e.EnrollmentStatus), "Incomplete:") {
-			e.EnrollmentEndedAt = &t
-		}
+	t := time.Now()
+	if e.EnrollmentStatus == "Enrolled" {
+		e.EnrolledAt = &t
+		tx.Statement.SetColumn("enrolled_at", e.EnrolledAt)
+	} else if e.EnrollmentStatus == "Cancelled" ||
+		e.EnrollmentStatus == "Completed" ||
+		strings.HasPrefix(string(e.EnrollmentStatus), "Incomplete:") {
+		e.EnrollmentEndedAt = &t
+		tx.Statement.SetColumn("enrolled_at", e.EnrollmentEndedAt)
 	}
 	return nil
 }


### PR DESCRIPTION
## Description of the change

- [x] Added `enrolled_at` and `enrollment_ended_at` columns via DB migration
- [x] Created a PostgreSQL trigger to manage timestamp updates via [hooks](https://gorm.io/docs/hooks.html)

## Screenshot(s)

## Additional context

Linked to Asna task: https://app.asana.com/1/1201607307149189/project/1209460078641109/task/1210701398297639