### PR TITLE
fix: knowledge center search modal sizing

### DIFF
--- a/frontend/src/Components/LibrarySearchResultsModal.tsx
+++ b/frontend/src/Components/LibrarySearchResultsModal.tsx
@@ -253,8 +253,8 @@ const LibrarySearchResultsModal = forwardRef<
 
     return (
         <dialog ref={ref} className="modal" onClose={handleCloseModal}>
-            <div className="w-[1200px] h-[700px] bg-background rounded-lg shadow-lg flex flex-col">
-                <div className="sticky top-0 bg-background z-50 p-4 border-b border-grey-2 rounded-t-lg">
+            <div className="w-[min(90vw,1200px)] h-[min(85vh,700px)] bg-background rounded-lg shadow-lg flex flex-col">
+                <div className="flex-shrink-0 bg-background z-50 p-4 border-b border-grey-2 rounded-t-lg">
                     <div className="flex items-center gap-4">
                         <div className="flex flex-col">
                             <h2 className="text-2xl">{searchResults.title}</h2>
@@ -317,43 +317,45 @@ const LibrarySearchResultsModal = forwardRef<
                         </div>
                     )}
                 </div>
-                <div
-                    ref={scrollContainerRef}
-                    className="flex flex-col gap-4 overflow-y-auto p-4 scrollbar"
-                >
-                    {searchResults.items?.map((item, index) => (
-                        <LibrarySearchResultCard
-                            key={index}
-                            item={item}
-                            onItemClick={navToViewer}
-                        />
-                    ))}
+
+                <div className="flex-1 min-h-0 flex flex-col">
+                    {isLoading ? (
+                        <div className="flex-1 flex gap-4 justify-center items-center">
+                            <span className="loading loading-spinner loading-lg"></span>
+                            <p className="text-lg">Loading...</p>
+                        </div>
+                    ) : searchError ? (
+                        <div className="flex-1 flex gap-4 justify-center items-center">
+                            <p className="text-lg text-error">{searchError}</p>
+                        </div>
+                    ) : searchResults.title === 'Search' ? (
+                        <div className="flex-1 flex gap-4 justify-center items-center">
+                            <p className="text-lg">Press 'Enter' to search</p>
+                        </div>
+                    ) : searchResults.items &&
+                      searchResults.items.length === 0 ? (
+                        <div className="flex-1 flex gap-4 justify-center items-center">
+                            <p className="text-lg">No Results Found</p>
+                        </div>
+                    ) : (
+                        <div
+                            ref={scrollContainerRef}
+                            className="flex-1 min-h-0 overflow-y-auto p-4 scrollbar"
+                        >
+                            <div className="flex flex-col gap-4">
+                                {searchResults.items?.map((item, index) => (
+                                    <LibrarySearchResultCard
+                                        key={index}
+                                        item={item}
+                                        onItemClick={navToViewer}
+                                    />
+                                ))}
+                            </div>
+                        </div>
+                    )}
                 </div>
-                {isLoading ? (
-                    <div className="flex h-screen gap-4 justify-center content-center">
-                        <span className="my-auto loading loading-spinner loading-lg"></span>
-                        <p className="my-auto text-lg">Loading...</p>
-                    </div>
-                ) : searchError ? (
-                    <div className="flex h-screen gap-4 justify-center content-center">
-                        <p className="my-auto text-lg text-error">
-                            {searchError}
-                        </p>
-                    </div>
-                ) : searchResults.title === 'Search' ? (
-                    <div className="flex h-screen gap-4 justify-center content-center">
-                        <p className="my-auto text-lg">
-                            Press 'Enter' to search
-                        </p>
-                    </div>
-                ) : searchResults.items && searchResults.items.length === 0 ? (
-                    <div className="flex h-screen gap-4 justify-center content-center">
-                        <p className="my-auto text-lg">No Results Found</p>
-                    </div>
-                ) : (
-                    ' '
-                )}
-                <div className="border-t border-grey-2 px-6 py-4 flex justify-center rounded-b-lg">
+
+                <div className="flex-shrink-0 border-t border-grey-2 px-6 py-4 flex justify-center rounded-b-lg">
                     <Pagination
                         meta={meta}
                         setPage={handleSetPage}

--- a/frontend/src/Components/LibrarySearchResultsModal.tsx
+++ b/frontend/src/Components/LibrarySearchResultsModal.tsx
@@ -253,8 +253,8 @@ const LibrarySearchResultsModal = forwardRef<
 
     return (
         <dialog ref={ref} className="modal" onClose={handleCloseModal}>
-            <div className="relative w-[min(90vw,1200px)]  h-[min(90vh,900px)]] bg-background rounded-lg shadow-lg flex flex-col">
-                <div className="flex-shrink-0 bg-background z-50 p-4 border-b border-grey-2 rounded-t-lg">
+            <div className="w-[min(90vw,1200px)]  h-[min(90vh,900px)] bg-background rounded-lg shadow-lg flex flex-col">
+                <div className="relative flex-shrink-0 bg-background z-50 p-4 border-b border-grey-2 rounded-t-lg">
                     <div className="flex items-center gap-4">
                         <div className="flex flex-col">
                             <h2 className="text-2xl">{searchResults.title}</h2>

--- a/frontend/src/Components/LibrarySearchResultsModal.tsx
+++ b/frontend/src/Components/LibrarySearchResultsModal.tsx
@@ -253,7 +253,7 @@ const LibrarySearchResultsModal = forwardRef<
 
     return (
         <dialog ref={ref} className="modal" onClose={handleCloseModal}>
-            <div className="w-[min(90vw,1200px)] h-[min(85vh,700px)] bg-background rounded-lg shadow-lg flex flex-col">
+            <div className="relative w-[min(90vw,1200px)]  h-[min(90vh,900px)]] bg-background rounded-lg shadow-lg flex flex-col">
                 <div className="flex-shrink-0 bg-background z-50 p-4 border-b border-grey-2 rounded-t-lg">
                     <div className="flex items-center gap-4">
                         <div className="flex flex-col">

--- a/frontend/src/Components/cards/LibrarySearchResultCard.tsx
+++ b/frontend/src/Components/cards/LibrarySearchResultCard.tsx
@@ -8,7 +8,33 @@ export default function LibrarySearchResultCard({
     onItemClick: (kind: string, url: string, title: string, id: number) => void;
 }) {
     const boldKeywords = (description: string) => {
-        const rawPieces = description.split(/<b>(.*?)<\/b>/g);
+        // Truncates description. Chose ~60 words to be similar to Google search results
+        const truncateDescription = (text: string, wordLimit = 60) => {
+            const words = text.split(/\s+/);
+            if (words.length <= wordLimit) return text;
+
+            let wordCount = 0;
+            let result = '';
+            let inBoldTag = false;
+
+            for (const word of words) {
+                if (word.includes('<b>')) inBoldTag = true;
+                if (!inBoldTag || word.includes('</b>')) wordCount++;
+                if (word.includes('</b>')) inBoldTag = false;
+
+                result += word + ' ';
+
+                if (wordCount >= wordLimit) {
+                    result += '...';
+                    break;
+                }
+            }
+
+            return result.trim();
+        };
+
+        const truncated = truncateDescription(description);
+        const rawPieces = truncated.split(/<b>(.*?)<\/b>/g);
         const elements = rawPieces.map((word, index) =>
             index % 2 === 1 ? <strong key={index}>{word}</strong> : word
         );
@@ -16,7 +42,7 @@ export default function LibrarySearchResultCard({
     };
     return (
         <div
-            className="card card-row-padding cursor-pointer"
+            className="card cursor-pointer p-3 hover:bg-grey-1 rounded-md"
             onClick={() =>
                 onItemClick(
                     item.content_type,
@@ -26,23 +52,23 @@ export default function LibrarySearchResultCard({
                 )
             }
         >
-            <div className="flex items-center gap-4 border-b pb-2 mb-2">
-                <div className="flex p-4 gap-2">
-                    <figure className="w-[48px] h-[48px] bg-cover rounded-md overflow-hidden">
+            <div className="mb-2">
+                <div className="flex items-center gap-2 mb-1">
+                    <figure className="w-[24px] h-[24px] flex-shrink-0 bg-cover rounded overflow-hidden">
                         <img
                             src={item.thumbnail_url ?? '/kiwix.jpg'}
                             alt={`${item.title} thumbnail`}
                             className="w-full h-full object-cover"
                         />
                     </figure>
+                    <p className="body text-grey-4">{item.title}</p>
                 </div>
-                <div>
-                    <h3 className="text-lg font-bold">{item.page_title}</h3>
-                    <p className="body">{item.title}</p>
-                </div>
-            </div>
-            <div className="mt-2">
-                <p className="body-small">
+
+                <h3 className="text-lg text-teal-3 hover:underline mb-2 leading-tight">
+                    {item.page_title}
+                </h3>
+
+                <p className="body text-body-text">
                     {item.description ? boldKeywords(item.description) : null}
                 </p>
             </div>


### PR DESCRIPTION
## Description of the change
This PR fixes the issue with the search functionality of the knowledge center and how the user, particularly on a secure book is/was unable to reach the bottom of the search results, or modal, disallowing them the ability to click on subsequent pages of results. 

- **Related issues**: https://app.asana.com/1/1201607307149189/project/1209460078641109/task/1210825285656046?focus=true

## Screenshot(s)
27" Monitor
<img width="2551" height="1401" alt="image" src="https://github.com/user-attachments/assets/6439b6d6-7cbf-4f68-9e97-2e7cb598f913" />

Laptop Monitor Chrome
<img width="1903" height="940" alt="image" src="https://github.com/user-attachments/assets/e7b10836-ec4d-43b7-8b70-62ddbaf97bb2" />

Chrome Securebook dimensions
<img width="1235" height="685" alt="image" src="https://github.com/user-attachments/assets/db295ea0-9915-442f-8988-4476a8f6a123" />

Firefox Securebook dimensions
<img width="1676" height="815" alt="image" src="https://github.com/user-attachments/assets/ccdf6e6c-c53b-40e9-af31-fd0cda2dea36" />



## Additional context
Prior to this PR the LibrarySearchModal had a set modal height, and was placed inside of a dialog element, which as a result stopped the modal from being able to scroll relative to it's parent page, essentially being constrained by the viewport. With a header of approximately 125px, and a footer of approximately 80px, together this leaves like 500px left for the actual flexible content area, and on a 768px screen (secure book) it just doesn't add up to being enough room, particularly on these odd, and weird resolutions. Second to that, my-auto was stopping the flex items from shrinking smaller than the content they were wrapping, so even though we were using auto in terms of overflow and height, the container was trying to be as tall as all of the content combined.  What this PR essentially does, is locks in the header and footer dimensions, but allows the content area to be dynamic, making sure that the overflow doesn't cause the modal to reach outside of appropriate dimensions. 