### PR TITLE
Center EmptyStateCard button in Firefox

### DIFF
--- a/frontend/src/Components/EmptyStateCard.tsx
+++ b/frontend/src/Components/EmptyStateCard.tsx
@@ -11,7 +11,7 @@ interface EmptyStateCardProps {
 
 export default function EmptyStateCard(props: EmptyStateCardProps) {
     return (
-        <div className="justify-items-center space-y-4 p-10">
+        <div className="flex flex-col items-center justify-center space-y-4 p-10">
             <p className="text-grey-3 text-base">{props.title}</p>
             {props.onActionButtonText && props.onActionButtonClick && (
                 <button


### PR DESCRIPTION
## Description of the change

Replaced justify-items-center with flexbox for consistent cross-browser centering



## Screenshot(s)
<img width="1889" height="1138" alt="chrome" src="https://github.com/user-attachments/assets/a9c2e5aa-b953-4096-a34d-31c995923358" />
<img width="1943" height="1077" alt="edge" src="https://github.com/user-attachments/assets/593c3fbd-66fd-4039-8f71-4190c2721610" />
<img width="1909" height="1072" alt="firefox" src="https://github.com/user-attachments/assets/cb275a68-57a1-4a32-9e2b-ace907670cda" />
