### PR TITLE
fix: add styles to fix double scrollbars on resident profile per 577

### DIFF
--- a/frontend/src/Components/AccountHistoryFilter.tsx
+++ b/frontend/src/Components/AccountHistoryFilter.tsx
@@ -45,6 +45,7 @@ export default function AccountHistoryFilter({
                 onSelectionChange={setSelectedCategories}
                 onBlurSearch={() => {}} // eslint-disable-line @typescript-eslint/no-empty-function
                 small={true}
+                openUpwards={true}
             />
         </div>
     );

--- a/frontend/src/Components/inputs/MultiSelectDropdownControl.tsx
+++ b/frontend/src/Components/inputs/MultiSelectDropdownControl.tsx
@@ -9,6 +9,7 @@ interface MultiSelectDropdownProps {
     onSelectionChange: (selected: number[]) => void;
     onBlurSearch: () => void;
     small?: boolean;
+    openUpwards?: boolean;
 }
 
 export function MultiSelectDropdown({
@@ -17,7 +18,8 @@ export function MultiSelectDropdown({
     selectedOptions,
     onSelectionChange,
     onBlurSearch,
-    small
+    small,
+    openUpwards = false
 }: MultiSelectDropdownProps) {
     const [isOpen, setIsOpen] = useState(false);
     const dropdownRef = useRef<HTMLDivElement>(null);
@@ -61,7 +63,7 @@ export function MultiSelectDropdown({
                 </button>
                 {isOpen && (
                     <ul
-                        className="absolute left-0 bg-base-100 rounded-box shadow-lg p-2 mt-2 max-h-64 overflow-y-auto z-10"
+                        className={`absolute left-0 bg-base-100 rounded-box shadow-lg p-2 max-h-64 overflow-y-auto z-10 ${openUpwards ? 'bottom-full mb-2' : 'top-full mt-2'}`}
                         tabIndex={0}
                         style={{ minWidth: 'max-content' }}
                     >

--- a/frontend/src/Pages/ResidentProfile.tsx
+++ b/frontend/src/Pages/ResidentProfile.tsx
@@ -309,7 +309,7 @@ const ResidentProfile = () => {
     }
 
     return (
-        <div className="resident-profile overflow-x-hidden px-5 pb-4">
+        <div className="overflow-x-hidden px-5 pb-4">
             {!data || (isLoading && <div>Loading...</div>)}
             {data && metrics && (
                 <div className="space-y-6">

--- a/frontend/src/Pages/ResidentProfile.tsx
+++ b/frontend/src/Pages/ResidentProfile.tsx
@@ -309,7 +309,7 @@ const ResidentProfile = () => {
     }
 
     return (
-        <div className="overflow-x-hidden px-5 pb-4">
+        <div className="resident-profile overflow-x-hidden px-5 pb-4">
             {!data || (isLoading && <div>Loading...</div>)}
             {data && metrics && (
                 <div className="space-y-6">


### PR DESCRIPTION
## Pre-Submission PR Checklist

- [x] No debug/console/fmt.Println statements
- [x] Unnecessary development comments removed
- [x] All acceptance criteria verified
- [x] Functions according to **ticket specifications**
- [x] Tested manually where applicable
- [x] Branch rebased with latest main
- [x] No business logic exists within the database layer

## Description of the change

Added styles to Account Overview's filter dropdown to pop out its list above the filter so that double scrollbar does not display. 

NOTE: To duplicate you will need to make sure that you have no records displayed within the card labeled 'Top Viewed Libraries|Recently Viewed Videos'.

- **Related issues**: Link to related Asana ticket that this closes: [Double Scrollbar on Resident Attendance Filter](https://app.asana.com/1/1201607307149189/project/1209460078641109/task/1213061154544348?focus=true)

<img width="1770" height="848" alt="image" src="https://github.com/user-attachments/assets/58b43972-ae32-4e57-a09b-ba2231bf8dce" />
