### PR TITLE
fix: standardize Program Status label font size on programs detail page

### DIFF
--- a/frontend/src/Pages/ProgramManagementForm.tsx
+++ b/frontend/src/Pages/ProgramManagementForm.tsx
@@ -290,15 +290,19 @@ export default function ProgramManagementForm() {
                         </div>
                     )}
                     <div>
-                        <label className="flex items-start gap-1 font-medium mb-2 relative">
-                            <span>Program Status</span>
-                            <ULIComponent
-                                icon={InformationCircleIcon}
-                                dataTip={
-                                    "Set to 'Available' to let facility admins schedule classes. 'Inactive' programs stay hidden."
-                                }
-                                iconClassName="tooltip absolute  mt-[2px] ml-[2px]"
-                            />
+                        <label className="form-control">
+                            <div className="label">
+                                <span className="label-text flex items-center gap-1">
+                                    Program Status
+                                    <ULIComponent
+                                        icon={InformationCircleIcon}
+                                        dataTip={
+                                            "Set to 'Available' to let facility admins schedule classes. 'Inactive' programs stay hidden."
+                                        }
+                                        iconClassName="tooltip"
+                                    />
+                                </span>
+                            </div>
                         </label>
                         <div className="flex space-x-6">
                             <label className="flex items-center cursor-pointer">


### PR DESCRIPTION
## Description of the change
- Replace custom label styling with consistent form-control structure
- Use label-text class instead of font-medium to match other form labels
- Maintain tooltip functionality within standardized DaisyUI pattern
- Ensures visual consistency across all form fields (Credit Type, Program Type, etc.)

Fixes inconsistent font sizing where Program Status label appeared larger than other labels on the programs/detail 
Please provide a brief description of the changes included in this PR.

- **Related issues**: Link to related Asana ticket that this closes.
[Fix the inconsistency between label font size on `programs/detail`](https://app.asana.com/1/1201607307149189/project/1209460078641109/task/1210535950665361)
