### PR TITLE
fix: add logic to hide resident programs information when program hub feature is turned off

### DIFF
--- a/frontend/src/Pages/ResidentProfile.tsx
+++ b/frontend/src/Pages/ResidentProfile.tsx
@@ -1,5 +1,6 @@
 import useSWR, { mutate } from 'swr';
 import {
+    FeatureAccess,
     OpenContentResponse,
     ResidentAccountAction,
     ResidentEngagementProfile,
@@ -9,7 +10,7 @@ import {
     UserRole,
     ValidResident
 } from '@/common';
-import { isUserDeactivated } from '@/useAuth';
+import { hasFeature, isUserDeactivated } from '@/useAuth';
 import EngagementRateGraph from '@/Components/EngagementRateGraph';
 import { ResponsiveContainer } from 'recharts';
 import StatsCard from '@/Components/StatsCard';
@@ -350,9 +351,15 @@ const ResidentProfile = () => {
                     </div>
                     {/* Tables */}
                     <div className="grid grid-cols-2 gap-6">
-                        <div className="card card-row-padding col-span-2 w-full">
-                            <ResidentPrograms user_id={residentId ? residentId : ''} />
-                        </div>
+                        {hasFeature(user, FeatureAccess.ProgramAccess) ? (
+                            <div className="card card-row-padding col-span-2 w-full">
+                                <ResidentPrograms
+                                    user_id={residentId ? residentId : ''}
+                                />
+                            </div>
+                        ) : (
+                            ' '
+                        )}
                         <ActivityHistoryCard residentId={residentId} />
                         <div className="card card-row-padding">
                             <OpenContentCardToggle
@@ -393,8 +400,8 @@ const ResidentProfile = () => {
                                                                           items.title ??
                                                                           'Untitled'
                                                                       } *`
-                                                                    : (items.title ??
-                                                                      'Untitled')}
+                                                                    : items.title ??
+                                                                      'Untitled'}
                                                             </td>
                                                             <td className="justify-self-end">
                                                                 {items.total_hours.toFixed(

--- a/frontend/src/Pages/ResidentProfile.tsx
+++ b/frontend/src/Pages/ResidentProfile.tsx
@@ -351,14 +351,12 @@ const ResidentProfile = () => {
                     </div>
                     {/* Tables */}
                     <div className="grid grid-cols-2 gap-6">
-                        {hasFeature(user, FeatureAccess.ProgramAccess) ? (
+                        {hasFeature(user, FeatureAccess.ProgramAccess) && (
                             <div className="card card-row-padding col-span-2 w-full">
                                 <ResidentPrograms
                                     user_id={residentId ? residentId : ''}
                                 />
                             </div>
-                        ) : (
-                            ' '
                         )}
                         <ActivityHistoryCard residentId={residentId} />
                         <div className="card card-row-padding">


### PR DESCRIPTION
## Description of the change

I added a conditional for checking whether the feature for the Program hub is turned off or on. Based on this condition the Program History/Information is displayed to the user. 

- [X] When the Program Hub feature is off, the Program History on the Resident Profile should be hidden from the Resident tab entirely.

- **Related issues**: Link to related Asana ticket is [Hide Resident Programs info on Resident Tab when Program Hub is turned off](https://app.asana.com/1/1201607307149189/project/1209460078641109/task/1210958323931677?focus=true)

## Screenshot(s)
Program Hub ON
<img width="1642" height="902" alt="on" src="https://github.com/user-attachments/assets/542271ca-3037-43e3-a84f-b3fa10b10b60" />

Program Hub OFF
<img width="1882" height="802" alt="off" src="https://github.com/user-attachments/assets/5665502d-ed5e-4c9c-b108-47e97306fdb9" />

[onoff.webm](https://github.com/user-attachments/assets/bd87fac3-7e8a-4293-aeaa-7a3b4448a102)

## Additional context
NAVIGATION: Login (SuperAdmin) | Click SuperAdmin (popup) | Toggle "Program Hub" Feature On/Off | Click Residents | Click on a resident's name | See table either exists or doesn't
