### PR TITLE
fix: add logic to not allow edits of events when class is cancelled or completed per ticket 356

### DIFF
--- a/backend/src/database/class_events.go
+++ b/backend/src/database/class_events.go
@@ -340,6 +340,7 @@ func (db *DB) GetFacilityCalendar(args *models.QueryContext, dtRng *models.DateR
 		p.name as program_name,
 		c.instructor_name,
 		c.name as class_name,
+		c.status as class_status,
         STRING_AGG(CONCAT(u.id, ':', u.name_last, ', ', u.name_first), '|' ORDER BY u.name_last) FILTER (WHERE e.enrollment_status = 'Enrolled') AS enrolled_users`).
 		Joins("JOIN program_classes c ON c.id = pcev.class_id and c.archived_at IS NULL").
 		Joins("JOIN programs p ON p.id = c.program_id").
@@ -353,8 +354,8 @@ func (db *DB) GetFacilityCalendar(args *models.QueryContext, dtRng *models.DateR
 	if !args.IsAdmin {
 		tx = tx.Where("u.id = ? AND e.enrollment_status = 'Enrolled'", args.UserID)
 	}
-	tx = tx.Group("pcev.id, c.instructor_name, c.name, p.name")
-	if err := tx.Scan(&events).Error; err != nil {
+	tx = tx.Group("pcev.id, c.instructor_name, c.name, c.status, p.name")
+	if err := tx.Debug().Scan(&events).Error; err != nil {
 		return nil, newGetRecordsDBError(err, "program_class_events")
 	}
 
@@ -404,6 +405,7 @@ func (db *DB) GetFacilityCalendar(args *models.QueryContext, dtRng *models.DateR
 				ProgramName:       event.ProgramName,
 				ClassName:         event.ClassName,
 				EnrolledUsers:     event.EnrolledUsers,
+				ClassStatus:       event.ClassStatus,
 				StartTime:         &occurrence,
 				EndTime:           &endTime,
 				Frequency:         rRule.OrigOptions.Freq.String(),
@@ -445,6 +447,7 @@ func (db *DB) GetFacilityCalendar(args *models.QueryContext, dtRng *models.DateR
 				ProgramName:         event.ProgramName,
 				ClassName:           event.ClassName,
 				EnrolledUsers:       event.EnrolledUsers,
+				ClassStatus:         event.ClassStatus,
 				StartTime:           &overrideDate,
 				EndTime:             &overrideEndTime,
 				Frequency:           rRule.OrigOptions.Freq.String(),

--- a/backend/src/database/class_events.go
+++ b/backend/src/database/class_events.go
@@ -355,7 +355,7 @@ func (db *DB) GetFacilityCalendar(args *models.QueryContext, dtRng *models.DateR
 		tx = tx.Where("u.id = ? AND e.enrollment_status = 'Enrolled'", args.UserID)
 	}
 	tx = tx.Group("pcev.id, c.instructor_name, c.name, c.status, p.name")
-	if err := tx.Debug().Scan(&events).Error; err != nil {
+	if err := tx.Scan(&events).Error; err != nil {
 		return nil, newGetRecordsDBError(err, "program_class_events")
 	}
 

--- a/backend/src/models/class_event.go
+++ b/backend/src/models/class_event.go
@@ -218,6 +218,7 @@ type FacilityProgramClassEvent struct {
 	StartTime           *time.Time                 `json:"start"`
 	EndTime             *time.Time                 `json:"end"`
 	Frequency           string                     `json:"frequency"`
+	ClassStatus         ClassStatus                `json:"class_status"`
 	OverrideID          uint                       `json:"override_id"`
 	LinkedOverrideEvent *FacilityProgramClassEvent `json:"linked_override_event" gorm:"-"`
 }

--- a/frontend/src/Pages/Schedule.tsx
+++ b/frontend/src/Pages/Schedule.tsx
@@ -1,4 +1,8 @@
-import { ClassLoaderData, ServerResponseMany } from '@/common';
+import {
+    ClassLoaderData,
+    SelectedClassStatus,
+    ServerResponseMany
+} from '@/common';
 import ClassEventDetailsCard from '@/Components/ClassEventDetailsCard';
 import EventCalendar from '@/Components/EventCalendar';
 import { FacilityProgramClassEvent } from '@/types/events';
@@ -70,10 +74,15 @@ export default function Schedule() {
     }
 
     function canUpdateEvent(): boolean {
-        if (
+        const isClassCompletedOrCancelled =
             selectedEvent &&
-            class_id &&
-            selectedEvent.class_id.toString() !== class_id
+            (selectedEvent.class_status === SelectedClassStatus.Completed ||
+                selectedEvent.class_status === SelectedClassStatus.Cancelled);
+        if (
+            (selectedEvent &&
+                class_id &&
+                selectedEvent.class_id.toString() !== class_id) ||
+            isClassCompletedOrCancelled
         ) {
             return false;
         }

--- a/frontend/src/types/events.ts
+++ b/frontend/src/types/events.ts
@@ -1,4 +1,4 @@
-import { Attendance } from '@/common';
+import { Attendance, SelectedClassStatus } from '@/common';
 
 // ClassEventInstance represents a single scheduled class event with attendance records
 export interface ClassEventInstance extends ProgramClassEvent {
@@ -63,4 +63,5 @@ export interface FacilityProgramClassEvent extends ProgramClassEvent {
     override_id: number;
     linked_override_event: FacilityProgramClassEvent;
     credit_types: string;
+    class_status: SelectedClassStatus;
 }


### PR DESCRIPTION
## Description of the change

Made changes to the frontend and backend for validating whether or not a user can update/modify events based on the class status of Completed or Cancelled. 

- When a class is marked as **Completed** or **Canceled**:
    - [X] The schedule should be **read-only**
- [X] On the **Class Schedule** tab, verify that schedules for **Completed** or **Canceled** classes are NOT editable
- [X] Attempt to edit schedules of **Completed** or **Canceled** classes and confirm editing is blocked
- [X] Confirm no new events can be created for classes that are **Completed** or **Canceled**

- **Related issues**: Link to related Asana ticket is [Class Schedule Allows Edits on Completed or Canceled Classes](https://app.asana.com/1/1201607307149189/project/1209460078641109/task/1210787043059233?focus=true).

## Screenshot(s)
NAVIGATION Video:

[navigation.webm](https://github.com/user-attachments/assets/6fb66401-5bc5-45b8-956c-7c0e9ad2709a)
