### PR TITLE
fix: attendance renders when complete

### DIFF
--- a/backend/src/database/events_attendance.go
+++ b/backend/src/database/events_attendance.go
@@ -71,16 +71,28 @@ func (db *DB) DeleteAttendance(eventId, userId int, date string) error {
 	return nil
 }
 
-func (db *DB) GetEnrollmentsWithAttendanceForEvent(qryCtx *models.QueryContext, classID, eventID int, date string) ([]models.EnrollmentAttendance, error) {
+func (db *DB) GetEnrollmentsWithAttendanceForEvent(qryCtx *models.QueryContext, classID, eventID int, date string, includeCurrentlyEnrolled bool) ([]models.EnrollmentAttendance, error) {
 	baseQuery := `
-		FROM program_class_enrollments AS e
-		JOIN users AS u ON u.id = e.user_id
-		LEFT JOIN program_class_event_attendance AS a
-			ON a.user_id = e.user_id AND a.event_id = ? AND a.date = ?
-		WHERE e.class_id = ?
-	       AND DATE(e.enrolled_at) <= ?::date
-	       AND (e.enrollment_ended_at IS NULL OR DATE(e.enrollment_ended_at) >= ?::date)
-		`
+        FROM program_class_enrollments AS e
+        JOIN users AS u ON u.id = e.user_id
+        LEFT JOIN program_class_event_attendance AS a
+            ON a.user_id = e.user_id AND a.event_id = ? AND a.date = ?
+        WHERE e.class_id = ?
+        `
+
+	if includeCurrentlyEnrolled {
+		baseQuery += `
+           AND (
+                (DATE(e.enrolled_at) <= ?::date AND (e.enrollment_ended_at IS NULL OR DATE(e.enrollment_ended_at) >= ?::date))
+                OR e.enrollment_status = 'Enrolled'
+           )
+        `
+	} else {
+		baseQuery += `
+           AND DATE(e.enrolled_at) <= ?::date
+           AND (e.enrollment_ended_at IS NULL OR DATE(e.enrollment_ended_at) >= ?::date)
+        `
+	}
 
 	args := []any{eventID, date, classID, date, date}
 

--- a/backend/src/database/events_attendance.go
+++ b/backend/src/database/events_attendance.go
@@ -78,10 +78,13 @@ func (db *DB) GetEnrollmentsWithAttendanceForEvent(qryCtx *models.QueryContext, 
 		LEFT JOIN program_class_event_attendance AS a
 			ON a.user_id = e.user_id AND a.event_id = ? AND a.date = ?
 		WHERE e.class_id = ?
-			AND e.enrollment_status = 'Enrolled'
+	       AND e.enrolled_at >= ? 
+	       AND (? <= e.enrollment_ended_at
+				OR (e.enrollment_ended_at IS NULL AND e.enrollment_status = 'Enrolled')
+		       )
 		`
 
-	args := []any{eventID, date, classID}
+	args := []any{eventID, date, classID, date, date}
 
 	if qryCtx.Search != "" {
 		query := qryCtx.SearchQuery()

--- a/backend/src/database/events_attendance.go
+++ b/backend/src/database/events_attendance.go
@@ -78,10 +78,8 @@ func (db *DB) GetEnrollmentsWithAttendanceForEvent(qryCtx *models.QueryContext, 
 		LEFT JOIN program_class_event_attendance AS a
 			ON a.user_id = e.user_id AND a.event_id = ? AND a.date = ?
 		WHERE e.class_id = ?
-	       AND e.enrolled_at >= ? 
-	       AND (? <= e.enrollment_ended_at
-				OR (e.enrollment_ended_at IS NULL AND e.enrollment_status = 'Enrolled')
-		       )
+	       AND DATE(e.enrolled_at) <= ?::date
+	       AND (e.enrollment_ended_at IS NULL OR DATE(e.enrollment_ended_at) >= ?::date)
 		`
 
 	args := []any{eventID, date, classID, date, date}

--- a/backend/src/handlers/events_attendance_handler.go
+++ b/backend/src/handlers/events_attendance_handler.go
@@ -102,6 +102,12 @@ func (srv *Server) handleGetEventAttendance(w http.ResponseWriter, r *http.Reque
 
 	args := srv.getQueryContext(r)
 
+	class, err := srv.Db.GetClassByID(classID)
+	if err != nil {
+		return newDatabaseServiceError(err)
+	}
+	includeCurrentlyEnrolled := class.Status != models.Active
+
 	overrides, err := srv.Db.GetProgramClassEventOverrides(&args, []uint{uint(eventID)}...)
 	if err != nil {
 		return newDatabaseServiceError(err)
@@ -110,7 +116,7 @@ func (srv *Server) handleGetEventAttendance(w http.ResponseWriter, r *http.Reque
 		return writePaginatedResponse(w, http.StatusConflict, []models.EnrollmentAttendance{}, args.IntoMeta())
 	}
 
-	combined, err := srv.Db.GetEnrollmentsWithAttendanceForEvent(&args, classID, eventID, date)
+	combined, err := srv.Db.GetEnrollmentsWithAttendanceForEvent(&args, classID, eventID, date, includeCurrentlyEnrolled)
 	if err != nil {
 		return newDatabaseServiceError(err)
 	}

--- a/frontend/src/Components/AttendanceStatusToggle.tsx
+++ b/frontend/src/Components/AttendanceStatusToggle.tsx
@@ -9,11 +9,13 @@ import { Attendance } from '@/common';
 interface AttendanceStatusToggleProps {
     value?: Attendance;
     onChange: (value: Attendance) => void;
+    disabled?: boolean;
 }
 
 export default function AttendanceStatusToggle({
     value,
-    onChange
+    onChange,
+    disabled = false
 }: AttendanceStatusToggleProps) {
     const buttonClass = `flex flex-1 items-center justify-center gap-2 rounded-md px-4 py-2 text-base`;
 
@@ -26,10 +28,12 @@ export default function AttendanceStatusToggle({
                         value === Attendance.Present
                             ? 'bg-teal-3 opacity-70 hover:shadow-md text-white'
                             : 'bg-grey-1 hover:bg-grey-2'
-                    }`
+                    }` +
+                    (disabled ? 'cursor-not-allowed opacity-50' : '')
                 }
                 onClick={() => onChange(Attendance.Present)}
                 type="button"
+                disabled={disabled}
             >
                 <ULIComponent icon={CheckIcon} />
                 <label className="body-small cursor-pointer">Present</label>
@@ -45,6 +49,7 @@ export default function AttendanceStatusToggle({
                 }
                 onClick={() => onChange(Attendance.Absent_Excused)}
                 type="button"
+                disabled={disabled}
             >
                 <ULIComponent icon={ShieldCheckIcon} />
                 <label className="body-small cursor-pointer">Excused</label>
@@ -60,6 +65,7 @@ export default function AttendanceStatusToggle({
                 }
                 onClick={() => onChange(Attendance.Absent_Unexcused)}
                 type="button"
+                disabled={disabled}
             >
                 <ULIComponent icon={XMarkIcon} />
                 <label className="body-small cursor-pointer">Unexcused</label>

--- a/frontend/src/Components/AttendanceStatusToggle.tsx
+++ b/frontend/src/Components/AttendanceStatusToggle.tsx
@@ -12,64 +12,85 @@ interface AttendanceStatusToggleProps {
     disabled?: boolean;
 }
 
+interface ButtonConfig {
+    value: Attendance;
+    icon: typeof CheckIcon;
+    label: string;
+    selectedStyles: {
+        enabled: string;
+        disabled: string;
+    };
+}
+
 export default function AttendanceStatusToggle({
     value,
     onChange,
     disabled = false
 }: AttendanceStatusToggleProps) {
-    const buttonClass = `flex flex-1 items-center justify-center gap-2 rounded-md px-4 py-2 text-base`;
+    const baseButtonClass = `flex flex-1 items-center justify-center gap-2 rounded-md px-4 py-2 text-base`;
+    const unselectedEnabledClass = `${baseButtonClass} bg-grey-1 hover:bg-grey-2`;
+    const unselectedDisabledClass = `${baseButtonClass} bg-grey-1 opacity-40 cursor-not-allowed`;
+
+    const buttonConfigs: ButtonConfig[] = [
+        {
+            value: Attendance.Present,
+            icon: CheckIcon,
+            label: 'Present',
+            selectedStyles: {
+                enabled: `${baseButtonClass} bg-teal-3 opacity-70 hover:shadow-md text-white`,
+                disabled: `${baseButtonClass} bg-teal-3 text-white opacity-60 cursor-not-allowed`
+            }
+        },
+        {
+            value: Attendance.Absent_Excused,
+            icon: ShieldCheckIcon,
+            label: 'Excused',
+            selectedStyles: {
+                enabled: `${baseButtonClass} bg-pale-yellow hover:shadow-md text-base`,
+                disabled: `${baseButtonClass} bg-pale-yellow text-base opacity-60 cursor-not-allowed`
+            }
+        },
+        {
+            value: Attendance.Absent_Unexcused,
+            icon: XMarkIcon,
+            label: 'Unexcused',
+            selectedStyles: {
+                enabled: `${baseButtonClass} bg-red-2 opacity-80 hover:shadow-md text-white`,
+                disabled: `${baseButtonClass} bg-red-2 text-white opacity-60 cursor-not-allowed`
+            }
+        }
+    ];
+
+    const getButtonClassName = (config: ButtonConfig): string => {
+        const isSelected = value === config.value;
+
+        if (isSelected) {
+            return disabled
+                ? config.selectedStyles.disabled
+                : config.selectedStyles.enabled;
+        }
+
+        return disabled ? unselectedDisabledClass : unselectedEnabledClass;
+    };
 
     return (
         <div className="inline-flex w-fit gap-3">
-            <button
-                className={
-                    buttonClass +
-                    ` ${
-                        value === Attendance.Present
-                            ? 'bg-teal-3 opacity-70 hover:shadow-md text-white'
-                            : 'bg-grey-1 hover:bg-grey-2'
-                    }` +
-                    (disabled ? 'cursor-not-allowed opacity-50' : '')
-                }
-                onClick={() => onChange(Attendance.Present)}
-                type="button"
-                disabled={disabled}
-            >
-                <ULIComponent icon={CheckIcon} />
-                <label className="body-small cursor-pointer">Present</label>
-            </button>
-            <button
-                className={
-                    buttonClass +
-                    ` ${
-                        value === Attendance.Absent_Excused
-                            ? 'bg-pale-yellow hover:shadow-md text-base'
-                            : 'bg-grey-1 hover:bg-grey-2'
-                    }`
-                }
-                onClick={() => onChange(Attendance.Absent_Excused)}
-                type="button"
-                disabled={disabled}
-            >
-                <ULIComponent icon={ShieldCheckIcon} />
-                <label className="body-small cursor-pointer">Excused</label>
-            </button>
-            <button
-                className={
-                    buttonClass +
-                    ` ${
-                        value === Attendance.Absent_Unexcused
-                            ? 'bg-red-2 opacity-80 hover:shadow-md text-white'
-                            : 'bg-grey-1 hover:bg-grey-2'
-                    }`
-                }
-                onClick={() => onChange(Attendance.Absent_Unexcused)}
-                type="button"
-                disabled={disabled}
-            >
-                <ULIComponent icon={XMarkIcon} />
-                <label className="body-small cursor-pointer">Unexcused</label>
-            </button>
+            {buttonConfigs.map((config) => (
+                <button
+                    key={config.value}
+                    className={getButtonClassName(config)}
+                    onClick={() => onChange(config.value)}
+                    type="button"
+                    disabled={disabled}
+                >
+                    <ULIComponent icon={config.icon} />
+                    <label
+                        className={`body-small ${disabled ? 'cursor-not-allowed' : 'cursor-pointer'}`}
+                    >
+                        {config.label}
+                    </label>
+                </button>
+            ))}
         </div>
     );
 }

--- a/frontend/src/Pages/EventAttendance.tsx
+++ b/frontend/src/Pages/EventAttendance.tsx
@@ -265,6 +265,10 @@ export default function EventAttendance() {
     const anyRowSelected = rows.some((row) => row.selected);
     return (
         <div className="p-4 space-y-4">
+            {isNotActive && (
+                <WarningBanner text="This class is not active. You can still view attendance, but cannot mark attendance." />
+            )}
+
             <div className="flex justify-between items-center">
                 <div className="flex flex-row gap-2 items-center">
                     <SearchBar
@@ -291,10 +295,6 @@ export default function EventAttendance() {
             </div>
 
             {isLoading && <div>Loading...</div>}
-
-            {isNotActive && (
-                <WarningBanner text="This class is currently not active, please activate class to take attendance" />
-            )}
 
             {error && error.message === 'Conflict' ? (
                 <div className="text-error">

--- a/frontend/src/Pages/EventAttendance.tsx
+++ b/frontend/src/Pages/EventAttendance.tsx
@@ -303,7 +303,7 @@ export default function EventAttendance() {
             ) : (
                 error && <div className="text-error">Error loading data</div>
             )}
-            {!isLoading && !error && rows.length > 0 && (
+            {!isLoading && !error && (
                 <form
                     onSubmit={(e) => {
                         e.preventDefault();
@@ -321,80 +321,87 @@ export default function EventAttendance() {
                                 </tr>
                             </thead>
                             <tbody>
-                                {rows.map((row) => (
-                                    <tr
-                                        key={row.user_id}
-                                        className="card w-full justify-items-center grid-cols-[1fr_1fr_350px_1fr] grid p-2 gap-2"
-                                    >
-                                        <td>
-                                            {row.name_last}, {row.name_first}
-                                        </td>
-                                        <td>
-                                            {' '}
-                                            {row.doc_id == ''
-                                                ? ' '
-                                                : `${row.doc_id}`}
-                                        </td>
-                                        <td className="flex">
-                                            <AttendanceStatusToggle
-                                                value={
-                                                    row.attendance_status ??
-                                                    (row.selected
-                                                        ? Attendance.Present
-                                                        : undefined)
-                                                }
-                                                onChange={(newStatus) =>
-                                                    handleAttendanceChange(
-                                                        row.user_id,
-                                                        newStatus
-                                                    )
-                                                }
-                                                disabled={blockEdits}
-                                            />
-                                        </td>
-                                        <td className="">
-                                            <TextInput
-                                                label=""
-                                                defaultValue={row.note}
-                                                disabled={
-                                                    blockEdits ||
-                                                    !(
-                                                        row.attendance_status &&
+                                {rows.length === 0 ? (
+                                    <p className="body">
+                                        No users enrolled for class on {date}.
+                                    </p>
+                                ) : (
+                                    rows.map((row) => (
+                                        <tr
+                                            key={row.user_id}
+                                            className="card w-full justify-items-center grid-cols-[1fr_1fr_350px_1fr] grid p-2 gap-2"
+                                        >
+                                            <td>
+                                                {row.name_last},{' '}
+                                                {row.name_first}
+                                            </td>
+                                            <td>
+                                                {' '}
+                                                {row.doc_id == ''
+                                                    ? ' '
+                                                    : `${row.doc_id}`}
+                                            </td>
+                                            <td className="flex">
+                                                <AttendanceStatusToggle
+                                                    value={
+                                                        row.attendance_status ??
+                                                        (row.selected
+                                                            ? Attendance.Present
+                                                            : undefined)
+                                                    }
+                                                    onChange={(newStatus) =>
+                                                        handleAttendanceChange(
+                                                            row.user_id,
+                                                            newStatus
+                                                        )
+                                                    }
+                                                    disabled={blockEdits}
+                                                />
+                                            </td>
+                                            <td className="">
+                                                <TextInput
+                                                    label=""
+                                                    defaultValue={row.note}
+                                                    disabled={
+                                                        blockEdits ||
+                                                        !(
+                                                            row.attendance_status &&
+                                                            row.attendance_status !==
+                                                                Attendance.Present
+                                                        )
+                                                    }
+                                                    inputClassName={
+                                                        blockEdits ||
+                                                        !(
+                                                            row.attendance_status &&
+                                                            row.attendance_status !==
+                                                                Attendance.Present
+                                                        )
+                                                            ? 'opacity-40'
+                                                            : ''
+                                                    }
+                                                    interfaceRef={`note_${row.user_id}`}
+                                                    required={
+                                                        !blockEdits &&
+                                                        row.selected &&
                                                         row.attendance_status !==
                                                             Attendance.Present
-                                                    )
-                                                }
-                                                inputClassName={
-                                                    blockEdits ||
-                                                    !(
-                                                        row.attendance_status &&
-                                                        row.attendance_status !==
-                                                            Attendance.Present
-                                                    )
-                                                        ? 'opacity-40'
-                                                        : ''
-                                                }
-                                                interfaceRef={`note_${row.user_id}`}
-                                                required={
-                                                    !blockEdits &&
-                                                    row.selected &&
-                                                    row.attendance_status !==
-                                                        Attendance.Present
-                                                }
-                                                length={500}
-                                                errors={errors}
-                                                register={register}
-                                                onChange={(e) =>
-                                                    handleNoteChange(
-                                                        row.user_id,
-                                                        e.target.value
-                                                    )
-                                                }
-                                                errorTextAlign="center"
-                                            />
-                                        </td>
-                                    </tr>
-                                ))}
+                                                    }
+                                                    length={500}
+                                                    errors={errors}
+                                                    register={register}
+                                                    onChange={(e) =>
+                                                        handleNoteChange(
+                                                            row.user_id,
+                                                            e.target.value
+                                                        )
+                                                    }
+                                                    errorTextAlign="center"
+                                                />
+                                            </td>
+                                        </tr>
+                                    ))
+                                )}
                             </tbody>
                         </table>
                     </div>

--- a/frontend/src/Pages/EventAttendance.tsx
+++ b/frontend/src/Pages/EventAttendance.tsx
@@ -15,6 +15,7 @@ import {
     ServerResponseMany,
     FilterResidentNames,
     Class,
+    SelectedClassStatus,
     ToastState
 } from '@/common';
 import SearchBar from '@/Components/inputs/SearchBar';
@@ -25,6 +26,7 @@ import Error from '@/Pages/Error';
 import { parseLocalDay } from '@/Components/helperFunctions/formatting';
 import { useToast } from '@/Context/ToastCtx';
 import { isCompletedCancelledOrArchived } from './ProgramOverviewDashboard';
+import WarningBanner from '@/Components/WarningBanner';
 import { CancelButton } from '@/Components/inputs';
 import AttendanceStatusToggle from '@/Components/AttendanceStatusToggle';
 import {
@@ -74,7 +76,9 @@ export default function EventAttendance() {
     } = useUrlPagination(1, 20);
     const rawClsInfo = useLoaderData() as { class?: Class };
     const clsInfo = rawClsInfo?.class;
-    const blockEdits = isCompletedCancelledOrArchived(clsInfo ?? ({} as Class));
+    const isNotActive = clsInfo?.status !== SelectedClassStatus.Active;
+    const blockEdits =
+        isCompletedCancelledOrArchived(clsInfo ?? ({} as Class)) || isNotActive;
     const { data, error, isLoading, mutate } = useSWR<
         ServerResponseMany<EnrollmentAttendance>,
         Error
@@ -287,6 +291,10 @@ export default function EventAttendance() {
             </div>
 
             {isLoading && <div>Loading...</div>}
+
+            {isNotActive && (
+                <WarningBanner text="This class is currently not active, please activate class to take attendance" />
+            )}
 
             {error && error.message === 'Conflict' ? (
                 <div className="text-error">

--- a/frontend/src/Pages/EventAttendance.tsx
+++ b/frontend/src/Pages/EventAttendance.tsx
@@ -341,6 +341,7 @@ export default function EventAttendance() {
                                                         newStatus
                                                     )
                                                 }
+                                                disabled={blockEdits}
                                             />
                                         </td>
                                         <td className="">

--- a/frontend/src/Pages/EventAttendance.tsx
+++ b/frontend/src/Pages/EventAttendance.tsx
@@ -349,6 +349,7 @@ export default function EventAttendance() {
                                                 label=""
                                                 defaultValue={row.note}
                                                 disabled={
+                                                    blockEdits ||
                                                     !(
                                                         row.attendance_status &&
                                                         row.attendance_status !==
@@ -356,6 +357,7 @@ export default function EventAttendance() {
                                                     )
                                                 }
                                                 inputClassName={
+                                                    blockEdits ||
                                                     !(
                                                         row.attendance_status &&
                                                         row.attendance_status !==
@@ -366,6 +368,7 @@ export default function EventAttendance() {
                                                 }
                                                 interfaceRef={`note_${row.user_id}`}
                                                 required={
+                                                    !blockEdits &&
                                                     row.selected &&
                                                     row.attendance_status !==
                                                         Attendance.Present


### PR DESCRIPTION
## Description of the change
Displays users on the attendance page after a class is canceled or completed. 


- **Related issues**:
https://app.asana.com/1/1201607307149189/project/1209460078641109/task/1210787043059218?focus=true

## Screenshot(s)
### Canceled Class
<img width="1863" height="1058" alt="image" src="https://github.com/user-attachments/assets/cd9e1434-9453-400e-8fa0-31d93afdeb3d" />

### Completed Class
<img width="1891" height="1046" alt="image" src="https://github.com/user-attachments/assets/64505bc4-a31e-4fcc-abab-c369c6ba0804" />

## Active Class (No changes)
<img width="1694" height="818" alt="image" src="https://github.com/user-attachments/assets/c9028d36-94dc-40f1-8152-82e0c2efea38" />


## Additional context
Prior to this ticket the related query was only searching for residents with an enrollment_status of enrolled, this became an issue because once a class is rendered complete, or cancelled, the enrollment_status is then changed to the appropriate status, but is no longer enrolled. This was resulting in a no records found issue in respective classes. We solve this issue by first removing the dependency on an enrolled status and switching to a time based logic. The primary change in terms of the original ticket issue being these LOC's:

 ```
AND DATE(e.enrolled_at) <= ?::date
	       AND (e.enrollment_ended_at IS NULL OR DATE(e.enrollment_ended_at) >= ?::date)
```

We type cast the function parameter dates and then compare. 

Other than the actual logic issues this PR fixed the issue of users being able to click around and mess with the Attendance Status toggles, even though they aren't/weren't actually able to call the endpoint and update the status for Cancelled or completed classes.