### PR TITLE
fix: replace history in unknown library navigation

### DIFF
--- a/frontend/src/Pages/LibraryViewer.tsx
+++ b/frontend/src/Pages/LibraryViewer.tsx
@@ -153,12 +153,12 @@ export default function LibraryViewer() {
                         setSrc(response.url);
                     }
                 } else if (response.status === 404) {
-                    navigate('/404');
+                    navigate('/404', { replace: true });
                 } else {
-                    navigate('/error');
+                    navigate('/error', { replace: true });
                 }
             } catch {
-                navigate('/404');
+                navigate('/404', { replace: true });
             } finally {
                 setIsLoading(false);
             }


### PR DESCRIPTION
## Description of the change
Fixes the 404 loop in un-available library

- **Related issues**: https://app.asana.com/1/1201607307149189/project/1209460078641109/task/1210881980228476?focus=true


## Additional context
just needed to replace the history item 