### PR TITLE
Hide pagination controls when total records are less than default per_page size

### DIFF
--- a/frontend/src/Components/Pagination.tsx
+++ b/frontend/src/Components/Pagination.tsx
@@ -8,8 +8,8 @@ export default function Pagination({
     meta,
     setPage,
     setPerPage,
-    specialPageSelecton,
-    forceShow
+    specialPageSelecton
+    // forceShow
 }: {
     meta: PaginationMeta;
     setPage: (page: number) => void;
@@ -17,7 +17,7 @@ export default function Pagination({
     specialPageSelecton?: boolean;
     forceShow?: boolean;
 }) {
-    if (!meta || (meta.total <= meta.per_page && !forceShow)) {
+    if (!meta || meta.total <= meta.per_page) {
         return null;
     }
 


### PR DESCRIPTION
# PR Description

## Description of the change

This PR improves the user experience by conditionally hiding pagination controls when they are not needed. Previously, pagination controls could render even when the number of records was less than the page size, creating unnecessary UI clutter.

**Changes made:**
- Updated `Pagination.tsx` to check the `total` field from the server response before rendering controls.
- Logic: hide pagination when `total <= per_page`.
- This behavior now applies **globally to all pages/components that import and use** the shared `Pagination` component.

- **Related issues**: [[Asana task link](https://app.asana.com/1/1201607307149189/project/1209460078641109/task/1210707681181885?focus=true)]

---

## Screenshot(s)
<img width="1822" height="965" alt="image" src="https://github.com/user-attachments/assets/99bcfa85-e93c-415c-a858-d4a695bcf99d" />

**Before:**  
- Pagination controls visible with fewer items than the page size (e.g., 4 or 0 items)

**After:**  
- Pagination controls hidden when not needed  
- Pagination only appears when `total > per_page`

---

## Additional context

**Implementation details:**  
- Relies on existing pagination metadata fields: `current_page`, `last_page`, `per_page`, and `total`.  
- No backend changes required — logic is handled client-side in `Pagination.tsx`.

**Areas to focus on during review:**  
- Spot-check several views that consume `Pagination` (e.g., Account Overview activity list, Resident Programs table) to confirm:
  - Hidden when the number of items is ≤ page size.
  - Visible when the number of items exceeds the page size.
- Verify pagination still functions correctly across multiple pages.
- Test edge cases per instance: exactly at threshold, 0 items, and 1 item.

**Known limitations:**  
- Only components that use the shared `Pagination` component are affected. Any views implementing custom/inline pagination will need a separate update to adopt this behavior.
