### PR TITLE
feat: editable enrollment date component

### DIFF
--- a/backend/src/database/class_enrollments.go
+++ b/backend/src/database/class_enrollments.go
@@ -185,6 +185,16 @@ func (db *DB) UpdateProgramClassEnrollments(classId int, userIds []int, status m
 	return nil
 }
 
+func (db *DB) UpdateProgramClassEnrollmentDate(enrollmentId int, enrolledDate time.Time) error {
+	if err := db.Model(&models.ProgramClassEnrollment{}).
+		Where("id = ?", enrollmentId).
+		Set("id", enrollmentId).
+		Update("enrolled_at", enrolledDate).Error; err != nil {
+		return newUpdateDBError(err, "enrollment date")
+	}
+	return nil
+}
+
 func (db *DB) UpdateProgramClasses(ctx context.Context, classIDs []int, classMap map[string]any) error {
 	tx := db.WithContext(ctx).Begin()
 	if tx.Error != nil {

--- a/backend/src/database/class_enrollments.go
+++ b/backend/src/database/class_enrollments.go
@@ -188,7 +188,6 @@ func (db *DB) UpdateProgramClassEnrollments(classId int, userIds []int, status m
 func (db *DB) UpdateProgramClassEnrollmentDate(enrollmentId int, enrolledDate time.Time) error {
 	if err := db.Model(&models.ProgramClassEnrollment{}).
 		Where("id = ?", enrollmentId).
-		Set("id", enrollmentId).
 		Update("enrolled_at", enrolledDate).Error; err != nil {
 		return newUpdateDBError(err, "enrollment date")
 	}

--- a/frontend/src/Components/ClassEnrollmentDetailsTable.tsx
+++ b/frontend/src/Components/ClassEnrollmentDetailsTable.tsx
@@ -1,5 +1,6 @@
 import DropdownControl from '@/Components/inputs/DropdownControl';
-import { ClassEnrollment, EnrollmentStatus } from '@/common';
+import { ClassEnrollment, EnrollmentStatus, Class } from '@/common';
+import EditableEnrollmentDate from './EditableEnrollmentDate';
 
 interface EnrollmentTableProps {
     enrollments: ClassEnrollment[];
@@ -14,6 +15,8 @@ interface EnrollmentTableProps {
     handleShowCompletionDetails: (enrollment: ClassEnrollment) => Promise<void>;
     showOthers: boolean;
     setShowOthers: (show: boolean) => void;
+    classInfo?: Class;
+    onEnrollmentUpdate: () => void;
 }
 
 const ClassEnrollmentDetailsTable: React.FC<EnrollmentTableProps> = ({
@@ -28,7 +31,9 @@ const ClassEnrollmentDetailsTable: React.FC<EnrollmentTableProps> = ({
     handleChange,
     handleShowCompletionDetails,
     showOthers,
-    setShowOthers
+    setShowOthers,
+    classInfo,
+    onEnrollmentUpdate
 }) => {
     const translateEnrollmentStatus = (status: string) =>
         status.startsWith('Incomplete: ')
@@ -98,9 +103,15 @@ const ClassEnrollmentDetailsTable: React.FC<EnrollmentTableProps> = ({
                         <td className="px-2">{enrollment.name_full}</td>
                         <td className="px-2">{enrollment.doc_id}</td>
                         <td className="px-2">
-                            {new Date(
-                                enrollment.created_at
-                            ).toLocaleDateString()}
+                            <EditableEnrollmentDate
+                                enrollment={enrollment}
+                                classInfo={classInfo}
+                                onUpdate={onEnrollmentUpdate}
+                                disabled={
+                                    enrollment.enrollment_status !==
+                                    EnrollmentStatus.Enrolled
+                                }
+                            />
                         </td>
                         <td className="text-center">
                             {enrollment.completion_dt ? (

--- a/frontend/src/Components/EditableEnrollmentDate.tsx
+++ b/frontend/src/Components/EditableEnrollmentDate.tsx
@@ -1,0 +1,134 @@
+import { useRef, useMemo } from 'react';
+import { ClassEnrollment, Class, ToastState } from '@/common';
+import { FormModal, FormInputTypes } from '@/Components/modals';
+import { FieldValues } from 'react-hook-form';
+import API from '@/api/api';
+import { useToast } from '@/Context/ToastCtx';
+import { PencilSquareIcon } from '@heroicons/react/24/outline';
+
+interface EditableEnrollmentDateProps {
+    enrollment: ClassEnrollment;
+    classInfo?: Class;
+    onUpdate: () => void;
+    disabled?: boolean;
+}
+
+export default function EditableEnrollmentDate({
+    enrollment,
+    classInfo,
+    onUpdate,
+    disabled = false
+}: EditableEnrollmentDateProps) {
+    const modalRef = useRef<HTMLDialogElement>(null);
+    const { toaster } = useToast();
+
+    const toDateOnly = (iso: string) => {
+        const d = new Date(iso);
+        return new Date(d.getUTCFullYear(), d.getUTCMonth(), d.getUTCDate());
+    };
+
+    const displayDate = enrollment.enrolled_at ?? enrollment.created_at;
+
+    const handleDateClick = () => {
+        if (!disabled) {
+            modalRef.current?.showModal();
+        }
+    };
+
+    const handleDateUpdate = async (formData: FieldValues) => {
+        const newDate = formData.enrolled_date as string;
+        const dateObj = toDateOnly(newDate + 'T00:00:00Z');
+
+        const response = await API.patch(
+            `program-classes/${enrollment.class_id}/enrollments/${enrollment.id}/date`,
+            {
+                enrolled_date: dateObj.toISOString()
+            }
+        );
+
+        if (response.success) {
+            toaster('Enrollment date updated successfully', ToastState.success);
+            onUpdate();
+            modalRef.current?.close();
+        } else {
+            toaster('Failed to update enrollment date', ToastState.error);
+        }
+    };
+
+    const validateEnrollmentDate = (date: string) => {
+        if (!date) return 'Date is required';
+
+        const selectedDate = toDateOnly(date + 'T00:00:00Z');
+        const today = toDateOnly(new Date().toISOString());
+
+        if (selectedDate > today) {
+            return 'Enrollment date cannot be in the future';
+        }
+
+        if (classInfo?.start_dt) {
+            const classStartDate = toDateOnly(classInfo.start_dt);
+            if (selectedDate < classStartDate) {
+                return 'Enrollment date cannot be before class start date';
+            }
+        }
+
+        if (classInfo?.end_dt) {
+            const classEndDate = toDateOnly(classInfo.end_dt);
+            if (selectedDate > classEndDate) {
+                return 'Enrollment date cannot be after class end date';
+            }
+        }
+
+        return true;
+    };
+
+    const defaultValues = useMemo(
+        () => ({
+            enrolled_date: enrollment.enrolled_at
+                ? toDateOnly(enrollment.enrolled_at).toISOString().split('T')[0]
+                : toDateOnly(enrollment.created_at).toISOString().split('T')[0]
+        }),
+        [enrollment.enrolled_at, enrollment.created_at]
+    );
+
+    return (
+        <>
+            <span
+                className={`group flex items-center gap-1 cursor-pointer hover:text-primary hover:underline ${
+                    disabled ? 'cursor-not-allowed opacity-50' : ''
+                }`}
+                onClick={handleDateClick}
+                title={
+                    disabled
+                        ? 'Cannot edit date'
+                        : 'Click to edit enrollment date'
+                }
+            >
+                {new Date(displayDate).toLocaleDateString()}
+                <PencilSquareIcon className="w-4 h-4 opacity-0 group-hover:opacity-100 transition-opacity" />
+            </span>
+
+            <FormModal
+                ref={modalRef}
+                title="Update Enrollment Date"
+                defaultValues={defaultValues}
+                inputs={[
+                    {
+                        type: FormInputTypes.Date,
+                        label: 'Enrollment Date',
+                        interfaceRef: 'enrolled_date',
+                        required: true,
+                        allowPastDate: true,
+                        validate: validateEnrollmentDate
+                    }
+                ]}
+                onSubmit={handleDateUpdate}
+                onClose={() => {
+                    modalRef.current?.close();
+                }}
+                showCancel
+                submitText="Update Date"
+            />
+        </>
+    );
+}

--- a/frontend/src/Components/inputs/DateInput.tsx
+++ b/frontend/src/Components/inputs/DateInput.tsx
@@ -20,6 +20,8 @@ interface DateProps {
         | Record<string, Validate<any, any>>; // eslint-disable-line @typescript-eslint/no-explicit-any
     disabled?: boolean;
     monthOnly?: boolean;
+    minDate?: string;
+    maxDate?: string;
     defaultValue?: string;
     onChange?: (value: string) => void;
 }

--- a/frontend/src/Components/modals/FormModal.tsx
+++ b/frontend/src/Components/modals/FormModal.tsx
@@ -192,6 +192,8 @@ export const FormModal = forwardRef(function FormModal<T extends FieldValues>(
                                             getValues={input.getValues}
                                             disabled={input.disabled}
                                             allowPastDate={input.allowPastDate}
+                                            minDate={input.minDate}
+                                            maxDate={input.maxDate}
                                             monthOnly={input.monthOnly}
                                         />
                                     );

--- a/frontend/src/Components/modals/index.ts
+++ b/frontend/src/Components/modals/index.ts
@@ -61,6 +61,8 @@ export interface Input {
     disabled?: boolean;
     allowPastDate?: boolean;
     monthOnly?: boolean;
+    minDate?: string;
+    maxDate?: string;
     getValues?: UseFormGetValues<any>; // eslint-disable-line
     onChange?: (event: React.ChangeEvent<HTMLInputElement>) => void;
     onChangeSelection?: (event: React.ChangeEvent<HTMLSelectElement>) => void;

--- a/frontend/src/Pages/ClassEnrollmentDetails.tsx
+++ b/frontend/src/Pages/ClassEnrollmentDetails.tsx
@@ -318,6 +318,8 @@ export default function ClassEnrollmentDetails() {
                     handleShowCompletionDetails={handleShowCompletionDetails}
                     showOthers={showOthers}
                     setShowOthers={setShowOthers}
+                    classInfo={clsInfo}
+                    onEnrollmentUpdate={() => void mutate()}
                 />
             )}
             <div className="flex justify-center m-2">

--- a/frontend/src/common.ts
+++ b/frontend/src/common.ts
@@ -854,6 +854,7 @@ export interface ClassEnrollment {
     name_full: string;
     doc_id: string;
     completion_dt?: string;
+    enrolled_at?: string;
 }
 
 export interface AttendanceFlag {


### PR DESCRIPTION
## Description of the change
This pull request adds the ability for admins to update a residents enrolled date retroactively so that the date reflects the actual date appropriately. 

- **Related issues**: https://app.asana.com/1/1201607307149189/project/1209457756469406/task/1211317866761100?focus=true

## Screenshot(s)
<img width="2289" height="900" alt="image" src="https://github.com/user-attachments/assets/ece6e04c-e9f5-4e05-a524-bfcf38eac3bd" />
<img width="2302" height="694" alt="image" src="https://github.com/user-attachments/assets/757fb8a0-25a0-490a-ad9f-37765434de54" />
<img width="766" height="480" alt="image" src="https://github.com/user-attachments/assets/11c4650d-321b-4ff2-b957-5be65cb1f1e9" />
<img width="528" height="331" alt="image" src="https://github.com/user-attachments/assets/55c53ad2-eee8-495f-a9c4-fcea3f782889" />

