### PR TITLE
fix: modified the reason field in the UI for attendance to be required

### DIFF
--- a/frontend/src/Components/inputs/TextInput.tsx
+++ b/frontend/src/Components/inputs/TextInput.tsx
@@ -39,7 +39,7 @@ export function TextInput({
     onChange,
     placeholder,
     inputClassName,
-    errorTextAlign = 'center'
+    errorTextAlign
 }: TextProps) {
     const options = {
         required: {
@@ -85,7 +85,7 @@ export function TextInput({
                         ? 'text-center'
                         : errorTextAlign === 'right'
                           ? 'text-right'
-                          : ''
+                          : 'text-left'
                 }`}
             >
                 {errors[interfaceRef]?.message as string}

--- a/frontend/src/Components/inputs/TextInput.tsx
+++ b/frontend/src/Components/inputs/TextInput.tsx
@@ -39,7 +39,7 @@ export function TextInput({
     onChange,
     placeholder,
     inputClassName,
-    errorTextAlign = 'left'
+    errorTextAlign = 'center'
 }: TextProps) {
     const options = {
         required: {

--- a/frontend/src/Components/inputs/TextInput.tsx
+++ b/frontend/src/Components/inputs/TextInput.tsx
@@ -77,7 +77,7 @@ export function TextInput({
                 }}
                 placeholder={placeholder}
             />
-            <div className="text-error text-sm">
+            <div className="text-error text-sm text-center">
                 {errors[interfaceRef]?.message as string}
             </div>
         </label>

--- a/frontend/src/Components/inputs/TextInput.tsx
+++ b/frontend/src/Components/inputs/TextInput.tsx
@@ -7,6 +7,7 @@ interface TextProps {
     required?: boolean;
     length: number | undefined;
     errors: FieldErrors<any>; // eslint-disable-line
+    errorTextAlign?: 'left' | 'center' | 'right';
     register: UseFormRegister<any>; // eslint-disable-line
     password?: boolean;
     isFocused?: boolean;
@@ -37,7 +38,8 @@ export function TextInput({
     defaultValue,
     onChange,
     placeholder,
-    inputClassName
+    inputClassName,
+    errorTextAlign = 'left'
 }: TextProps) {
     const options = {
         required: {
@@ -77,7 +79,15 @@ export function TextInput({
                 }}
                 placeholder={placeholder}
             />
-            <div className="text-error text-sm text-center">
+            <div
+                className={`text-error text-sm ${
+                    errorTextAlign === 'center'
+                        ? 'text-center'
+                        : errorTextAlign === 'right'
+                          ? 'text-right'
+                          : ''
+                }`}
+            >
                 {errors[interfaceRef]?.message as string}
             </div>
         </label>

--- a/frontend/src/Pages/EventAttendance.tsx
+++ b/frontend/src/Pages/EventAttendance.tsx
@@ -376,6 +376,7 @@ export default function EventAttendance() {
                                                         e.target.value
                                                     )
                                                 }
+                                                errorTextAlign="center"
                                             />
                                         </td>
                                     </tr>

--- a/frontend/src/Pages/EventAttendance.tsx
+++ b/frontend/src/Pages/EventAttendance.tsx
@@ -57,6 +57,7 @@ export default function EventAttendance() {
     const {
         register,
         handleSubmit,
+        setValue,
         getValues,
         formState: { errors }
     } = useForm<FormData>();
@@ -182,6 +183,9 @@ export default function EventAttendance() {
     }
 
     function handleAttendanceChange(user_id: number, newStatus: Attendance) {
+        if (newStatus === Attendance.Present) {
+            setValue(`note_${user_id}`, '');
+        }
         const currentRow = rows.find((r) => r.user_id === user_id) ?? {
             selected: false,
             user_id: user_id,

--- a/frontend/src/Pages/EventAttendance.tsx
+++ b/frontend/src/Pages/EventAttendance.tsx
@@ -59,6 +59,7 @@ export default function EventAttendance() {
         handleSubmit,
         setValue,
         getValues,
+        clearErrors,
         formState: { errors }
     } = useForm<FormData>();
     const [searchTerm, setSearchTerm] = useState('');
@@ -185,6 +186,7 @@ export default function EventAttendance() {
     function handleAttendanceChange(user_id: number, newStatus: Attendance) {
         if (newStatus === Attendance.Present) {
             setValue(`note_${user_id}`, '');
+            clearErrors(`note_${user_id}`);
         }
         const currentRow = rows.find((r) => r.user_id === user_id) ?? {
             selected: false,

--- a/frontend/src/Pages/EventAttendance.tsx
+++ b/frontend/src/Pages/EventAttendance.tsx
@@ -358,7 +358,11 @@ export default function EventAttendance() {
                                                         : ''
                                                 }
                                                 interfaceRef={`note_${row.user_id}`}
-                                                required={false}
+                                                required={
+                                                    row.selected &&
+                                                    row.attendance_status !==
+                                                        Attendance.Present
+                                                }
                                                 length={500}
                                                 errors={errors}
                                                 register={register}


### PR DESCRIPTION
## Description of the change

Please provide a brief description of the changes included in this PR.
## The reason textbox is now required and clears whenever one switches back to "Present"
- **Related issues**: Link to related issue(s) this PR addresses, if any (use phrases like "fixes #1234" or "closes #1234").
[Require the reason field in the UI for Excused/Unexcused attendance](https://app.asana.com/1/1201607307149189/project/1209460078641109/task/1210842346686462) &
[Clear out notes text input when user selects present on attendance page ](https://app.asana.com/1/1201607307149189/project/1209460078641109/task/1210801792172853)
## Screenshot(s)

https://github.com/user-attachments/assets/68e8d68a-cd3a-4304-9437-d2e5b7984073


If the PR includes changes to the UI, please add screenshots or a brief screengrab to demonstrate the changes.

## Additional context

Please include any additional context or information that the reviewer may need to understand the PR.

If any core features or components were removed with this PR, please note them here so that they can be added to the wiki (see [Deprecated features and Components](https://github.com/UnlockedLabs/UnlockEdv2/wiki/Deprecated-Features-and-Components)).