### PR TITLE
feat: add loading state logic on iframe src evaluate loading state

### DIFF
--- a/frontend/src/Components/LibraryLayout.tsx
+++ b/frontend/src/Components/LibraryLayout.tsx
@@ -10,6 +10,7 @@ import { useTourContext } from '@/Context/TourContext';
 import { targetToStepIndexMap } from './UnlockEdTour';
 import { useUrlPagination } from '@/Hooks/paginationUrlSync';
 import { closeModal, showModal } from './modals';
+import LoadingSpinner from '@/Components/LoadingSpinner';
 
 export default function LibaryLayout({
     studentView
@@ -100,54 +101,64 @@ export default function LibaryLayout({
 
     return (
         <>
-            <div
-                className={`${activeView === ViewType.Grid ? 'grid grid-cols-4 gap-6' : 'space-y-4'}`}
-            >
-                {libraries?.data.map((library, index) => {
-                    if (index === 0) {
-                        return (
-                            <div
-                                id="knowledge-center-enter-library"
-                                className={
-                                    tourState.tourActive &&
-                                    tourState.target ===
-                                        '#knowledge-center-enter-library'
-                                        ? 'animate-pulse border border-2 border-primary-yellow rounded-xl'
-                                        : ''
-                                }
-                                key={library.id}
-                            >
-                                <LibraryCard
+            {librariesLoading ? (
+                <div className="flex justify-center items-center py-12">
+                    <LoadingSpinner text="Loading libraries..." />
+                </div>
+            ) : (
+                <div
+                    className={`${activeView === ViewType.Grid ? 'grid grid-cols-4 gap-6' : 'space-y-4'}`}
+                >
+                    {libraries?.data.map((library, index) => {
+                        if (index === 0) {
+                            return (
+                                <div
+                                    id="knowledge-center-enter-library"
+                                    className={
+                                        tourState.tourActive &&
+                                        tourState.target ===
+                                            '#knowledge-center-enter-library'
+                                            ? 'animate-pulse border border-2 border-primary-yellow rounded-xl'
+                                            : ''
+                                    }
                                     key={library.id}
-                                    library={library}
-                                    mutate={updateLibrary}
-                                    role={
-                                        adminWithStudentView()
-                                            ? UserRole.Student
-                                            : role
-                                    }
-                                    onSearchClick={() =>
-                                        setSearchModalLibrary(library)
-                                    }
-                                    view={activeView}
-                                />
-                            </div>
+                                >
+                                    <LibraryCard
+                                        key={library.id}
+                                        library={library}
+                                        mutate={updateLibrary}
+                                        role={
+                                            adminWithStudentView()
+                                                ? UserRole.Student
+                                                : role
+                                        }
+                                        onSearchClick={() =>
+                                            setSearchModalLibrary(library)
+                                        }
+                                        view={activeView}
+                                    />
+                                </div>
+                            );
+                        }
+                        return (
+                            <LibraryCard
+                                key={library.id}
+                                library={library}
+                                mutate={updateLibrary}
+                                role={
+                                    adminWithStudentView()
+                                        ? UserRole.Student
+                                        : role
+                                }
+                                onSearchClick={() =>
+                                    setSearchModalLibrary(library)
+                                }
+                                view={activeView}
+                            />
                         );
-                    }
-                    return (
-                        <LibraryCard
-                            key={library.id}
-                            library={library}
-                            mutate={updateLibrary}
-                            role={
-                                adminWithStudentView() ? UserRole.Student : role
-                            }
-                            onSearchClick={() => setSearchModalLibrary(library)}
-                            view={activeView}
-                        />
-                    );
-                })}
-            </div>
+                    })}
+                </div>
+            )}
             {!librariesLoading && !librariesError && librariesMeta && (
                 <div className="flex justify-center">
                     <Pagination

--- a/frontend/src/Components/LibraryLayout.tsx
+++ b/frontend/src/Components/LibraryLayout.tsx
@@ -102,9 +102,7 @@ export default function LibaryLayout({
     return (
         <>
             {librariesLoading ? (
-                <div className="flex justify-center items-center py-12">
-                    <LoadingSpinner text="Loading libraries..." />
-                </div>
+                <LoadingSpinner text="Loading libraries..." centered />
             ) : (
                 <div
                     className={`${activeView === ViewType.Grid ? 'grid grid-cols-4 gap-6' : 'space-y-4'}`}

--- a/frontend/src/Components/LoadingSpinner.tsx
+++ b/frontend/src/Components/LoadingSpinner.tsx
@@ -1,0 +1,26 @@
+interface LoadingSpinnerProps {
+    size?: 'sm' | 'md' | 'lg';
+    text?: string;
+    className?: string;
+}
+
+export default function LoadingSpinner({
+    size = 'md',
+    text = 'Loading...',
+    className = ''
+}: LoadingSpinnerProps) {
+    const sizeClasses = {
+        sm: 'loading-sm',
+        md: 'loading-md',
+        lg: 'loading-lg'
+    };
+
+    return (
+        <div className={`flex gap-4 justify-center items-center ${className}`}>
+            <span
+                className={`loading loading-spinner ${sizeClasses[size]}`}
+            ></span>
+            {text && <p className="text-lg">{text}</p>}
+        </div>
+    );
+}

--- a/frontend/src/Components/LoadingSpinner.tsx
+++ b/frontend/src/Components/LoadingSpinner.tsx
@@ -2,12 +2,16 @@ interface LoadingSpinnerProps {
     size?: 'sm' | 'md' | 'lg';
     text?: string;
     className?: string;
+    centered?: boolean;
+    overlay?: boolean;
 }
 
 export default function LoadingSpinner({
     size = 'md',
     text = 'Loading...',
-    className = ''
+    className = '',
+    centered = false,
+    overlay = false
 }: LoadingSpinnerProps) {
     const sizeClasses = {
         sm: 'loading-sm',
@@ -15,12 +19,24 @@ export default function LoadingSpinner({
         lg: 'loading-lg'
     };
 
-    return (
-        <div className={`flex gap-4 justify-center items-center ${className}`}>
+    const spinnerContent = (
+        <div
+            className={`flex gap-4 justify-center items-center ${overlay ? 'text-grey-4 bg-grey-1 p-4 rounded-md shadow-lg' : ''} ${className}`}
+        >
             <span
                 className={`loading loading-spinner ${sizeClasses[size]}`}
             ></span>
             {text && <p className="text-lg">{text}</p>}
         </div>
     );
+
+    if (centered) {
+        return (
+            <div className="flex justify-center items-center py-12">
+                {spinnerContent}
+            </div>
+        );
+    }
+
+    return spinnerContent;
 }

--- a/frontend/src/Components/VideoContent.tsx
+++ b/frontend/src/Components/VideoContent.tsx
@@ -11,6 +11,7 @@ import VideoCard from '@/Components/VideoCard';
 import { isAdministrator, useAuth } from '@/useAuth';
 import { useLocation, useOutletContext } from 'react-router-dom';
 import { useUrlPagination } from '@/Hooks/paginationUrlSync';
+import LoadingSpinner from '@/Components/LoadingSpinner';
 
 export default function VideoContent() {
     const { user } = useAuth();
@@ -49,19 +50,25 @@ export default function VideoContent() {
 
     return (
         <>
-            <div
-                className={`${activeView === ViewType.Grid ? 'grid grid-cols-4 gap-6' : 'space-y-4'}`}
-            >
-                {videoData.map((video) => (
-                    <VideoCard
-                        key={video.id}
-                        video={video}
-                        mutate={mutate}
-                        role={UserRole.Student}
-                        view={activeView}
-                    />
-                ))}
-            </div>
+            {isLoading ? (
+                <div className="flex justify-center items-center py-12">
+                    <LoadingSpinner text="Loading videos..." />
+                </div>
+            ) : (
+                <div
+                    className={`${activeView === ViewType.Grid ? 'grid grid-cols-4 gap-6' : 'space-y-4'}`}
+                >
+                    {videoData.map((video) => (
+                        <VideoCard
+                            key={video.id}
+                            video={video}
+                            mutate={mutate}
+                            role={UserRole.Student}
+                            view={activeView}
+                        />
+                    ))}
+                </div>
+            )}
             {!isLoading && !error && meta && videoData.length > 0 && (
                 <div className="flex justify-center">
                     <Pagination

--- a/frontend/src/Components/VideoContent.tsx
+++ b/frontend/src/Components/VideoContent.tsx
@@ -51,9 +51,7 @@ export default function VideoContent() {
     return (
         <>
             {isLoading ? (
-                <div className="flex justify-center items-center py-12">
-                    <LoadingSpinner text="Loading videos..." />
-                </div>
+                <LoadingSpinner text="Loading videos..." centered />
             ) : (
                 <div
                     className={`${activeView === ViewType.Grid ? 'grid grid-cols-4 gap-6' : 'space-y-4'}`}

--- a/frontend/src/Pages/HelpfulLinks.tsx
+++ b/frontend/src/Pages/HelpfulLinks.tsx
@@ -58,9 +58,7 @@ export default function HelpfulLinks() {
     return (
         <>
             {isLoading ? (
-                <div className="flex justify-center items-center py-12">
-                    <LoadingSpinner text="Loading helpful links..." />
-                </div>
+                <LoadingSpinner text="Loading helpful links..." centered />
             ) : (
                 <div
                     className={`${activeView === ViewType.Grid ? 'grid grid-cols-4 gap-6' : 'space-y-4'}`}

--- a/frontend/src/Pages/HelpfulLinks.tsx
+++ b/frontend/src/Pages/HelpfulLinks.tsx
@@ -12,6 +12,7 @@ import useSWR from 'swr';
 import { useUrlPagination } from '@/Hooks/paginationUrlSync';
 import { useLocation, useOutletContext } from 'react-router-dom';
 import { isAdministrator, useAuth } from '@/useAuth';
+import LoadingSpinner from '@/Components/LoadingSpinner';
 
 export default function HelpfulLinks() {
     const { user } = useAuth();
@@ -56,29 +57,37 @@ export default function HelpfulLinks() {
 
     return (
         <>
-            <div
-                className={`${activeView === ViewType.Grid ? 'grid grid-cols-4 gap-6' : 'space-y-4'}`}
-            >
-                {helpfulLinks?.data?.helpful_links.map((link: HelpfulLink) => (
-                    <HelpfulLinkCard
-                        key={link.id}
-                        link={link}
-                        mutate={updateFavorites}
-                        role={UserRole.Student}
-                        view={activeView}
-                    />
-                ))}
-                {error && (
-                    <span className="text-error">
-                        Failed to load helpful links.
-                    </span>
-                )}
-                {!isLoading &&
-                    !error &&
-                    helpfulLinks?.data.helpful_links.length === 0 && (
-                        <span className="text-error">No results</span>
+            {isLoading ? (
+                <div className="flex justify-center items-center py-12">
+                    <LoadingSpinner text="Loading helpful links..." />
+                </div>
+            ) : (
+                <div
+                    className={`${activeView === ViewType.Grid ? 'grid grid-cols-4 gap-6' : 'space-y-4'}`}
+                >
+                    {helpfulLinks?.data?.helpful_links.map(
+                        (link: HelpfulLink) => (
+                            <HelpfulLinkCard
+                                key={link.id}
+                                link={link}
+                                mutate={updateFavorites}
+                                role={UserRole.Student}
+                                view={activeView}
+                            />
+                        )
                     )}
-            </div>
+                    {error && (
+                        <span className="text-error">
+                            Failed to load helpful links.
+                        </span>
+                    )}
+                    {!isLoading &&
+                        !error &&
+                        helpfulLinks?.data.helpful_links.length === 0 && (
+                            <span className="text-error">No results</span>
+                        )}
+                </div>
+            )}
             {!isLoading && !error && helpfulLinksMeta && (
                 <div className="flex justify-center">
                     <Pagination

--- a/frontend/src/Pages/LibraryViewer.tsx
+++ b/frontend/src/Pages/LibraryViewer.tsx
@@ -21,6 +21,7 @@ import { FormModal } from '@/Components/modals/FormModal';
 import { FormInputTypes } from '@/Components/modals';
 import { useTourContext } from '@/Context/TourContext';
 import { targetToStepIndexMap } from '@/Components/UnlockEdTour';
+import LoadingSpinner from '@/Components/LoadingSpinner';
 interface UrlNavState {
     url?: string;
 }
@@ -371,26 +372,27 @@ export default function LibraryViewer() {
                         />
                         {iframeLoading && (
                             <div className="absolute inset-0 bg-background/90 flex items-center justify-center z-10">
-                                <div className="flex gap-4 justify-center items-center">
-                                    <span className="loading loading-spinner loading-lg"></span>
-                                    <p className="text-lg">
-                                        Loading library content...
-                                    </p>
-                                </div>
+                                <LoadingSpinner
+                                    size="lg"
+                                    text="Loading library content..."
+                                    overlay
+                                />
                             </div>
                         )}
                         {iframeError && (
                             <div className="absolute inset-0 bg-background/90 flex items-center justify-center z-10">
-                                <div className="text-center space-y-4">
+                                <div className="text-center space-y-6">
                                     <p className="text-lg text-error">
                                         Failed to load library content
                                     </p>
-                                    <button
-                                        className="button"
-                                        onClick={retryIframeLoad}
-                                    >
-                                        Try Again
-                                    </button>
+                                    <div className="flex justify-center">
+                                        <button
+                                            className="button"
+                                            onClick={retryIframeLoad}
+                                        >
+                                            Try Again
+                                        </button>
+                                    </div>
                                 </div>
                             </div>
                         )}

--- a/frontend/src/Pages/LibraryViewer.tsx
+++ b/frontend/src/Pages/LibraryViewer.tsx
@@ -30,6 +30,8 @@ export default function LibraryViewer() {
     const { id: libraryId } = useParams();
     const [src, setSrc] = useState<string>('');
     const [isLoading, setIsLoading] = useState<boolean>(true);
+    const [iframeLoading, setIframeLoading] = useState<boolean>(false);
+    const [iframeError, setIframeError] = useState<boolean>(false);
     const { toaster } = useToast();
     const navigate = useNavigate();
     const [bookmarked, setBookmarked] = useState<boolean>(false);
@@ -39,6 +41,7 @@ export default function LibraryViewer() {
     const [searchTerm, setSearchTerm] = useState('');
     const modalRef = useRef<HTMLDialogElement>(null);
     const iframeRef = useRef<HTMLIFrameElement>(null);
+    const loadingTimeoutRef = useRef<number | null>(null);
     const location = useLocation() as { state: UrlNavState };
     const { url } = location.state || {};
     const { setPageTitle: setAuthLayoutPageTitle } = usePageTitle();
@@ -71,6 +74,32 @@ export default function LibraryViewer() {
             modalRef.current.style.visibility = 'hidden';
             modalRef.current.close();
         }
+    };
+
+    const handleIframeLoad = () => {
+        setIframeError(false);
+        if (loadingTimeoutRef.current) {
+            clearTimeout(loadingTimeoutRef.current);
+            loadingTimeoutRef.current = null;
+        }
+        setTimeout(() => setIframeLoading(false), 500);
+    };
+
+    const handleIframeError = () => {
+        setIframeLoading(false);
+        setIframeError(true);
+        if (loadingTimeoutRef.current) {
+            clearTimeout(loadingTimeoutRef.current);
+            loadingTimeoutRef.current = null;
+        }
+    };
+
+    const retryIframeLoad = () => {
+        setIframeError(false);
+        setIframeLoading(true);
+        const currentSrc = src;
+        setSrc('');
+        setTimeout(() => setSrc(currentSrc), 100);
     };
 
     const handleSearch = () => {
@@ -147,6 +176,11 @@ export default function LibraryViewer() {
                     `/api/proxy/libraries/${libraryId}/`
                 );
                 if (response.ok) {
+                    setIframeLoading(true);
+                    loadingTimeoutRef.current = window.setTimeout(() => {
+                        setIframeLoading(false);
+                    }, 10000);
+
                     if (url && url !== '' && url.includes('/api/proxy/')) {
                         setSrc(url);
                     } else {
@@ -321,17 +355,46 @@ export default function LibraryViewer() {
                         <p className="my-auto text-lg">Loading...</p>
                     </div>
                 ) : src !== '' ? (
-                    <iframe
-                        ref={iframeRef}
-                        sandbox="allow-scripts allow-same-origin allow-modals allow-popups"
-                        className="w-full h-full"
-                        id="library-viewer-iframe"
-                        src={src}
-                        style={{
-                            border: 'none',
-                            minHeight: '600px'
-                        }}
-                    />
+                    <div className="relative w-full h-full">
+                        <iframe
+                            ref={iframeRef}
+                            sandbox="allow-scripts allow-same-origin allow-modals allow-popups"
+                            className="w-full h-full"
+                            id="library-viewer-iframe"
+                            src={src}
+                            onLoad={handleIframeLoad}
+                            onError={handleIframeError}
+                            style={{
+                                border: 'none',
+                                minHeight: '600px'
+                            }}
+                        />
+                        {iframeLoading && (
+                            <div className="absolute inset-0 bg-background/90 flex items-center justify-center z-10">
+                                <div className="flex gap-4 justify-center items-center">
+                                    <span className="loading loading-spinner loading-lg"></span>
+                                    <p className="text-lg">
+                                        Loading library content...
+                                    </p>
+                                </div>
+                            </div>
+                        )}
+                        {iframeError && (
+                            <div className="absolute inset-0 bg-background/90 flex items-center justify-center z-10">
+                                <div className="text-center space-y-4">
+                                    <p className="text-lg text-error">
+                                        Failed to load library content
+                                    </p>
+                                    <button
+                                        className="button"
+                                        onClick={retryIframeLoad}
+                                    >
+                                        Try Again
+                                    </button>
+                                </div>
+                            </div>
+                        )}
+                    </div>
                 ) : (
                     <div />
                 )}


### PR DESCRIPTION
## Description of the change
This PR is the beginning implementation of loading state improvements across the app, it focuses on the Knowledge Center and Library viewer. 
Changes: 
- Added loading spinners to all 3 knowledge center sections
- Implemented iframe loading overlay for the Library Viewer with error handling and a retry functionality 
- Created a reusable loading spinner component 


- **Related issues**:https://app.asana.com/1/1201607307149189/project/1209460078641109/task/1210839607709210?focus=true

## Screenshot(s)
<img width="1123" height="296" alt="image" src="https://github.com/user-attachments/assets/86157182-0b97-4d3d-b96a-37debc449375" />

### The loading spinner is kind of hard to see here because it's a gray color, I was going to change it, but am hesitant to due to the fact that all of these libraries are going to have different backgrounds, so if we adjust it, it's more than likely going to affect a different library and how it's seen on that library, I don't know if there's a happy medium?
<img width="842" height="570" alt="image" src="https://github.com/user-attachments/assets/757f97c9-2f6e-4131-b365-288e68f6bece" />



## Additional context

Current places (including what was updated in this PR) that are arguably all set for loading state: MyCourses.tsx, Favorites.tsx, LibrarySearchResultsModal.tsx, LoginForm.tsx, LibraryLayout.tsx, VideoContent.tsx, HelpfulLinks.tsx, LibraryViewer.tsx

Places that need to be addressed: 
ResidentHome.tsx - Has 3 SWR Calls and no loading feedback
CourseCatalog.tsx - No loading for course catalog and or the search/catalog
MyProgress.tsx - Only basic text loading 
AdminLayer1.tsx - Each section loads without any feedback or loading state 
ClassLayout.tsx - Class data loads without indication
StudentManagement.tsx - Needs updated loading interface 

I focused on a LoadingSpinner for API calls, and more of an overlay for the iframe content after originally building out matching skeleton cards. We have a decent array of in particular SWR calls throughout the application that don't have loading states attached to them, I understand that these are singular API calls, but at the same time some of our SWR calls are pretty complex queries, so I think we need to account for that, and I think it's better to stay consistent across the application than to have some for some calls, and not the other. I don't think being safe and consistent could ever be a bad thing. If the SWR loading state never gets triggered, great, if it does, we have something in place. 