### PR TITLE
Hidden Helpful Links appears on admin "preview student view" mode

### DIFF
--- a/frontend/src/Pages/HelpfulLinks.tsx
+++ b/frontend/src/Pages/HelpfulLinks.tsx
@@ -10,9 +10,12 @@ import Pagination from '@/Components/Pagination';
 import { useEffect } from 'react';
 import useSWR from 'swr';
 import { useUrlPagination } from '@/Hooks/paginationUrlSync';
-import { useOutletContext } from 'react-router-dom';
+import { useLocation, useOutletContext } from 'react-router-dom';
+import { isAdministrator, useAuth } from '@/useAuth';
 
 export default function HelpfulLinks() {
+    const { user } = useAuth();
+    const route = useLocation();
     const { activeView, searchQuery, sortQuery } = useOutletContext<{
         activeView: ViewType;
         searchQuery: string;
@@ -24,14 +27,16 @@ export default function HelpfulLinks() {
         setPage: setPageQuery,
         setPerPage
     } = useUrlPagination(1, 20);
-
+    const adminWithStudentView = (): boolean => {
+        return !route.pathname.includes('management') && isAdministrator(user);
+    };
     const {
         data: helpfulLinks,
         mutate: mutateHelpfulFavs,
         isLoading,
         error
     } = useSWR<ServerResponseOne<HelpfulLinkAndSort>, Error>(
-        `/api/helpful-links?page=${pageQuery}&per_page=${perPage}&search=${searchQuery}${sortQuery}`
+        `/api/helpful-links?page=${pageQuery}&per_page=${perPage}&search=${searchQuery}${sortQuery}&visibility=${adminWithStudentView()}`
     );
     function updateFavorites() {
         void mutateHelpfulFavs();


### PR DESCRIPTION
## Description of the change

Before this change, when an admin switched to **Preview Student View**, they could still see helpful links that were marked as hidden. Students are only supposed to see links marked as visible, so this was incorrect.  

I fixed this by:  
modifying the query string in the useSWR call, this strategy is similar to that used for 'Preview Student View' on the Libraries/Videos tab 

- **Related issues**: [Link to related Asana ticket that this closes.](https://app.asana.com/1/1201607307149189/project/1209460078641109/task/1210464235048873)  

---

## Screenshot(s)  

https://github.com/user-attachments/assets/15dcc214-59b1-408f-bedc-80b0122ef2a2  

---

## Additional context  

- Students and admins in student preview see the same limited set of visible links.  
- Admins in admin mode see all links.  
- We used `sessionStorage` instead of adding a URL parameter so it’s cleaner and only applies to the current admin session.  
- The button label now changes right away when switching, so it’s always clear which mode you’re in.  

---
