### PR TITLE
fix: Suggestion button visibility in Knowledge Center search

### DIFF
--- a/frontend/src/Components/LibrarySearchResultsModal.tsx
+++ b/frontend/src/Components/LibrarySearchResultsModal.tsx
@@ -268,7 +268,7 @@ const LibrarySearchResultsModal = forwardRef<
                             onSearchClick={() => void handleSearch(1, 10)}
                             ref={searchBarRef}
                         />
-                        {searchTerm.trim() && !searchResults?.items?.length && (
+                        {searchTerm.trim() && (
                             <button
                                 type="button"
                                 onClick={() => void handleSuggestQueries()}


### PR DESCRIPTION
## Fixed Knowledge Center search suggestion button disappearing after selecting libraries from the dropdown.

 Removed the condition that was hiding the suggestion button when search results were found, ensuring the button remains visible whenever a user has entered a search term.

- **Related issues**: Link to related Asana ticket that this closes.
[Suggestion button in Search disappears and reappears after choosing libraries.](https://app.asana.com/1/1201607307149189/project/1209460078641109/task/1210464235048871)
## Screenshot(s)


https://github.com/user-attachments/assets/2dbe49d9-9429-490f-8584-cbcb9aa934fb




