### PR TITLE
fix: add proper validation to attendance endpoints

### DIFF
--- a/backend/tests/integration/attendance_validation_test.go
+++ b/backend/tests/integration/attendance_validation_test.go
@@ -1,0 +1,208 @@
+package integration
+
+import (
+	"fmt"
+	"net/http"
+	"testing"
+	"time"
+
+	"UnlockEdv2/src/handlers"
+	"UnlockEdv2/src/models"
+
+	"github.com/stretchr/testify/require"
+)
+
+// - POST /api/program-classes/{class_id}/events/{event_id}/attendance
+// - DELETE /api/program-classes/{class_id}/events/{event_id}/attendance/{user_id}
+func TestAttendanceValidation(t *testing.T) {
+	env := SetupTestEnv(t)
+	defer env.CleanupTestEnv()
+
+	facility, err := env.CreateTestFacility("Test Facility")
+	require.NoError(t, err)
+
+	facilityAdmin, err := env.CreateTestUser("testadmin", models.FacilityAdmin, facility.ID, "")
+	require.NoError(t, err)
+
+	enrolledStudent, err := env.CreateTestUser("enrolledstudent", models.Student, facility.ID, "STU001")
+	require.NoError(t, err)
+
+	unenrolledStudent, err := env.CreateTestUser("unenrolledstudent", models.Student, facility.ID, "STU002")
+	require.NoError(t, err)
+
+	program, err := env.CreateTestProgram("Test Program", models.FundingType(models.FederalGrants), []models.ProgramType{}, []models.ProgramCreditType{}, true, nil)
+	require.NoError(t, err)
+
+	err = env.SetFacilitiesToProgram(program.ID, []uint{facility.ID})
+	require.NoError(t, err)
+
+	class, err := env.CreateTestClass(program, facility, models.Active)
+	require.NoError(t, err)
+
+	event, err := env.CreateTestEvent(class.ID, "")
+	require.NoError(t, err)
+
+	_, err = env.CreateTestEnrollment(class.ID, enrolledStudent.ID, models.Enrolled)
+	require.NoError(t, err)
+
+	cancelledDate := time.Now().AddDate(0, 0, -1).Format("2006-01-02") // yesterday (past date)
+	_, err = env.CreateTestEventOverride(event.ID, cancelledDate, true, "cancelled")
+	require.NoError(t, err)
+
+	t.Run("POST Attendance Validation", func(t *testing.T) {
+		testPOSTAttendanceValidation(t, env, facilityAdmin, class, event, enrolledStudent, unenrolledStudent, cancelledDate)
+	})
+
+	t.Run("DELETE Attendance Validation", func(t *testing.T) {
+		testDELETEAttendanceValidation(t, env, facilityAdmin, class, event, enrolledStudent, unenrolledStudent, cancelledDate)
+	})
+}
+
+func testPOSTAttendanceValidation(t *testing.T, env *TestEnv, admin *models.User, class *models.ProgramClass, event *models.ProgramClassEvent, enrolledStudent, unenrolledStudent *models.User, cancelledDate string) {
+	validDate := time.Now().AddDate(0, 0, -2).Format("2006-01-02") // day before yesterday
+
+	t.Run("Reject attendance for cancelled date", func(t *testing.T) {
+		attendanceData := []models.ProgramClassEventAttendance{
+			{
+				UserID:           enrolledStudent.ID,
+				Date:             cancelledDate,
+				AttendanceStatus: models.Present,
+				Note:             "Test attendance",
+			},
+		}
+
+		NewRequest[any](env.Client, t, http.MethodPost,
+			fmt.Sprintf("/api/program-classes/%d/events/%d/attendance", class.ID, event.ID),
+			attendanceData).
+			WithTestClaims(&handlers.Claims{
+				Role:       models.FacilityAdmin,
+				FacilityID: admin.FacilityID,
+			}).
+			Do().
+			ExpectStatus(http.StatusConflict).
+			ExpectBodyContains("cannot record attendance for cancelled class date")
+	})
+
+	t.Run("Reject attendance for unenrolled user", func(t *testing.T) {
+		attendanceData := []models.ProgramClassEventAttendance{
+			{
+				UserID:           unenrolledStudent.ID,
+				Date:             validDate,
+				AttendanceStatus: models.Present,
+				Note:             "Test attendance",
+			},
+		}
+
+		NewRequest[any](env.Client, t, http.MethodPost,
+			fmt.Sprintf("/api/program-classes/%d/events/%d/attendance", class.ID, event.ID),
+			attendanceData).
+			WithTestClaims(&handlers.Claims{
+				Role:       models.FacilityAdmin,
+				FacilityID: admin.FacilityID,
+			}).
+			Do().
+			ExpectStatus(http.StatusBadRequest).
+			ExpectBodyContains(fmt.Sprintf("user %d is not enrolled in class %d", unenrolledStudent.ID, class.ID))
+	})
+
+	t.Run("Accept valid attendance for enrolled user on valid date", func(t *testing.T) {
+		attendanceData := []models.ProgramClassEventAttendance{
+			{
+				UserID:           enrolledStudent.ID,
+				Date:             validDate,
+				AttendanceStatus: models.Present,
+				Note:             "Valid attendance",
+			},
+		}
+
+		NewRequest[any](env.Client, t, http.MethodPost,
+			fmt.Sprintf("/api/program-classes/%d/events/%d/attendance", class.ID, event.ID),
+			attendanceData).
+			WithTestClaims(&handlers.Claims{
+				Role:       models.FacilityAdmin,
+				FacilityID: admin.FacilityID,
+			}).
+			Do().
+			ExpectStatus(http.StatusOK).
+			ExpectBodyContains("Attendance updated")
+	})
+
+	t.Run("Reject multiple users with mixed enrollment status", func(t *testing.T) {
+		attendanceData := []models.ProgramClassEventAttendance{
+			{
+				UserID:           enrolledStudent.ID,
+				Date:             validDate,
+				AttendanceStatus: models.Present,
+				Note:             "Enrolled student",
+			},
+			{
+				UserID:           unenrolledStudent.ID,
+				Date:             validDate,
+				AttendanceStatus: models.Present,
+				Note:             "Unenrolled student",
+			},
+		}
+
+		NewRequest[any](env.Client, t, http.MethodPost,
+			fmt.Sprintf("/api/program-classes/%d/events/%d/attendance", class.ID, event.ID),
+			attendanceData).
+			WithTestClaims(&handlers.Claims{
+				Role:       models.FacilityAdmin,
+				FacilityID: admin.FacilityID,
+			}).
+			Do().
+			ExpectStatus(http.StatusBadRequest).
+			ExpectBodyContains(fmt.Sprintf("user %d is not enrolled in class %d", unenrolledStudent.ID, class.ID))
+	})
+}
+
+func testDELETEAttendanceValidation(t *testing.T, env *TestEnv, admin *models.User, class *models.ProgramClass, event *models.ProgramClassEvent, enrolledStudent, unenrolledStudent *models.User, cancelledDate string) {
+	validDate := time.Now().AddDate(0, 0, -2).Format("2006-01-02") // day before yesterday
+
+	attendanceData := []models.ProgramClassEventAttendance{
+		{
+			EventID:          event.ID,
+			UserID:           enrolledStudent.ID,
+			Date:             validDate,
+			AttendanceStatus: models.Present,
+			Note:             "To be deleted",
+		},
+	}
+	err := env.DB.LogUserAttendance(attendanceData)
+	require.NoError(t, err)
+
+	t.Run("Reject delete attendance for cancelled date", func(t *testing.T) {
+		NewRequest[any](env.Client, t, http.MethodDelete,
+			fmt.Sprintf("/api/program-classes/%d/events/%d/attendance/%d?date=%s", class.ID, event.ID, enrolledStudent.ID, cancelledDate), nil).
+			WithTestClaims(&handlers.Claims{
+				Role:       models.FacilityAdmin,
+				FacilityID: admin.FacilityID,
+			}).
+			Do().
+			ExpectStatus(http.StatusConflict).
+			ExpectBodyContains("cannot delete attendance for cancelled class date")
+	})
+
+	t.Run("Reject delete attendance for unenrolled user", func(t *testing.T) {
+		NewRequest[any](env.Client, t, http.MethodDelete,
+			fmt.Sprintf("/api/program-classes/%d/events/%d/attendance/%d?date=%s", class.ID, event.ID, unenrolledStudent.ID, validDate), nil).
+			WithTestClaims(&handlers.Claims{
+				Role:       models.FacilityAdmin,
+				FacilityID: admin.FacilityID,
+			}).
+			Do().
+			ExpectStatus(http.StatusBadRequest).
+			ExpectBodyContains("user is not enrolled in class")
+	})
+
+	t.Run("Accept delete attendance for enrolled user on valid date", func(t *testing.T) {
+		NewRequest[any](env.Client, t, http.MethodDelete,
+			fmt.Sprintf("/api/program-classes/%d/events/%d/attendance/%d?date=%s", class.ID, event.ID, enrolledStudent.ID, validDate), nil).
+			WithTestClaims(&handlers.Claims{
+				Role:       models.FacilityAdmin,
+				FacilityID: admin.FacilityID,
+			}).
+			Do().
+			ExpectStatus(http.StatusNoContent)
+	})
+}

--- a/backend/tests/integration/client.go
+++ b/backend/tests/integration/client.go
@@ -102,7 +102,7 @@ func (r *Request[T]) Do() *Response[T] {
 	var decoded bool
 	rawStr := string(rawBytes)
 
-	if r.asJson && resp.StatusCode < 400 {
+	if r.asJson && resp.StatusCode < 400 && resp.StatusCode != http.StatusNoContent {
 		require.NoError(r.t, json.Unmarshal(rawBytes, &env), "failed to unmarshal response body")
 
 		parsed = new(T)
@@ -159,6 +159,13 @@ func (r *Response[T]) ExpectRaw(expected string) {
 	r.t.Helper()
 
 	require.Equal(r.t, expected, r.rawBody)
+}
+
+func (r *Response[T]) ExpectBodyContains(expected string) *Response[T] {
+	r.t.Helper()
+
+	require.Contains(r.t, r.rawBody, expected, "expected response body to contain '%s', got: %s", expected, r.rawBody)
+	return r
 }
 
 func (c *Client) buildURL(endpoint string) (string, error) {


### PR DESCRIPTION
## Description of the change
This PR makes sure there is proper validation for the endpoints related to attendance, in particular when adding and or deleting attendance. 

- **Related issues**: https://app.asana.com/1/1201607307149189/project/1209460078641109/task/1210871477181002?focus=true



## Additional context
I'm not overly comfortable with the so much happening inside of a loop in the add attendance method, but I currently can't think of a clever way around it. I think we could probably get away with just checking one of the attendances date, and as long as it's not cancelled safely assume that none of the rest of the array is cancelled, but then that begs the question, "what happens if someone figures that out, gets an admin cookie, and just starts sending curl requests, they could manipulate all the attendance they want". Which is true, it's highly unlikely, but it's true, they could. I think given that it's highly unlikely this array will ever be much larger than 20 residents/users at a time, I think the load is manageable, and nothing to worry about. 
- Added support in the testing client for validating response bodies. 
- Fixed JSON parsing for 204 no content responses 
- Decided to perform cancelled date validation before enrollment validation because a cancelled date will automatically apply to everyone where as enrollment validation can be case by case 
- 409 for cancelled date as this indicates that there is a resource state conflict 
- 400 for enrollment issues as this indicates a bad request /  client issue, and I felt as though a non-enrolled user would be a client issue, or more than likely a malicious actor or bug as we take steps to prevent un-enrolled users from appearing in the attendance tracking event page. 
