### PR TITLE
fix: add logic to display enrollment status options based on class status per ticket 394

### DIFF
--- a/backend/go.mod
+++ b/backend/go.mod
@@ -25,8 +25,6 @@ require (
 	gorm.io/gorm v1.25.12
 )
 
-require github.com/aws/aws-sdk-go v1.55.7 // indirect
-
 require (
 	github.com/aws/aws-sdk-go-v2/aws/protocol/eventstream v1.6.7 // indirect
 	github.com/aws/aws-sdk-go-v2/credentials v1.17.48 // indirect

--- a/backend/go.sum
+++ b/backend/go.sum
@@ -1,5 +1,3 @@
-github.com/aws/aws-sdk-go v1.55.7 h1:UJrkFq7es5CShfBwlWAC8DA077vp8PyVbQd3lqLiztE=
-github.com/aws/aws-sdk-go v1.55.7/go.mod h1:eRwEWoyTWFMVYVQzKMNHWP5/RV4xIUGMQfXQHfHkpNU=
 github.com/aws/aws-sdk-go-v2 v1.36.3 h1:mJoei2CxPutQVxaATCzDUjcZEjVRdpsiiXi2o38yqWM=
 github.com/aws/aws-sdk-go-v2 v1.36.3/go.mod h1:LLXuLpgzEbD766Z5ECcRmi8AzSwfZItDtmABVkRLGzg=
 github.com/aws/aws-sdk-go-v2/aws/protocol/eventstream v1.6.7 h1:lL7IfaFzngfx0ZwUGOZdsFFnQ5uLvR0hWqqhyE7Q9M8=

--- a/backend/src/database/class_enrollments.go
+++ b/backend/src/database/class_enrollments.go
@@ -168,7 +168,7 @@ func (db *DB) GraduateEnrollments(ctx context.Context, adminEmail string, userId
 	return tx.Commit().Error
 }
 
-func (db *DB) UpdateProgramClassEnrollments(classId int, userIds []int, status string, changeReason *string) error {
+func (db *DB) UpdateProgramClassEnrollments(classId int, userIds []int, status models.ProgramEnrollmentStatus, changeReason *string) error {
 	updates := map[string]any{
 		"enrollment_status": status,
 	}

--- a/backend/src/handlers/class_enrollments.go
+++ b/backend/src/handlers/class_enrollments.go
@@ -114,13 +114,6 @@ func (srv *Server) handleUpdateProgramClassEnrollments(w http.ResponseWriter, r 
 	if err != nil {
 		return newInvalidIdServiceError(err, "class enrollment ID")
 	}
-	class, err := srv.Db.GetClassByID(classId)
-	if err != nil {
-		return newDatabaseServiceError(err)
-	}
-	if class.CannotUpdateClass() {
-		return newBadRequestServiceError(err, "cannot perform action on class that is completed cancelled or archived")
-	}
 	enrollment := struct {
 		EnrollmentStatus string  `json:"enrollment_status"`
 		UserIDs          []int   `json:"user_ids"`
@@ -131,6 +124,13 @@ func (srv *Server) handleUpdateProgramClassEnrollments(w http.ResponseWriter, r 
 	}
 	if enrollment.EnrollmentStatus == "" {
 		return newInvalidIdServiceError(errors.New("enrollment status is required"), "enrollment status")
+	}
+	class, err := srv.Db.GetClassByID(classId)
+	if err != nil {
+		return newDatabaseServiceError(err)
+	}
+	if class.CannotUpdateClassWithEnrollment(enrollment.EnrollmentStatus) {
+		return newBadRequestServiceError(err, "cannot perform action on class that is completed, cancelled, archived, class is scheduled and enrollment is not cancelled, or class is active and enrollment is cancelled")
 	}
 	switch enrollment.EnrollmentStatus {
 	case "Completed":

--- a/backend/src/handlers/class_enrollments.go
+++ b/backend/src/handlers/class_enrollments.go
@@ -115,9 +115,9 @@ func (srv *Server) handleUpdateProgramClassEnrollments(w http.ResponseWriter, r 
 		return newInvalidIdServiceError(err, "class enrollment ID")
 	}
 	enrollment := struct {
-		EnrollmentStatus string  `json:"enrollment_status"`
-		UserIDs          []int   `json:"user_ids"`
-		ChangeReason     *string `json:"change_reason,omitempty"`
+		EnrollmentStatus models.ProgramEnrollmentStatus `json:"enrollment_status"`
+		UserIDs          []int                          `json:"user_ids"`
+		ChangeReason     *string                        `json:"change_reason,omitempty"`
 	}{}
 	if err := json.NewDecoder(r.Body).Decode(&enrollment); err != nil {
 		return newJSONReqBodyServiceError(err)

--- a/backend/src/handlers/class_enrollments.go
+++ b/backend/src/handlers/class_enrollments.go
@@ -130,7 +130,7 @@ func (srv *Server) handleUpdateProgramClassEnrollments(w http.ResponseWriter, r 
 		return newDatabaseServiceError(err)
 	}
 	if class.CannotUpdateClassWithEnrollment(enrollment.EnrollmentStatus) {
-		return newBadRequestServiceError(err, "cannot perform action on class that is completed, cancelled, archived, class is scheduled and enrollment is not cancelled, or class is active and enrollment is cancelled")
+		return newBadRequestServiceError(err, "cannot perform action due to invalid class or enrollment status")
 	}
 	switch enrollment.EnrollmentStatus {
 	case "Completed":

--- a/backend/src/models/program_classes.go
+++ b/backend/src/models/program_classes.go
@@ -254,9 +254,9 @@ type ProgramClassesHistory struct {
 
 func (ProgramClassesHistory) TableName() string { return "program_classes_history" }
 
-func (pc *ProgramClass) CannotUpdateClassWithEnrollment(enrollmentStatus string) bool {
-	isScheduledAndNotCancelled := pc.Status == Scheduled && enrollmentStatus != "Cancelled"
-	isActiveAndCancelled := pc.Status == Active && enrollmentStatus == "Cancelled"
+func (pc *ProgramClass) CannotUpdateClassWithEnrollment(enrollmentStatus ProgramEnrollmentStatus) bool {
+	isScheduledAndNotCancelled := pc.Status == Scheduled && enrollmentStatus != EnrollmentCancelled
+	isActiveAndCancelled := pc.Status == Active && enrollmentStatus == EnrollmentCancelled
 	return pc.CannotUpdateClass() || isScheduledAndNotCancelled || isActiveAndCancelled
 }
 

--- a/backend/src/models/program_classes.go
+++ b/backend/src/models/program_classes.go
@@ -254,6 +254,12 @@ type ProgramClassesHistory struct {
 
 func (ProgramClassesHistory) TableName() string { return "program_classes_history" }
 
+func (pc *ProgramClass) CannotUpdateClassWithEnrollment(enrollmentStatus string) bool {
+	isScheduledAndNotCancelled := pc.Status == Scheduled && enrollmentStatus != "Cancelled"
+	isActiveAndCancelled := pc.Status == Active && enrollmentStatus == "Cancelled"
+	return pc.CannotUpdateClass() || isScheduledAndNotCancelled || isActiveAndCancelled
+}
+
 func (pc *ProgramClass) CannotUpdateClass() bool {
 	return pc.Status == Completed || pc.Status == Cancelled || pc.ArchivedAt != nil
 }

--- a/frontend/src/Pages/ClassEnrollmentDetails.tsx
+++ b/frontend/src/Pages/ClassEnrollmentDetails.tsx
@@ -160,7 +160,7 @@ export default function ClassEnrollmentDetails() {
                 // If one or more users are selected with the check-boxes, then they are going to be
                 // 'Graduated'. If selectedResidents is empty, that means the Dropdown is being used
                 // to change an individual status inline.
-                enrollment_status: changeStatusValue?.status ?? 'completed',
+                enrollment_status: changeStatusValue?.status ?? 'Completed',
                 user_ids:
                     selectedResidents.length > 0
                         ? selectedResidents
@@ -271,7 +271,7 @@ export default function ClassEnrollmentDetails() {
                                 'incomplete: failed to complete',
                             Transferred: 'incomplete: transferred',
                             Segregated: 'incomplete: segregated',
-                            Canceled: 'incomplete: cancelled'
+                            Cancelled: 'incomplete: cancelled'
                         }}
                     />
                 </div>

--- a/frontend/src/Pages/ClassEnrollmentDetails.tsx
+++ b/frontend/src/Pages/ClassEnrollmentDetails.tsx
@@ -217,7 +217,8 @@ export default function ClassEnrollmentDetails() {
             case SelectedClassStatus.Scheduled:
                 return Object.fromEntries(
                     Object.entries(EnrollmentStatusOptions).filter(
-                        ([value]) => value === 'Cancelled'
+                        ([value]) =>
+                            value === 'Cancelled' || value === 'Enrolled'
                     )
                 );
             case SelectedClassStatus.Active:

--- a/frontend/src/Pages/ClassEnrollmentDetails.tsx
+++ b/frontend/src/Pages/ClassEnrollmentDetails.tsx
@@ -283,15 +283,16 @@ export default function ClassEnrollmentDetails() {
                             : undefined
                     }
                 >
-                    {selectedResidents.length > 0 && (
-                        <button
-                            disabled={blockEdits}
-                            className="button"
-                            onClick={handleOpenModalGraduate}
-                        >
-                            Graduate Selected
-                        </button>
-                    )}
+                    {selectedResidents.length > 0 &&
+                        clsInfo?.status === SelectedClassStatus.Active && (
+                            <button
+                                disabled={blockEdits}
+                                className="button"
+                                onClick={handleOpenModalGraduate}
+                            >
+                                Graduate Selected
+                            </button>
+                        )}
                     <AddButton
                         label="Add Resident"
                         disabled={blockEdits}

--- a/frontend/src/Pages/ClassEnrollmentDetails.tsx
+++ b/frontend/src/Pages/ClassEnrollmentDetails.tsx
@@ -11,7 +11,9 @@ import {
     EnrollmentStatus,
     FilterResidentNames,
     ProgramCompletion,
-    ServerResponseMany
+    SelectedClassStatus,
+    ServerResponseMany,
+    ToastState
 } from '@/common';
 import API from '@/api/api';
 import {
@@ -27,6 +29,7 @@ import ClassEnrollmentDetailsTable from '@/Components/ClassEnrollmentDetailsTabl
 import { AddButton } from '@/Components/inputs';
 import { isCompletedCancelledOrArchived } from './ProgramOverviewDashboard';
 import { FieldValues } from 'react-hook-form';
+import { useToast } from '@/Context/ToastCtx';
 
 interface StatusChange {
     name_full: string;
@@ -39,6 +42,7 @@ export default function ClassEnrollmentDetails() {
     const navigate = useNavigate();
     const { redirect, class: clsInfo } = useLoaderData() as ClassLoaderData;
     const blockEdits = isCompletedCancelledOrArchived(clsInfo ?? ({} as Class));
+    const { toaster } = useToast();
 
     const [searchTerm, setSearchTerm] = useState('');
     const [sortQuery, setSortQuery] = useState<string>(
@@ -150,21 +154,33 @@ export default function ClassEnrollmentDetails() {
     const handleSubmitEnrollmentChange = async (reasonText?: string) => {
         if (!changeStatusValue) return;
         const { status, user_id } = changeStatusValue;
-        await API.patch(`program-classes/${class_id}/enrollments`, {
-            // If one or more users are selected with the check-boxes, then they are going to be
-            // 'Graduated'. If selectedResidents is empty, that means the Dropdown is being used
-            // to change an individual status inline.
-            enrollment_status: changeStatusValue?.status ?? 'completed',
-            user_ids:
-                selectedResidents.length > 0 ? selectedResidents : [user_id],
-            ...(requiresReason(status) && {
-                change_reason: reasonText?.trim()
-            })
-        });
+        const resp = await API.patch(
+            `program-classes/${class_id}/enrollments`,
+            {
+                // If one or more users are selected with the check-boxes, then they are going to be
+                // 'Graduated'. If selectedResidents is empty, that means the Dropdown is being used
+                // to change an individual status inline.
+                enrollment_status: changeStatusValue?.status ?? 'completed',
+                user_ids:
+                    selectedResidents.length > 0
+                        ? selectedResidents
+                        : [user_id],
+                ...(requiresReason(status) && {
+                    change_reason: reasonText?.trim()
+                })
+            }
+        );
 
-        setSelectedResidents([]);
-        setChangeStatusValue(undefined);
-        await mutate();
+        if (resp.success) {
+            setSelectedResidents([]);
+            setChangeStatusValue(undefined);
+            await mutate();
+        } else {
+            toaster(
+                "Unable to update resident's enrollment status",
+                ToastState.error
+            );
+        }
     };
 
     const isEditable = (enrollment: ClassEnrollment) =>
@@ -193,6 +209,28 @@ export default function ClassEnrollmentDetails() {
         'Segregated - Dropped' = 'Incomplete: Segregated',
         'Failed To Complete' = 'Incomplete: Failed to Complete'
     }
+
+    const getEnrollmentStatusOptions = (): Record<string, string> => {
+        switch (
+            clsInfo?.status //displays differently per scheduled or active see asana ticket ID 394
+        ) {
+            case SelectedClassStatus.Scheduled:
+                return Object.fromEntries(
+                    Object.entries(EnrollmentStatusOptions).filter(
+                        ([value]) => value === 'Cancelled'
+                    )
+                );
+            case SelectedClassStatus.Active:
+                return Object.fromEntries(
+                    Object.entries(EnrollmentStatusOptions).filter(
+                        ([value]) => value !== 'Cancelled'
+                    )
+                );
+            default:
+                return { ...EnrollmentStatusOptions };
+        }
+    };
+
     return (
         <div className="flex flex-col gap-8">
             <div className="flex flex-row justify-between items-center">
@@ -267,7 +305,7 @@ export default function ClassEnrollmentDetails() {
             {!isLoading && !error && (
                 <ClassEnrollmentDetailsTable
                     enrollments={enrollments}
-                    statusOptions={EnrollmentStatusOptions}
+                    statusOptions={getEnrollmentStatusOptions()}
                     selectedResidents={selectedResidents}
                     toggleSelection={toggleSelection}
                     handleSelectAll={handleSelectAll}


### PR DESCRIPTION
## Description of the change

Added the necessary frontend logic to do the following:
- allow the selection of 'Cancelled' when class status is 'Scheduled'
- when class status is 'Active' the status 'Cancelled' will not be an enrollment option

Added the necessary backend logic to do the following:
- rejects the user's request if there is an attempt to set any status that is not allowed.

### Front-end
- [X] UI filters the status list based on the current class status.
- [X] It is impossible for the user to select or submit an invalid enrollment status through the interface.

### Back-end
- [X] The backend (`handleUpdateProgramClassEnrollments`) rejects any request that attempts to set an enrollment status not allowed for the current class status.

- **Related issues**: Link to related Asana ticket is: [Limit Enrollment Status Options for Scheduled & Active Classes](https://app.asana.com/1/1201607307149189/project/1209460078641109/task/1210839726305327?focus=true)

## Screenshot(s)

[statuses.webm](https://github.com/user-attachments/assets/f1a26a59-a062-4cce-a158-71416895886b)

## Additional context
NAVIGATION: Login (Admin) | Click Programs | Click Program | Select Class (Active/Scheduled) | Select Enrollment Tab | Make sure when a class is Scheduled you cannot see any other selection other than 'Cancelled' for a resident when the class is Active make sure you can't select 'Cancelled'

