### PR TITLE
Correctly dereference pointer values in change log generation

### DIFF
--- a/backend/src/models/change_log_entry.go
+++ b/backend/src/models/change_log_entry.go
@@ -36,14 +36,16 @@ func NewChangeLogEntry(tableName, fieldName string, oldValue, newValue *string, 
 }
 
 func derefToString(v reflect.Value) string {
-	if v.Kind() == reflect.Ptr && !v.IsNil() {
-		return fmt.Sprint(v.Elem().Interface())
-	}
-	if v.Kind() == reflect.Ptr && v.IsNil() {
-		return ""
+
+	for v.Kind() == reflect.Ptr {
+		if v.IsNil() {
+			return ""
+		}
+		v = v.Elem()
 	}
 	return fmt.Sprint(v.Interface())
 }
+
 func GenerateChangeLogEntries(oldRecord, updRecord interface{}, tableName string, parentID uint, userID uint, ignoreFieldNames []string) []ChangeLogEntry {
 	var entries []ChangeLogEntry
 	oldVal := reflect.ValueOf(oldRecord).Elem()


### PR DESCRIPTION
## Description of the change

Fixes an issue in the change log audit system where pointer values (e.g., *string, *int) were being logged as memory addresses instead of actual values.

What changed: 

Added derefToString() helper function to safely dereference reflect.Value fields during audit comparison.

Updated GenerateChangeLogEntries to use derefToString instead of fmt.Sprintf("%v", ...).

Why it matters
Previously, audit entries for pointer fields would show raw pointer addresses like 0xc0004d3080. This change ensures consistent, human-readable logs for all supported field types.

Asana Task: 400
🔗 [View in Asana](https://app.asana.com/1/1201607307149189/project/1209460078641109/task/1210839425550614)