### PR TITLE
fix: add try catch block around logic that accesses the document object to avoid error loop per 465

### DIFF
--- a/frontend/src/Components/TitleManager.tsx
+++ b/frontend/src/Components/TitleManager.tsx
@@ -18,12 +18,21 @@ export function TitleManager() {
                         const libraryViewer = document.getElementById(
                             'library-viewer-iframe'
                         ) as HTMLIFrameElement;
-                        if (libraryViewer?.contentWindow?.document) {
-                            const iframeTitle =
-                                libraryViewer.contentWindow.document.title;
-                            if (iframeTitle) {
-                                document.title = iframeTitle + ' - UnlockEd';
+                        try {
+                            if (libraryViewer?.contentWindow?.document) {
+                                const iframeTitle =
+                                    libraryViewer.contentWindow.document.title;
+                                if (iframeTitle) {
+                                    document.title =
+                                        iframeTitle + ' - UnlockEd';
+                                }
                             }
+                        } catch (error) {
+                            console.log(
+                                'Error occurred while trying to access document, error is: ',
+                                error
+                            );
+                            clearInterval(titleInterval);
                         }
                     }, 1000);
 


### PR DESCRIPTION
## Description of the change

Added some error handling logic to avoid an infinite error loop when viewing specific kiwix library pages within the Knowledge Center. 

- **Related issues**: Link to related Asana ticket that this closes: [Bug: TitleManager Cross-Origin Frame Access Error](https://app.asana.com/1/1201607307149189/project/1209460078641109/task/1211317165922357?focus=true)

## Screenshot(s)
After fix:
<img width="1894" height="673" alt="image" src="https://github.com/user-attachments/assets/ba370a21-e502-414e-9e6c-db591744f2cb" />

Before fix:
<img width="1891" height="939" alt="image" src="https://github.com/user-attachments/assets/4550e474-378b-4114-8178-2eeafc1c3997" />

## Additional context
In order to test that this process is working I suggest that you do the following steps:

1. Open kiwix.go on line 23 change it to:  `return 1000`
2. Open up docker-compose.yml on line 85 change url to: `https://kiwix.dev.unlockedlabs.xyz`
3. Open proxy_handler.go on line 45 change `http` to `https`
4. Run the following query against the unlocked database: 

`update open_content_providers set url = 'https://kiwix.dev.unlockedlabs.xyz' where id = 2;`

5. Start your containers
6. Make sure you have 'nats' client tool installed (if you do not, then google it).
7. Run the following command (find the correct values if this does not work for you): 
`nats pub --server=nats://127.0.0.1:4222 --user=unlocked --password=dev tasks.scrape_kiwix '{"job_id":"8263ac14-dbf7-4eb7-90d0-c2f4a72e157e", "open_content_provider_id":2}'`