### PR TITLE
James unlocked/improved attendance page nav

### DIFF
--- a/frontend/src/Components/MonthNavigation.tsx
+++ b/frontend/src/Components/MonthNavigation.tsx
@@ -1,51 +1,36 @@
 import { ChevronLeftIcon, ChevronRightIcon } from '@heroicons/react/24/outline';
+import {
+    getPreviousMonth,
+    getNextMonth,
+    formatMonthYear,
+    getCurrentMonth
+} from '@/Components/helperFunctions/formatting';
 
 interface MonthNavigationProps {
-    currentMonth: string; // YYYY-MM format
+    currentMonth: string;
     onMonthChange: (month: string) => void;
-    hasEarlierClasses?: boolean; // Whether earlier months have classes
-    hasLaterClasses?: boolean; // Whether later months have classes
+    showPrevious?: boolean;
+    showNext?: boolean;
 }
 
 export default function MonthNavigation({
     currentMonth,
     onMonthChange,
-    hasEarlierClasses = true, // Default to true for backward compatibility
-    hasLaterClasses = true // Default to true for backward compatibility
+    showPrevious = true,
+    showNext = true
 }: MonthNavigationProps) {
-    const [year, month] = currentMonth.split('-').map(Number);
-
-    const currentMonthYear = new Date().toISOString().substring(0, 7);
+    const currentMonthYear = getCurrentMonth();
     const isCurrentMonth = currentMonth === currentMonthYear;
 
-    const formatMonthYear = (dateStr: string): string => {
-        const [y, m] = dateStr.split('-').map(Number);
-        const date = new Date(y, m - 1);
-        return date.toLocaleDateString('en-US', {
-            month: 'long',
-            year: 'numeric'
-        });
-    };
-
-    const getPreviousMonth = (): string => {
-        const prevDate = new Date(year, month - 2); // month - 2 because JS months are 0-indexed
-        return `${prevDate.getFullYear()}-${String(prevDate.getMonth() + 1).padStart(2, '0')}`;
-    };
-
-    const getNextMonth = (): string => {
-        const nextDate = new Date(year, month); // month is already correct for next month
-        return `${nextDate.getFullYear()}-${String(nextDate.getMonth() + 1).padStart(2, '0')}`;
-    };
-
     const goToPreviousMonth = () => {
-        if (hasEarlierClasses) {
-            onMonthChange(getPreviousMonth());
+        if (showPrevious) {
+            onMonthChange(getPreviousMonth(currentMonth));
         }
     };
 
     const goToNextMonth = () => {
-        if (hasLaterClasses) {
-            onMonthChange(getNextMonth());
+        if (showNext) {
+            onMonthChange(getNextMonth(currentMonth));
         }
     };
 
@@ -54,45 +39,43 @@ export default function MonthNavigation({
     };
 
     return (
-        <div className="flex items-center justify-between mb-6 p-4 bg-grey-1 rounded-lg">
-            <div className="flex items-center gap-4">
-                <button
-                    onClick={goToPreviousMonth}
-                    disabled={!hasEarlierClasses}
-                    className={`flex items-center gap-2 px-3 py-2 rounded-md transition-colors ${
-                        hasEarlierClasses
-                            ? 'text-teal-4 hover:bg-grey-2 cursor-pointer'
-                            : 'text-grey-3 cursor-not-allowed'
-                    }`}
-                    aria-label="Previous month"
-                >
-                    <ChevronLeftIcon className="h-5 w-5" />
-                    Previous
-                </button>
+        <div className="flex items-center justify-between mb-6 py-3 px-4 border border-grey-1 rounded-lg bg-white shadow-sm">
+            <button
+                onClick={goToPreviousMonth}
+                disabled={!showPrevious}
+                className={`flex items-center gap-2 px-4 py-3 rounded-md transition-colors ${
+                    showPrevious
+                        ? 'text-teal-4 hover:bg-grey-1 cursor-pointer'
+                        : 'text-grey-3 cursor-default'
+                }`}
+                aria-label="Previous month"
+            >
+                <ChevronLeftIcon className="h-5 w-5" />
+                Previous
+            </button>
 
-                <h2 className="text-xl font-semibold text-teal-4 min-w-[200px] text-center">
-                    {formatMonthYear(currentMonth)}
-                </h2>
+            <h2 className="text-xl font-semibold text-teal-4 px-4 py-3 text-center flex-1 max-w-[300px]">
+                {formatMonthYear(currentMonth)}
+            </h2>
 
-                <button
-                    onClick={goToNextMonth}
-                    disabled={!hasLaterClasses}
-                    className={`flex items-center gap-2 px-3 py-2 rounded-md transition-colors ${
-                        hasLaterClasses
-                            ? 'text-teal-4 hover:bg-grey-2 cursor-pointer'
-                            : 'text-grey-3 cursor-not-allowed'
-                    }`}
-                    aria-label="Next month"
-                >
-                    Next
-                    <ChevronRightIcon className="h-5 w-5" />
-                </button>
-            </div>
+            <button
+                onClick={goToNextMonth}
+                disabled={!showNext}
+                className={`flex items-center gap-2 px-4 py-3 rounded-md transition-colors ${
+                    showNext
+                        ? 'text-teal-4 hover:bg-grey-1 cursor-pointer'
+                        : 'text-grey-3 cursor-default'
+                }`}
+                aria-label="Next month"
+            >
+                Next
+                <ChevronRightIcon className="h-5 w-5" />
+            </button>
 
             {!isCurrentMonth && (
                 <button
                     onClick={goToThisMonth}
-                    className="px-4 py-2 bg-teal-4 text-white rounded-md hover:bg-teal-5 transition-colors"
+                    className="ml-4 px-4 py-3 bg-teal-1 text-teal-4 rounded-md hover:bg-teal-2 transition-colors border border-teal-3"
                 >
                     This Month
                 </button>

--- a/frontend/src/Components/MonthNavigation.tsx
+++ b/frontend/src/Components/MonthNavigation.tsx
@@ -72,14 +72,17 @@ export default function MonthNavigation({
                 <ChevronRightIcon className="h-5 w-5" />
             </button>
 
-            {!isCurrentMonth && (
-                <button
-                    onClick={goToThisMonth}
-                    className="ml-4 px-4 py-3 bg-teal-1 text-teal-4 rounded-md hover:bg-teal-2 transition-colors border border-teal-3"
-                >
-                    This Month
-                </button>
-            )}
+            <button
+                onClick={goToThisMonth}
+                disabled={isCurrentMonth}
+                className={`ml-4 px-4 py-3 rounded-md transition-colors border ${
+                    isCurrentMonth
+                        ? 'bg-grey-1 text-grey-3 border-grey-2 cursor-default'
+                        : 'bg-teal-1 text-teal-4 border-teal-3 hover:bg-teal-2 cursor-pointer'
+                }`}
+            >
+                This Month
+            </button>
         </div>
     );
 }

--- a/frontend/src/Components/MonthNavigation.tsx
+++ b/frontend/src/Components/MonthNavigation.tsx
@@ -1,0 +1,102 @@
+import { ChevronLeftIcon, ChevronRightIcon } from '@heroicons/react/24/outline';
+
+interface MonthNavigationProps {
+    currentMonth: string; // YYYY-MM format
+    onMonthChange: (month: string) => void;
+    hasEarlierClasses?: boolean; // Whether earlier months have classes
+    hasLaterClasses?: boolean; // Whether later months have classes
+}
+
+export default function MonthNavigation({
+    currentMonth,
+    onMonthChange,
+    hasEarlierClasses = true, // Default to true for backward compatibility
+    hasLaterClasses = true // Default to true for backward compatibility
+}: MonthNavigationProps) {
+    const [year, month] = currentMonth.split('-').map(Number);
+
+    const currentMonthYear = new Date().toISOString().substring(0, 7);
+    const isCurrentMonth = currentMonth === currentMonthYear;
+
+    const formatMonthYear = (dateStr: string): string => {
+        const [y, m] = dateStr.split('-').map(Number);
+        const date = new Date(y, m - 1);
+        return date.toLocaleDateString('en-US', {
+            month: 'long',
+            year: 'numeric'
+        });
+    };
+
+    const getPreviousMonth = (): string => {
+        const prevDate = new Date(year, month - 2); // month - 2 because JS months are 0-indexed
+        return `${prevDate.getFullYear()}-${String(prevDate.getMonth() + 1).padStart(2, '0')}`;
+    };
+
+    const getNextMonth = (): string => {
+        const nextDate = new Date(year, month); // month is already correct for next month
+        return `${nextDate.getFullYear()}-${String(nextDate.getMonth() + 1).padStart(2, '0')}`;
+    };
+
+    const goToPreviousMonth = () => {
+        if (hasEarlierClasses) {
+            onMonthChange(getPreviousMonth());
+        }
+    };
+
+    const goToNextMonth = () => {
+        if (hasLaterClasses) {
+            onMonthChange(getNextMonth());
+        }
+    };
+
+    const goToThisMonth = () => {
+        onMonthChange(currentMonthYear);
+    };
+
+    return (
+        <div className="flex items-center justify-between mb-6 p-4 bg-grey-1 rounded-lg">
+            <div className="flex items-center gap-4">
+                <button
+                    onClick={goToPreviousMonth}
+                    disabled={!hasEarlierClasses}
+                    className={`flex items-center gap-2 px-3 py-2 rounded-md transition-colors ${
+                        hasEarlierClasses
+                            ? 'text-teal-4 hover:bg-grey-2 cursor-pointer'
+                            : 'text-grey-3 cursor-not-allowed'
+                    }`}
+                    aria-label="Previous month"
+                >
+                    <ChevronLeftIcon className="h-5 w-5" />
+                    Previous
+                </button>
+
+                <h2 className="text-xl font-semibold text-teal-4 min-w-[200px] text-center">
+                    {formatMonthYear(currentMonth)}
+                </h2>
+
+                <button
+                    onClick={goToNextMonth}
+                    disabled={!hasLaterClasses}
+                    className={`flex items-center gap-2 px-3 py-2 rounded-md transition-colors ${
+                        hasLaterClasses
+                            ? 'text-teal-4 hover:bg-grey-2 cursor-pointer'
+                            : 'text-grey-3 cursor-not-allowed'
+                    }`}
+                    aria-label="Next month"
+                >
+                    Next
+                    <ChevronRightIcon className="h-5 w-5" />
+                </button>
+            </div>
+
+            {!isCurrentMonth && (
+                <button
+                    onClick={goToThisMonth}
+                    className="px-4 py-2 bg-teal-4 text-white rounded-md hover:bg-teal-5 transition-colors"
+                >
+                    This Month
+                </button>
+            )}
+        </div>
+    );
+}

--- a/frontend/src/Components/helperFunctions/formatting.tsx
+++ b/frontend/src/Components/helperFunctions/formatting.tsx
@@ -143,7 +143,31 @@ export function fromLocalDateToNumericDateFormat(date: Date, timezone: string) {
     });
 }
 
-//returns timestamp in YYYYmmDDhhMM used currently for naming files
+export function getPreviousMonth(currentMonth: string): string {
+    const [year, month] = currentMonth.split('-').map(Number);
+    const prevDate = new Date(year, month - 2);
+    return `${prevDate.getFullYear()}-${String(prevDate.getMonth() + 1).padStart(2, '0')}`;
+}
+
+export function getNextMonth(currentMonth: string): string {
+    const [year, month] = currentMonth.split('-').map(Number);
+    const nextDate = new Date(year, month);
+    return `${nextDate.getFullYear()}-${String(nextDate.getMonth() + 1).padStart(2, '0')}`;
+}
+
+export function formatMonthYear(monthString: string): string {
+    const [year, month] = monthString.split('-').map(Number);
+    const date = new Date(year, month - 1);
+    return date.toLocaleDateString('en-US', {
+        month: 'long',
+        year: 'numeric'
+    });
+}
+
+export function getCurrentMonth(): string {
+    return new Date().toISOString().substring(0, 7);
+}
+
 export function getTimestamp(): string {
     const currentDate = new Date();
     const padIt = (theNumber: number) => theNumber.toString().padStart(2, '0');

--- a/frontend/src/Pages/ClassEvents.tsx
+++ b/frontend/src/Pages/ClassEvents.tsx
@@ -64,7 +64,6 @@ export default function ClassEvents() {
         this_program ?? ({} as Class)
     );
 
-    // Helper functions to check if adjacent months have actual events
     const getPreviousMonth = (): string => {
         const [year, month] = currentMonth.split('-').map(Number);
         const prevDate = new Date(year, month - 2); // month - 2 because JS months are 0-indexed

--- a/frontend/src/Pages/ClassEvents.tsx
+++ b/frontend/src/Pages/ClassEvents.tsx
@@ -188,8 +188,8 @@ export default function ClassEvents() {
             <MonthNavigation
                 currentMonth={currentMonth}
                 onMonthChange={setCurrentMonth}
-                hasEarlierClasses={hasEarlierClasses()}
-                hasLaterClasses={hasLaterClasses()}
+                showPrevious={hasEarlierClasses()}
+                showNext={hasLaterClasses()}
             />
 
             {isLoading && <div>Loading...</div>}

--- a/frontend/src/Pages/ClassEvents.tsx
+++ b/frontend/src/Pages/ClassEvents.tsx
@@ -11,7 +11,11 @@ import MonthNavigation from '@/Components/MonthNavigation';
 import { isCompletedCancelledOrArchived } from './ProgramOverviewDashboard';
 import { ClassEventInstance } from '@/types/events';
 import AttendanceCell from '@/Components/AttendanceCell';
-import { parseLocalDay } from '@/Components/helperFunctions/formatting';
+import {
+    parseLocalDay,
+    getPreviousMonth,
+    getNextMonth
+} from '@/Components/helperFunctions/formatting';
 import {
     ClipboardDocumentCheckIcon,
     EyeIcon
@@ -29,7 +33,7 @@ export default function ClassEvents() {
     const navigate = useNavigate();
 
     const defaultMonth = new Date().toISOString().substring(0, 7);
-    const [currentMonth, setCurrentMonth] = useState(defaultMonth);
+    const [currentMonth, setCurrentMonth] = useState<string>(defaultMonth);
 
     const [year, month] = currentMonth.split('-');
 
@@ -63,46 +67,6 @@ export default function ClassEvents() {
     const blockEdits = isCompletedCancelledOrArchived(
         this_program ?? ({} as Class)
     );
-
-    const getPreviousMonth = (): string => {
-        const [year, month] = currentMonth.split('-').map(Number);
-        const prevDate = new Date(year, month - 2); // month - 2 because JS months are 0-indexed
-        return `${prevDate.getFullYear()}-${String(prevDate.getMonth() + 1).padStart(2, '0')}`;
-    };
-
-    const getNextMonth = (): string => {
-        const [year, month] = currentMonth.split('-').map(Number);
-        const nextDate = new Date(year, month); // month is already correct for next month
-        return `${nextDate.getFullYear()}-${String(nextDate.getMonth() + 1).padStart(2, '0')}`;
-    };
-
-    const previousMonth = getPreviousMonth();
-    const nextMonth = getNextMonth();
-
-    const hasEarlierClasses = (): boolean => {
-        if (!this_program) return true;
-        if (!this_program.start_dt) return true;
-
-        const classStartMonth = new Date(this_program.start_dt)
-            .toISOString()
-            .substring(0, 7);
-        if (previousMonth < classStartMonth) return false;
-
-        return true;
-    };
-
-    const hasLaterClasses = (): boolean => {
-        if (!this_program) return true;
-        if (!this_program.end_dt) return true;
-
-        const classEndMonth = new Date(this_program.end_dt)
-            .toISOString()
-            .substring(0, 7);
-
-        if (nextMonth > classEndMonth) return false;
-
-        return true;
-    };
 
     function isFutureDate(date: string): boolean {
         const day = parseLocalDay(date);
@@ -182,6 +146,20 @@ export default function ClassEvents() {
             </div>
         );
     }
+
+    const hasEarlierClasses = () => {
+        if (!this_program?.start_dt) return true;
+        const classStartMonth = this_program.start_dt.substring(0, 7);
+        const previousMonth = getPreviousMonth(currentMonth);
+        return previousMonth >= classStartMonth;
+    };
+
+    const hasLaterClasses = () => {
+        if (!this_program?.end_dt) return true;
+        const classEndMonth = this_program.end_dt.substring(0, 7);
+        const nextMonth = getNextMonth(currentMonth);
+        return nextMonth <= classEndMonth;
+    };
 
     return (
         <div>


### PR DESCRIPTION
## Description of the change

Users were confused by having both calendar dropdown AND pagination controls on the attendance page. The pagination only worked within the selected month, leading users to think earlier classes were missing and attendance percentages were incorrect.

## Solution
- **Removed** calendar dropdown component
- **Removed** pagination controls that only worked within months  
- **Added** clean month navigation: "← Previous | August 2025 | Next →"
- **Added** "This Month" button for quick navigation
- **Fixed** daily classes to show all events per month (31 max)
- **Added** smart button states based on class date ranges

## Benefits
- Eliminates user confusion about dual navigation
- All events for a month are visible at once
- Clear visual month navigation that users understand
- Accurate attendance tracking across all months
- Works reliably for daily, weekly, and monthly classes

- [x] Daily programs show all events per month
- [x] Navigation buttons work correctly within class date ranges  
- [x] "This Month" button functions properly

- **Related issues**: Link to related Asana ticket that this closes.
[Improve Navigation on Attendance Page](https://app.asana.com/1/1201607307149189/project/1209460078641109/task/1210958323931663)
## Screenshot(s)

https://github.com/user-attachments/assets/46c2d8b0-f480-46e0-b125-9f3ab191a2ab


