### PR TITLE
fix: add code to download videos to local disk and upload to s3 bucket per ticket 409

### DIFF
--- a/backend/go.mod
+++ b/backend/go.mod
@@ -25,6 +25,8 @@ require (
 	gorm.io/gorm v1.25.12
 )
 
+require github.com/aws/aws-sdk-go v1.55.7 // indirect
+
 require (
 	github.com/aws/aws-sdk-go-v2/aws/protocol/eventstream v1.6.7 // indirect
 	github.com/aws/aws-sdk-go-v2/credentials v1.17.48 // indirect

--- a/backend/go.sum
+++ b/backend/go.sum
@@ -1,3 +1,5 @@
+github.com/aws/aws-sdk-go v1.55.7 h1:UJrkFq7es5CShfBwlWAC8DA077vp8PyVbQd3lqLiztE=
+github.com/aws/aws-sdk-go v1.55.7/go.mod h1:eRwEWoyTWFMVYVQzKMNHWP5/RV4xIUGMQfXQHfHkpNU=
 github.com/aws/aws-sdk-go-v2 v1.36.3 h1:mJoei2CxPutQVxaATCzDUjcZEjVRdpsiiXi2o38yqWM=
 github.com/aws/aws-sdk-go-v2 v1.36.3/go.mod h1:LLXuLpgzEbD766Z5ECcRmi8AzSwfZItDtmABVkRLGzg=
 github.com/aws/aws-sdk-go-v2/aws/protocol/eventstream v1.6.7 h1:lL7IfaFzngfx0ZwUGOZdsFFnQ5uLvR0hWqqhyE7Q9M8=

--- a/provider-middleware/video_dl.go
+++ b/provider-middleware/video_dl.go
@@ -459,7 +459,7 @@ func (yt *VideoService) downloadVideo(ctx context.Context, vidInfo *goutubedl.Re
 		vidInfo = &result
 	}
 
-	// if we already have the video on disk, skip the download
+	// if we already have the video in the S3 bucket, skip the download
 	if yt.videoExistsInS3(ctx, vidInfo.Info.ID) {
 		return nil
 	}


### PR DESCRIPTION
## Description of the change

Updated the yt-dlp download process to follow this flow of logic:

1. Download the video to local disk storage
2. Upload video to S3 bucket
3. Delete video from local disk storage

- **Related issues**:  Link to asana ticket [YT Videos unable to be downloaded directly to S3 bucket](https://app.asana.com/1/1201607307149189/project/1209460078641109/task/1210874048031369?focus=true)

## Additional context

NOTE: This change will only be able to be tested once deployed to staging due to our local development environment not being configured to utilitze the S3 bucket. It should still function and download the files while testing locally.
