### PR TITLE
fix: added tests for historical enrollment checks

### DIFF
--- a/backend/src/database/program_classes.go
+++ b/backend/src/database/program_classes.go
@@ -103,8 +103,8 @@ func (db *DB) GetHistoricalEnrollmentForDates(classID int, dates []string) (map[
 		var count int64
 		if err := db.Model(&models.ProgramClassEnrollment{}).
 			Where("class_id = ?", classID).
-			Where("enrolled_at <= ?", trimmedDate).
-			Where("enrollment_ended_at IS NULL OR enrollment_ended_at > ?", trimmedDate).
+			Where("DATE(enrolled_at) <= DATE(?)", trimmedDate).
+			Where("enrollment_ended_at IS NULL OR DATE(enrollment_ended_at) > DATE(?)", trimmedDate).
 			Count(&count).Error; err != nil {
 			return nil, NewDBError(err, "historical enrollment count for date: "+trimmedDate)
 		}

--- a/backend/tests/integration/class_enrollments_test.go
+++ b/backend/tests/integration/class_enrollments_test.go
@@ -185,3 +185,186 @@ func runUpdateToTerminalStatusTest(t *testing.T, env *TestEnv, facility *models.
 		})
 	}
 }
+
+func TestGetHistoricalEnrollmentBatch(t *testing.T) {
+	env := SetupTestEnv(t)
+	defer env.CleanupTestEnv()
+
+	facility, err := env.CreateTestFacility("Test Facility")
+	require.NoError(t, err)
+
+	facilityAdmin, err := env.CreateTestUser("testadmin", models.FacilityAdmin, facility.ID, "")
+	require.NoError(t, err)
+
+	// Create program and make it available at facility
+	program, err := env.CreateTestProgram("Historical Enrollment Test Program", models.FundingType(models.FederalGrants), []models.ProgramType{}, []models.ProgramCreditType{}, true, nil)
+	require.NoError(t, err)
+
+	err = env.SetFacilitiesToProgram(program.ID, []uint{facility.ID})
+	require.NoError(t, err)
+
+	// Create an Active class
+	activeClass, err := env.CreateTestClass(program, facility, models.Active)
+	require.NoError(t, err)
+
+	// Create test users
+	user1, err := env.CreateTestUser("histuser1", models.Student, facility.ID, "hist1")
+	require.NoError(t, err)
+	user2, err := env.CreateTestUser("histuser2", models.Student, facility.ID, "hist2")
+	require.NoError(t, err)
+	user3, err := env.CreateTestUser("histuser3", models.Student, facility.ID, "hist3")
+	require.NoError(t, err)
+
+	// Create enrollments with specific dates
+	// User1: enrolled on 2025-08-13
+	enrolledAt1 := time.Date(2025, 8, 13, 0, 0, 0, 0, time.UTC)
+	enrollment1 := &models.ProgramClassEnrollment{
+		ClassID:          activeClass.ID,
+		UserID:           user1.ID,
+		EnrollmentStatus: models.Enrolled,
+		EnrolledAt:       &enrolledAt1,
+	}
+	err = env.DB.Create(enrollment1).Error
+	require.NoError(t, err)
+
+	// User2: enrolled on 2025-08-14
+	enrolledAt2 := time.Date(2025, 8, 14, 0, 0, 0, 0, time.UTC)
+	enrollment2 := &models.ProgramClassEnrollment{
+		ClassID:          activeClass.ID,
+		UserID:           user2.ID,
+		EnrollmentStatus: models.Enrolled,
+		EnrolledAt:       &enrolledAt2,
+	}
+	err = env.DB.Create(enrollment2).Error
+	require.NoError(t, err)
+
+	// User3: enrolled on 2025-08-15, ended on 2025-08-16
+	enrolledAt3 := time.Date(2025, 8, 15, 0, 0, 0, 0, time.UTC)
+	endedAt3 := time.Date(2025, 8, 16, 0, 0, 0, 0, time.UTC)
+	enrollment3 := &models.ProgramClassEnrollment{
+		ClassID:           activeClass.ID,
+		UserID:            user3.ID,
+		EnrollmentStatus:  models.EnrollmentCompleted,
+		EnrolledAt:        &enrolledAt3,
+		EnrollmentEndedAt: &endedAt3,
+	}
+	err = env.DB.Create(enrollment3).Error
+	require.NoError(t, err)
+
+	t.Run("Single date with varying enrollment levels", func(t *testing.T) {
+		runSingleDateHistoricalEnrollmentTest(t, env, activeClass, facilityAdmin, facility, user1, user2, user3)
+	})
+
+	t.Run("Batch multiple dates with varying enrollment levels", func(t *testing.T) {
+		runBatchDateHistoricalEnrollmentTest(t, env, activeClass, facilityAdmin, facility, user1, user2, user3)
+	})
+
+	t.Run("Edge cases and validation", func(t *testing.T) {
+		runHistoricalEnrollmentEdgeCasesTest(t, env, activeClass, facilityAdmin, facility)
+	})
+}
+
+func runSingleDateHistoricalEnrollmentTest(t *testing.T, env *TestEnv, activeClass *models.ProgramClass, facilityAdmin *models.User, facility *models.Facility, user1, user2, user3 *models.User) {
+	// Test single date queries
+	testCases := []struct {
+		date     string
+		expected int64
+		desc     string
+	}{
+		{"2025-08-12", 0, "no enrollments before 2025-08-13"},
+		{"2025-08-13", 1, "only user1 enrolled by 2025-08-13"},
+		{"2025-08-14", 2, "user1 and user2 enrolled by 2025-08-14"},
+		{"2025-08-15", 3, "all three users enrolled on 2025-08-15"},
+		{"2025-08-16", 2, "user3 enrollment ended on 2025-08-16, so only user1 and user2"},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.desc, func(t *testing.T) {
+			resp := NewRequest[map[string]int64](env.Client, t, http.MethodGet, fmt.Sprintf("/api/program-classes/%d/historical-enrollment-batch?dates=%s", activeClass.ID, tc.date), nil).
+				WithTestClaims(&handlers.Claims{Role: models.FacilityAdmin, UserID: facilityAdmin.ID, FacilityID: facility.ID}).
+				Do().
+				ExpectStatus(http.StatusOK)
+
+			result := resp.GetData()
+			require.Contains(t, result, tc.date, "Response should contain the requested date")
+			require.Equal(t, tc.expected, result[tc.date], tc.desc)
+		})
+	}
+}
+
+func runBatchDateHistoricalEnrollmentTest(t *testing.T, env *TestEnv, activeClass *models.ProgramClass, facilityAdmin *models.User, facility *models.Facility, user1, user2, user3 *models.User) {
+	// Test batch query with multiple dates
+	dates := "2025-08-12,2025-08-13,2025-08-14,2025-08-15,2025-08-16"
+	resp := NewRequest[map[string]int64](env.Client, t, http.MethodGet, fmt.Sprintf("/api/program-classes/%d/historical-enrollment-batch?dates=%s", activeClass.ID, dates), nil).
+		WithTestClaims(&handlers.Claims{Role: models.FacilityAdmin, UserID: facilityAdmin.ID, FacilityID: facility.ID}).
+		Do().
+		ExpectStatus(http.StatusOK)
+
+	result := resp.GetData()
+
+	// Verify all dates are present in response
+	expectedResults := map[string]int64{
+		"2025-08-12": 0, // no enrollments before 2025-08-13
+		"2025-08-13": 1, // only user1 enrolled by 2025-08-13
+		"2025-08-14": 2, // user1 and user2 enrolled by 2025-08-14
+		"2025-08-15": 3, // all three users enrolled on 2025-08-15
+		"2025-08-16": 2, // user3 enrollment ended on 2025-08-16, so only user1 and user2
+	}
+
+	require.Len(t, result, 5, "Should return results for all 5 dates")
+
+	for date, expected := range expectedResults {
+		require.Contains(t, result, date, "Response should contain date %s", date)
+		require.Equal(t, expected, result[date], "Incorrect enrollment count for %s", date)
+	}
+
+	// Verify this was a single API call that returned all results
+	t.Logf("Successfully retrieved historical enrollment data for %d dates in a single batch request", len(expectedResults))
+}
+
+func runHistoricalEnrollmentEdgeCasesTest(t *testing.T, env *TestEnv, activeClass *models.ProgramClass, facilityAdmin *models.User, facility *models.Facility) {
+	// Test case 1: Missing dates parameter
+	t.Run("Missing dates parameter", func(t *testing.T) {
+		NewRequest[interface{}](env.Client, t, http.MethodGet, fmt.Sprintf("/api/program-classes/%d/historical-enrollment-batch", activeClass.ID), nil).
+			WithTestClaims(&handlers.Claims{Role: models.FacilityAdmin, UserID: facilityAdmin.ID, FacilityID: facility.ID}).
+			Do().
+			ExpectStatus(http.StatusBadRequest)
+	})
+
+	// Test case 2: Empty dates parameter
+	t.Run("Empty dates parameter", func(t *testing.T) {
+		NewRequest[interface{}](env.Client, t, http.MethodGet, fmt.Sprintf("/api/program-classes/%d/historical-enrollment-batch?dates=", activeClass.ID), nil).
+			WithTestClaims(&handlers.Claims{Role: models.FacilityAdmin, UserID: facilityAdmin.ID, FacilityID: facility.ID}).
+			Do().
+			ExpectStatus(http.StatusBadRequest)
+	})
+
+	// Test case 3: Invalid date format
+	t.Run("Invalid date format", func(t *testing.T) {
+		invalidDates := []string{
+			"2025/08/13",   // wrong format
+			"2025-13-01",   // invalid month
+			"2025-02-30",   // invalid day
+			"invalid-date", // completely invalid
+			"2025-8-1",     // missing zero padding
+		}
+
+		for _, invalidDate := range invalidDates {
+			t.Run(fmt.Sprintf("date_%s", invalidDate), func(t *testing.T) {
+				NewRequest[interface{}](env.Client, t, http.MethodGet, fmt.Sprintf("/api/program-classes/%d/historical-enrollment-batch?dates=%s", activeClass.ID, invalidDate), nil).
+					WithTestClaims(&handlers.Claims{Role: models.FacilityAdmin, UserID: facilityAdmin.ID, FacilityID: facility.ID}).
+					Do().
+					ExpectStatus(http.StatusBadRequest)
+			})
+		}
+	})
+
+	// Test case 4: Mixed valid and invalid dates
+	t.Run("Mixed valid and invalid dates", func(t *testing.T) {
+		dates := "2025-08-13,invalid-date,2025-08-14"
+		NewRequest[interface{}](env.Client, t, http.MethodGet, fmt.Sprintf("/api/program-classes/%d/historical-enrollment-batch?dates=%s", activeClass.ID, dates), nil).
+			WithTestClaims(&handlers.Claims{Role: models.FacilityAdmin, UserID: facilityAdmin.ID, FacilityID: facility.ID}).
+			Do().
+			ExpectStatus(http.StatusBadRequest)
+	})
+}


### PR DESCRIPTION
@CK-7vn Can you look at this and merge it into your branch if you're good with it?

I added tests for the following 

Test Scenario Setup:

- 3 test users with staggered enrollment dates:
  - User1: enrolled 2025-08-13 (ongoing)
  - User2: enrolled 2025-08-14 (ongoing)
  - User3: enrolled 2025-08-15, ended 2025-08-16

**Single date checks**

Tests individual date lookups with varying enrollment levels:
- ✅ 2025-08-12: 0 enrollments (before any start dates)
- ✅ 2025-08-13: 1 enrollment (only user1)
- ✅ 2025-08-14: 2 enrollments (user1 + user2)
- ✅ 2025-08-15: 3 enrollments (all users active)
- ✅ 2025-08-16: 2 enrollments (user3 ended, user1+user2 remain)

**Batch date checks**

Tests the core focus - single API call for multiple dates:
- ✅ Batch query: 2025-08-12,2025-08-13,2025-08-14,2025-08-15,2025-08-16
- ✅ Validates: All 5 dates returned in single response with correct counts