### PR TITLE
Add a sort-by hidden/available to the videos tab

### DIFF
--- a/backend/src/database/videos.go
+++ b/backend/src/database/videos.go
@@ -67,7 +67,7 @@ type VideoResponse struct {
 	IsFavorited bool `json:"is_favorited"`
 }
 
-func (db *DB) GetAllVideos(args *models.QueryContext, onlyVisible bool) ([]VideoResponse, error) {
+func (db *DB) GetAllVideos(args *models.QueryContext, visibility string) ([]VideoResponse, error) {
 	var videos []VideoResponse
 	tx := db.WithContext(args.Ctx).Model(&models.Video{}).Preload("Attempts").Select(`
 	videos.*,
@@ -86,8 +86,11 @@ func (db *DB) GetAllVideos(args *models.QueryContext, onlyVisible bool) ([]Video
         and fvs.content_id = videos.id 
         and fvs.facility_id = ?`, args.FacilityID)
 
-	if onlyVisible {
-		tx = tx.Where("fvs.visibility_status = ?", true)
+	switch visibility {
+	case "student":
+		tx = tx.Where("COALESCE(fvs.visibility_status, false) = ?", true)
+	case "hidden":
+		tx = tx.Where("COALESCE(fvs.visibility_status, false) = ?", false)
 	}
 	if args.Search != "" {
 		args.Search = "%" + args.Search + "%"

--- a/backend/src/handlers/video_handler.go
+++ b/backend/src/handlers/video_handler.go
@@ -25,10 +25,13 @@ func (srv *Server) registerVideoRoutes() []routeDef {
 
 func (srv *Server) handleGetVideos(w http.ResponseWriter, r *http.Request, log sLog) error {
 	user := r.Context().Value(ClaimsKey).(*Claims)
-	// cookie gets preference over query unless query specifies student
-	onlyVisible := !user.isAdmin() || r.URL.Query().Get("visibility") == "student"
+	visibility := r.URL.Query().Get("visibility")
+
+	if !user.isAdmin() {
+		visibility = "student"
+	}
 	args := srv.getQueryContext(r)
-	videos, err := srv.Db.GetAllVideos(&args, onlyVisible)
+	videos, err := srv.Db.GetAllVideos(&args, visibility)
 	if err != nil {
 		return newInternalServerServiceError(err, "error fetching videos")
 	}

--- a/frontend/src/Pages/OpenContent.tsx
+++ b/frontend/src/Pages/OpenContent.tsx
@@ -4,7 +4,8 @@ import {
     Tab,
     Option,
     FilterOpenContent,
-    FeatureAccess
+    FeatureAccess,
+    VideoAdminVisibility
 } from '@/common';
 import { usePageTitle } from '@/Context/AuthLayoutPageTitleContext';
 import { useEffect, useMemo, useRef, useState } from 'react';
@@ -71,7 +72,13 @@ export default function OpenContent() {
         setActiveTab(
             tabOptions.find((t) => t.value === currentTabValue) ?? tabOptions[0]
         );
-        setFilterVisibilityAdmin(LibraryAdminVisibility['All Libraries']);
+        if (currentTabValue === 'videos') {
+            setVideoVisibilityAdmin(VideoAdminVisibility['All Videos']);
+        } else if (currentTabValue === 'libraries') {
+            setFilterLibraryVisibilityAdmin(
+                LibraryAdminVisibility['All Libraries']
+            );
+        }
         setSortQuery(FilterOpenContent['Title (A to Z)']);
         setSearchTerm('');
     }, [route.pathname, tabOptions]);
@@ -160,9 +167,12 @@ export default function OpenContent() {
     const { categories } = useLoaderData() as {
         categories: Option[];
     };
-    const [filterVisibilityAdmin, setFilterVisibilityAdmin] = useState<string>(
-        LibraryAdminVisibility['All Libraries']
-    );
+    const [filterLibraryVisibilityAdmin, setFilterLibraryVisibilityAdmin] =
+        useState<LibraryAdminVisibility>(
+            LibraryAdminVisibility['All Libraries']
+        );
+    const [filterVideoVisibilityAdmin, setVideoVisibilityAdmin] =
+        useState<VideoAdminVisibility>(VideoAdminVisibility['All Videos']);
     const [categoryQueryString, setCategoryQueryString] = useState<string>('');
     const [sortQuery, setSortQuery] = useState<string>(
         FilterOpenContent['Title (A to Z)']
@@ -182,7 +192,23 @@ export default function OpenContent() {
                         {isAdmin && isManagement && (
                             <DropdownControl
                                 enumType={LibraryAdminVisibility}
-                                setState={setFilterVisibilityAdmin}
+                                setState={setFilterLibraryVisibilityAdmin}
+                            />
+                        )}
+                    </>
+                );
+            } else if (currentTabValue === 'videos') {
+                return (
+                    <>
+                        <DropdownControl
+                            setState={setSortQuery}
+                            enumType={FilterOpenContent}
+                        />
+                        {isAdmin && isManagement && (
+                            <DropdownControl
+                                key={`video-vis-${currentTabValue}`}
+                                enumType={VideoAdminVisibility}
+                                setState={setVideoVisibilityAdmin}
                             />
                         )}
                     </>
@@ -199,9 +225,13 @@ export default function OpenContent() {
         [
             currentTabValue,
             user,
+            isAdmin,
+            isManagement,
             setCategoryQueryString,
             setSortQuery,
-            categories
+            categories,
+            filterLibraryVisibilityAdmin,
+            filterVideoVisibilityAdmin
         ]
     );
 
@@ -251,7 +281,10 @@ export default function OpenContent() {
                     context={{
                         activeView,
                         searchQuery,
-                        filterVisibilityAdmin,
+                        filterVisibilityAdmin:
+                            currentTabValue === 'videos'
+                                ? filterVideoVisibilityAdmin
+                                : filterLibraryVisibilityAdmin,
                         categoryQueryString,
                         sortQuery
                     }}

--- a/frontend/src/Pages/VideoManagement.tsx
+++ b/frontend/src/Pages/VideoManagement.tsx
@@ -8,7 +8,8 @@ import {
     MAX_DOWNLOAD_ATTEMPTS,
     getVideoErrorMessage,
     ViewType,
-    FeatureAccess
+    FeatureAccess,
+    VideoAdminVisibility
 } from '../common';
 import Pagination from '@/Components/Pagination';
 import API from '@/api/api';
@@ -41,14 +42,24 @@ export default function VideoManagement() {
     const navigate = useNavigate();
     const { toaster } = useToast();
 
-    const { activeView, sortQuery } = useOutletContext<{
+    const { activeView, sortQuery, filterVisibilityAdmin } = useOutletContext<{
         activeView: ViewType;
         sortQuery: string;
+        filterVisibilityAdmin: VideoAdminVisibility;
     }>();
+    const visibilitySuffix =
+        filterVisibilityAdmin === VideoAdminVisibility.Visible
+            ? '&visibility=student'
+            : filterVisibilityAdmin === VideoAdminVisibility.Hidden
+              ? '&visibility=hidden'
+              : '';
+
     const { data, mutate, error, isLoading } = useSWR<
         ServerResponseMany<Video>,
         Error
-    >(`/api/videos?page=${pageQuery}&per_page=${perPage}&${sortQuery}`);
+    >(
+        `/api/videos?page=${pageQuery}&per_page=${perPage}&${sortQuery}${visibilitySuffix}`
+    );
 
     const videoData = data?.data ?? [];
     const meta = data?.meta;

--- a/frontend/src/common.ts
+++ b/frontend/src/common.ts
@@ -908,6 +908,12 @@ export interface ProgramTag {
     value: number;
 }
 
+export enum VideoAdminVisibility {
+    'All Videos' = 'all',
+    'Visible' = 'visible',
+    'Hidden' = 'hidden'
+}
+
 export enum LibraryAdminVisibility {
     'All Libraries' = 'all',
     'Visible' = 'visible',


### PR DESCRIPTION
## Description of the change

This PR adds hidden/visible filtering to the Videos tab, providing consistent functionality with the Libraries tab.  
In addition to the UI updates, the backend video handler (`video.go`) was updated to properly handle the new visibility filter when querying videos.  

**Changes made:**
- **Frontend (React):**
  - Added `DropdownControl` with hidden/visible options to the Videos tab
  - Reused the existing enum for visibility filters
  - Ensured the dropdown only appears for Admin and Management users

- **Backend (Go):**
  - Updated `video.go` handler to accept a visibility query parameter
  - Added filtering logic to include/exclude hidden videos based on dropdown selection
  - Ensured default behavior remains unchanged when no filter is provided


- **Related issues**: [Asana Task – Add hidden/visible filter to Videos dropdown](https://app.asana.com/1/1201607307149189/project/1209460078641109/task/1210981460322285)

## Screenshot(s)

https://github.com/user-attachments/assets/4ef2854f-df51-4a91-b81e-057967d241aa

## Additional context

- This change aligns video filtering behavior with libraries for consistency  
- No core features were removed  


