### PR TITLE
Feat: rrule utils patch  for future event display

### DIFF
--- a/backend/src/models/rrule_utils.go
+++ b/backend/src/models/rrule_utils.go
@@ -1,0 +1,19 @@
+package models
+
+import "strings"
+
+func ReplaceOrAddUntilDate(rRule, untilDate string) string {
+	parts := strings.Split(rRule, ";")
+	found := false
+	for i, p := range parts {
+		if strings.HasPrefix(p, "UNTIL=") {
+			parts[i] = "UNTIL=" + untilDate
+			found = true
+			break
+		}
+	}
+	if !found {
+		parts = append(parts, "UNTIL="+untilDate)
+	}
+	return strings.Join(parts, ";")
+}


### PR DESCRIPTION
# Description of the change
##  Truncate recurring class events on completion/cancellation

### Summary: Implements automatic truncation of a class’s active recurring event series when the class status is set to Completed or Cancelled. Prevents future sessions from appearing as “Scheduled” or later flipping to “Not Marked.”
- **Related issues**: Link to related Asana ticket that this closes.
[Future Events Still Displayed as Scheduled After Class is Marked Completed or Cancelled](https://app.asana.com/1/1201607307149189/project/1209460078641109/task/1210881980228465)
## Screenshot(s)

If the PR includes changes to the UI: 
- Please add screenshots or a short screengrab of the change 

https://github.com/user-attachments/assets/25e5131e-edce-40ee-8446-d6476322d6d3



# Additional context
## Key Changes:

* Added models.ReplaceOrAddUntilDate helper to inject or replace UNTIL in recurrence rules.
* Updated UpdateProgramClasses (bulk) and UpdateProgramClass (single) to:
  - Detect status transition to Completed/Cancelled.
  - Determine facility timezone and apply an immediate cutoff (UNTIL=YYYYMMDDT000000Z).
  - Update only the newest (active) event’s recurrence_rule if needed.
  - Cancel (is_cancelled = true) any non-cancelled overrides scheduled after the cutoff.
  - Record a change log entry using existing event_rescheduled_series label when the rule changes.
* Introduced new file [rrule_utils.go](vscode-file://vscode-app/c:/Users/Hudson%20Link/AppData/Local/Programs/Microsoft%20VS%20Code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) for shared recurrence logic.
## Behavior:

* All future occurrences (including same-day future times) are removed once status flips.
* Re-running status updates on an already truncated class is idempotent (no further changes).
* Attendance and calendar endpoints no longer surface post-completion sessions.
## Scope:

- No schema changes.
- Minimal touch points: class_enrollments.go, program_classes.go, new utility file.
- Existing handlers and APIs unchanged.
## Testing Notes:

* Mark an Active class as Completed/Cancelled: verify recurrence_rule now contains expected UNTIL.
* Confirm no future instances returned by /api/program-classes/{id}/events after cutoff.
* Verify overrides after cutoff are marked is_cancelled=true.

Rationale: Removes misleading “Scheduled” or later “Not Marked” rows after a class has ended, preventing false attendance * gaps and report noise.

Rollback: Revert this commit; optionally manually restore prior recurrence_rule values if needed.

If any core features or components were removed with this PR, please note them here so that they can be added to the wiki (see [Deprecated features and Components](https://github.com/UnlockedLabs/UnlockEdv2/wiki/Deprecated-Features-and-Components)).