### PR TITLE
Ck 7vn/total refactor residents 3

### DIFF
--- a/backend/src/database/users.go
+++ b/backend/src/database/users.go
@@ -109,17 +109,13 @@ func (db *DB) GetUserByDocIDAndID(ctx context.Context, docID string, userID int)
 	return &user, nil
 }
 
-func (db *DB) GetUsersByIDs(userIDs []uint, args *models.QueryContext) ([]models.User, error) {
+func (db *DB) GetUsersByIDs(ctx context.Context, userIDs []uint, facID uint) ([]models.User, error) {
 	users := make([]models.User, 0, len(userIDs))
-	if err := db.WithContext(args.Ctx).Where("id IN (?)", userIDs).Find(&users).Error; err != nil {
-		return nil, newGetRecordsDBError(err, "users")
+	tx := db.WithContext(ctx).Where("id IN ? AND role = ?", userIDs, models.Student)
+	if facID != 0 {
+		tx = tx.Where("facility_id = ?", facID)
 	}
-	return users, nil
-}
-
-func (db *DB) FindUsersByIDs(userIDs []uint) ([]models.User, error) {
-	var users []models.User
-	if err := db.Where("id IN ?", userIDs).Find(&users).Error; err != nil {
+	if err := tx.Find(&users).Error; err != nil {
 		return nil, newGetRecordsDBError(err, "users")
 	}
 	return users, nil

--- a/backend/src/database/users.go
+++ b/backend/src/database/users.go
@@ -111,7 +111,15 @@ func (db *DB) GetUserByDocIDAndID(ctx context.Context, docID string, userID int)
 
 func (db *DB) GetUsersByIDs(userIDs []uint, args *models.QueryContext) ([]models.User, error) {
 	users := make([]models.User, 0, len(userIDs))
-	if err := db.WithContext(args.Ctx).Find(&users).Where("id IN (?)", userIDs).Error; err != nil {
+	if err := db.WithContext(args.Ctx).Where("id IN (?)", userIDs).Find(&users).Error; err != nil {
+		return nil, newGetRecordsDBError(err, "users")
+	}
+	return users, nil
+}
+
+func (db *DB) FindUsersByIDs(userIDs []uint) ([]models.User, error) {
+	var users []models.User
+	if err := db.Where("id IN ?", userIDs).Find(&users).Error; err != nil {
 		return nil, newGetRecordsDBError(err, "users")
 	}
 	return users, nil
@@ -226,6 +234,14 @@ func fuzzySearchUsers(tx *gorm.DB, ctx *models.QueryContext) *gorm.DB {
 			likeSearch, likeSearch)
 	}
 	return tx
+}
+
+func (db *DB) GetUserRoleByID(ctx context.Context, id string) (models.UserRole, error) {
+	var role string
+	if err := db.WithContext(ctx).Model(&models.User{}).Select("role").Where("id = ?", id).First(&role).Error; err != nil {
+		return "", newNotFoundDBError(err, "users")
+	}
+	return models.UserRole(role), nil
 }
 
 func (db *DB) GetUserByID(id uint) (*models.User, error) {

--- a/backend/src/handlers/ory.go
+++ b/backend/src/handlers/ory.go
@@ -48,6 +48,9 @@ func (srv *Server) deleteAllKratosIdentities(ctx context.Context) error {
 }
 
 func (srv *Server) deleteIdentityInKratos(ctx context.Context, kratosId *string) error {
+	if kratosId == nil || *kratosId == "" {
+		return nil
+	}
 	resp, err := srv.OryClient.IdentityAPI.DeleteIdentity(ctx, *kratosId).Execute()
 	if err != nil {
 		log.WithField("identity", kratosId).Errorln("unable to delete identity from Ory Kratos")

--- a/backend/src/handlers/user_handler.go
+++ b/backend/src/handlers/user_handler.go
@@ -43,6 +43,9 @@ func (srv *Server) registerUserRoutes() []routeDef {
 		validatedAdminRoute("GET /api/users/{id}/account-history", srv.handleGetUserAccountHistory, resolver),
 		newAdminRoute("POST /api/users/bulk/upload", srv.handleBulkUpload),
 		newAdminRoute("POST /api/users/bulk/create", srv.handleBulkCreate),
+		newAdminRoute("POST /api/users/bulk/reset-password", srv.handleBulkResetPassword),
+		newAdminRoute("POST /api/users/bulk/deactivate", srv.handleBulkDeactivateUsers),
+		newAdminRoute("POST /api/users/bulk/delete", srv.handleBulkDeleteUsers),
 		validatedAdminRoute("POST /api/users/{id}/deactivate", srv.handleDeactivateUser, FacilityAdminResolver("users", "id")),
 		validatedAdminRoute("GET /api/users/{id}/usage-report", srv.handleGenerateUsageReportPDF, FacilityAdminResolver("users", "id")),
 		validatedAdminRoute("GET /api/users/{id}/attendance-export", srv.handleExportResidentAttendanceCSV, UserRoleResolver("id")),
@@ -829,4 +832,174 @@ func (srv *Server) handleExportResidentAttendanceCSV(w http.ResponseWriter, r *h
 	log.info("Exported resident attendance CSV")
 
 	return nil
+}
+
+func (srv *Server) handleBulkResetPassword(w http.ResponseWriter, r *http.Request, log sLog) error {
+	claims := r.Context().Value(ClaimsKey).(*Claims)
+	var req struct {
+		UserIDs []uint `json:"user_ids"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		return newJSONReqBodyServiceError(err)
+	}
+	if len(req.UserIDs) == 0 {
+		return newBadRequestServiceError(errors.New("no user IDs provided"), "user_ids is required")
+	}
+	var users []models.User
+	if err := srv.Db.Where("id IN ?", req.UserIDs).Find(&users).Error; err != nil {
+		return newDatabaseServiceError(err)
+	}
+	if !claims.canSwitchFacility() {
+		filtered := users[:0]
+		for _, u := range users {
+			if u.FacilityID == claims.FacilityID {
+				filtered = append(filtered, u)
+			}
+		}
+		users = filtered
+	}
+	type resultEntry struct {
+		UserID       uint   `json:"user_id"`
+		Username     string `json:"username"`
+		Name         string `json:"name"`
+		DocID        string `json:"doc_id"`
+		TempPassword string `json:"temp_password"`
+	}
+	var results []resultEntry
+	for i := range users {
+		user := &users[i]
+		lockedStatus, err := srv.Db.IsAccountLocked(user.ID)
+		if err != nil {
+			log.add("user_id", user.ID)
+			log.error("bulk reset: error checking locked status")
+			continue
+		}
+		if lockedStatus.IsLocked {
+			if err := srv.Db.ResetFailedLoginAttempts(user.ID); err != nil {
+				log.add("user_id", user.ID)
+				log.error("bulk reset: error resetting failed login attempts")
+				continue
+			}
+		}
+		newPass, err := user.CreateTempPassword()
+		if err != nil {
+			log.add("user_id", user.ID)
+			log.error("bulk reset: error creating temp password")
+			continue
+		}
+		if user.KratosID == "" {
+			if err := srv.HandleCreateUserKratos(user.Username, newPass); err != nil {
+				log.add("user_id", user.ID)
+				log.error("bulk reset: error creating user in kratos")
+				continue
+			}
+		} else {
+			kratosC := claimsFromUser(user)
+			kratosC.PasswordReset = true
+			if err := srv.handleUpdatePasswordKratos(kratosC, newPass, true); err != nil {
+				log.add("user_id", user.ID)
+				log.error("bulk reset: error updating password in kratos")
+				continue
+			}
+		}
+		resetPw := models.NewUserAccountHistory(user.ID, models.ResetPassword, &claims.UserID, nil, nil)
+		if err := srv.Db.InsertUserAccountHistoryAction(r.Context(), resetPw); err != nil {
+			log.add("user_id", user.ID)
+			log.error("bulk reset: error inserting account history")
+		}
+		results = append(results, resultEntry{
+			UserID:       user.ID,
+			Username:     user.Username,
+			Name:         user.NameFirst + " " + user.NameLast,
+			DocID:        user.DocID,
+			TempPassword: newPass,
+		})
+	}
+	return writeJsonResponse(w, http.StatusOK, results)
+}
+
+func (srv *Server) handleBulkDeactivateUsers(w http.ResponseWriter, r *http.Request, log sLog) error {
+	claims := r.Context().Value(ClaimsKey).(*Claims)
+	var req struct {
+		UserIDs []uint `json:"user_ids"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		return newJSONReqBodyServiceError(err)
+	}
+	if len(req.UserIDs) == 0 {
+		return newBadRequestServiceError(errors.New("no user IDs provided"), "user_ids is required")
+	}
+	var users []models.User
+	if err := srv.Db.Where("id IN ?", req.UserIDs).Find(&users).Error; err != nil {
+		return newDatabaseServiceError(err)
+	}
+	if !claims.canSwitchFacility() {
+		filtered := users[:0]
+		for _, u := range users {
+			if u.FacilityID == claims.FacilityID {
+				filtered = append(filtered, u)
+			}
+		}
+		users = filtered
+	}
+	var successCount, failedCount int
+	for _, user := range users {
+		if err := srv.Db.DeactivateUser(r.Context(), user.ID, &claims.UserID); err != nil {
+			log.add("user_id", user.ID)
+			log.error("bulk deactivate: error deactivating user")
+			failedCount++
+			continue
+		}
+		successCount++
+	}
+	return writeJsonResponse(w, http.StatusOK, map[string]int{
+		"success_count": successCount,
+		"failed_count":  failedCount,
+	})
+}
+
+func (srv *Server) handleBulkDeleteUsers(w http.ResponseWriter, r *http.Request, log sLog) error {
+	claims := r.Context().Value(ClaimsKey).(*Claims)
+	var req struct {
+		UserIDs []uint `json:"user_ids"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		return newJSONReqBodyServiceError(err)
+	}
+	if len(req.UserIDs) == 0 {
+		return newBadRequestServiceError(errors.New("no user IDs provided"), "user_ids is required")
+	}
+	var users []models.User
+	if err := srv.Db.Where("id IN ?", req.UserIDs).Find(&users).Error; err != nil {
+		return newDatabaseServiceError(err)
+	}
+	if !claims.canSwitchFacility() {
+		filtered := users[:0]
+		for _, u := range users {
+			if u.FacilityID == claims.FacilityID {
+				filtered = append(filtered, u)
+			}
+		}
+		users = filtered
+	}
+	var successCount, failedCount int
+	for _, user := range users {
+		if err := srv.deleteIdentityInKratos(r.Context(), &user.KratosID); err != nil {
+			log.add("user_id", user.ID)
+			log.error("bulk delete: error deleting identity in kratos")
+			failedCount++
+			continue
+		}
+		if err := srv.WithUserContext(r).DeleteUser(int(user.ID)); err != nil {
+			log.add("user_id", user.ID)
+			log.error("bulk delete: error deleting user")
+			failedCount++
+			continue
+		}
+		successCount++
+	}
+	return writeJsonResponse(w, http.StatusOK, map[string]int{
+		"success_count": successCount,
+		"failed_count":  failedCount,
+	})
 }

--- a/backend/src/handlers/user_handler.go
+++ b/backend/src/handlers/user_handler.go
@@ -34,9 +34,8 @@ func (srv *Server) registerUserRoutes() []routeDef {
 		newAdminRoute("GET /api/users/resident-verify", srv.handleResidentVerification),
 		newDeptAdminRoute("PATCH /api/users/resident-transfer", srv.handleResidentTransfer),
 		validatedAdminRoute("POST /api/users/{id}/student-password", srv.handleResetStudentPassword, func(tx *database.DB, r *http.Request) bool {
-			var role string
-			return tx.WithContext(r.Context()).Model(&models.User{}).Select("role").Where("id = ?", r.PathValue("id")).First(&role).Error == nil &&
-				canResetUserPassword(r.Context().Value(ClaimsKey).(*Claims), models.UserRole(role))
+			role, err := tx.GetUserRoleByID(r.Context(), r.PathValue("id"))
+			return err == nil && canResetUserPassword(r.Context().Value(ClaimsKey).(*Claims), role)
 		}),
 		validatedAdminRoute("DELETE /api/users/{id}", srv.handleDeleteUser, FacilityAdminResolver("users", "id")),
 		validatedAdminRoute("PATCH /api/users/{id}", srv.handleUpdateUser, FacilityAdminResolver("users", "id")),
@@ -207,10 +206,10 @@ func (srv *Server) handleCreateUser(w http.ResponseWriter, r *http.Request, log 
 	log.add("created_username", reqForm.User.Username)
 	userNameExists, docExists := srv.Db.UserIdentityExists(reqForm.User.Username, reqForm.User.DocID)
 	if userNameExists {
-		return newBadRequestServiceError(err, "userexists")
+		return newBadRequestServiceError(err, "Username already exists")
 	}
 	if docExists {
-		return newBadRequestServiceError(err, "docexists")
+		return newBadRequestServiceError(err, "Doc ID already exists")
 	}
 	reqForm.User.Username = stripNonAlphaChars(reqForm.User.Username, func(char rune) bool {
 		return unicode.IsLetter(char) || unicode.IsDigit(char)
@@ -845,8 +844,8 @@ func (srv *Server) handleBulkResetPassword(w http.ResponseWriter, r *http.Reques
 	if len(req.UserIDs) == 0 {
 		return newBadRequestServiceError(errors.New("no user IDs provided"), "user_ids is required")
 	}
-	var users []models.User
-	if err := srv.Db.Where("id IN ?", req.UserIDs).Find(&users).Error; err != nil {
+	users, err := srv.Db.FindUsersByIDs(req.UserIDs)
+	if err != nil {
 		return newDatabaseServiceError(err)
 	}
 	if !claims.canSwitchFacility() {
@@ -929,8 +928,8 @@ func (srv *Server) handleBulkDeactivateUsers(w http.ResponseWriter, r *http.Requ
 	if len(req.UserIDs) == 0 {
 		return newBadRequestServiceError(errors.New("no user IDs provided"), "user_ids is required")
 	}
-	var users []models.User
-	if err := srv.Db.Where("id IN ?", req.UserIDs).Find(&users).Error; err != nil {
+	users, err := srv.Db.FindUsersByIDs(req.UserIDs)
+	if err != nil {
 		return newDatabaseServiceError(err)
 	}
 	if !claims.canSwitchFacility() {
@@ -969,8 +968,8 @@ func (srv *Server) handleBulkDeleteUsers(w http.ResponseWriter, r *http.Request,
 	if len(req.UserIDs) == 0 {
 		return newBadRequestServiceError(errors.New("no user IDs provided"), "user_ids is required")
 	}
-	var users []models.User
-	if err := srv.Db.Where("id IN ?", req.UserIDs).Find(&users).Error; err != nil {
+	users, err := srv.Db.FindUsersByIDs(req.UserIDs)
+	if err != nil {
 		return newDatabaseServiceError(err)
 	}
 	if !claims.canSwitchFacility() {

--- a/backend/src/handlers/user_handler.go
+++ b/backend/src/handlers/user_handler.go
@@ -844,39 +844,43 @@ func (srv *Server) handleBulkResetPassword(w http.ResponseWriter, r *http.Reques
 	if len(req.UserIDs) == 0 {
 		return newBadRequestServiceError(errors.New("no user IDs provided"), "user_ids is required")
 	}
-	users, err := srv.Db.FindUsersByIDs(req.UserIDs)
+	var facID uint
+	if !claims.canSwitchFacility() {
+		facID = claims.FacilityID
+	}
+	users, err := srv.Db.GetUsersByIDs(r.Context(), req.UserIDs, facID)
 	if err != nil {
 		return newDatabaseServiceError(err)
 	}
-	if !claims.canSwitchFacility() {
-		filtered := users[:0]
-		for _, u := range users {
-			if u.FacilityID == claims.FacilityID {
-				filtered = append(filtered, u)
-			}
-		}
-		users = filtered
-	}
-	type resultEntry struct {
+	type successEntry struct {
 		UserID       uint   `json:"user_id"`
 		Username     string `json:"username"`
 		Name         string `json:"name"`
 		DocID        string `json:"doc_id"`
 		TempPassword string `json:"temp_password"`
 	}
-	var results []resultEntry
+	type failedEntry struct {
+		UserID   uint   `json:"user_id"`
+		Username string `json:"username"`
+		Name     string `json:"name"`
+		Reason   string `json:"reason"`
+	}
+	var successes []successEntry
+	var failures []failedEntry
 	for i := range users {
 		user := &users[i]
 		lockedStatus, err := srv.Db.IsAccountLocked(user.ID)
 		if err != nil {
 			log.add("user_id", user.ID)
 			log.error("bulk reset: error checking locked status")
+			failures = append(failures, failedEntry{UserID: user.ID, Username: user.Username, Name: user.NameFirst + " " + user.NameLast, Reason: "error checking locked status"})
 			continue
 		}
 		if lockedStatus.IsLocked {
 			if err := srv.Db.ResetFailedLoginAttempts(user.ID); err != nil {
 				log.add("user_id", user.ID)
 				log.error("bulk reset: error resetting failed login attempts")
+				failures = append(failures, failedEntry{UserID: user.ID, Username: user.Username, Name: user.NameFirst + " " + user.NameLast, Reason: "error resetting failed login attempts"})
 				continue
 			}
 		}
@@ -884,12 +888,14 @@ func (srv *Server) handleBulkResetPassword(w http.ResponseWriter, r *http.Reques
 		if err != nil {
 			log.add("user_id", user.ID)
 			log.error("bulk reset: error creating temp password")
+			failures = append(failures, failedEntry{UserID: user.ID, Username: user.Username, Name: user.NameFirst + " " + user.NameLast, Reason: "error creating temp password"})
 			continue
 		}
 		if user.KratosID == "" {
 			if err := srv.HandleCreateUserKratos(user.Username, newPass); err != nil {
 				log.add("user_id", user.ID)
 				log.error("bulk reset: error creating user in kratos")
+				failures = append(failures, failedEntry{UserID: user.ID, Username: user.Username, Name: user.NameFirst + " " + user.NameLast, Reason: "error creating identity"})
 				continue
 			}
 		} else {
@@ -898,6 +904,7 @@ func (srv *Server) handleBulkResetPassword(w http.ResponseWriter, r *http.Reques
 			if err := srv.handleUpdatePasswordKratos(kratosC, newPass, true); err != nil {
 				log.add("user_id", user.ID)
 				log.error("bulk reset: error updating password in kratos")
+				failures = append(failures, failedEntry{UserID: user.ID, Username: user.Username, Name: user.NameFirst + " " + user.NameLast, Reason: "error updating password"})
 				continue
 			}
 		}
@@ -906,7 +913,7 @@ func (srv *Server) handleBulkResetPassword(w http.ResponseWriter, r *http.Reques
 			log.add("user_id", user.ID)
 			log.error("bulk reset: error inserting account history")
 		}
-		results = append(results, resultEntry{
+		successes = append(successes, successEntry{
 			UserID:       user.ID,
 			Username:     user.Username,
 			Name:         user.NameFirst + " " + user.NameLast,
@@ -914,7 +921,10 @@ func (srv *Server) handleBulkResetPassword(w http.ResponseWriter, r *http.Reques
 			TempPassword: newPass,
 		})
 	}
-	return writeJsonResponse(w, http.StatusOK, results)
+	return writeJsonResponse(w, http.StatusOK, map[string]any{
+		"successes": successes,
+		"failures":  failures,
+	})
 }
 
 func (srv *Server) handleBulkDeactivateUsers(w http.ResponseWriter, r *http.Request, log sLog) error {
@@ -928,32 +938,35 @@ func (srv *Server) handleBulkDeactivateUsers(w http.ResponseWriter, r *http.Requ
 	if len(req.UserIDs) == 0 {
 		return newBadRequestServiceError(errors.New("no user IDs provided"), "user_ids is required")
 	}
-	users, err := srv.Db.FindUsersByIDs(req.UserIDs)
+	var facID uint
+	if !claims.canSwitchFacility() {
+		facID = claims.FacilityID
+	}
+	users, err := srv.Db.GetUsersByIDs(r.Context(), req.UserIDs, facID)
 	if err != nil {
 		return newDatabaseServiceError(err)
 	}
-	if !claims.canSwitchFacility() {
-		filtered := users[:0]
-		for _, u := range users {
-			if u.FacilityID == claims.FacilityID {
-				filtered = append(filtered, u)
-			}
-		}
-		users = filtered
+	type failedEntry struct {
+		UserID   uint   `json:"user_id"`
+		Username string `json:"username"`
+		Name     string `json:"name"`
+		Reason   string `json:"reason"`
 	}
-	var successCount, failedCount int
+	var successCount int
+	var failures []failedEntry
 	for _, user := range users {
 		if err := srv.Db.DeactivateUser(r.Context(), user.ID, &claims.UserID); err != nil {
 			log.add("user_id", user.ID)
 			log.error("bulk deactivate: error deactivating user")
-			failedCount++
+			failures = append(failures, failedEntry{UserID: user.ID, Username: user.Username, Name: user.NameFirst + " " + user.NameLast, Reason: "error deactivating user"})
 			continue
 		}
 		successCount++
 	}
-	return writeJsonResponse(w, http.StatusOK, map[string]int{
+	return writeJsonResponse(w, http.StatusOK, map[string]any{
 		"success_count": successCount,
-		"failed_count":  failedCount,
+		"failed_count":  len(failures),
+		"failures":      failures,
 	})
 }
 
@@ -968,37 +981,40 @@ func (srv *Server) handleBulkDeleteUsers(w http.ResponseWriter, r *http.Request,
 	if len(req.UserIDs) == 0 {
 		return newBadRequestServiceError(errors.New("no user IDs provided"), "user_ids is required")
 	}
-	users, err := srv.Db.FindUsersByIDs(req.UserIDs)
+	var facID uint
+	if !claims.canSwitchFacility() {
+		facID = claims.FacilityID
+	}
+	users, err := srv.Db.GetUsersByIDs(r.Context(), req.UserIDs, facID)
 	if err != nil {
 		return newDatabaseServiceError(err)
 	}
-	if !claims.canSwitchFacility() {
-		filtered := users[:0]
-		for _, u := range users {
-			if u.FacilityID == claims.FacilityID {
-				filtered = append(filtered, u)
-			}
-		}
-		users = filtered
+	type failedEntry struct {
+		UserID   uint   `json:"user_id"`
+		Username string `json:"username"`
+		Name     string `json:"name"`
+		Reason   string `json:"reason"`
 	}
-	var successCount, failedCount int
+	var successCount int
+	var failures []failedEntry
 	for _, user := range users {
 		if err := srv.deleteIdentityInKratos(r.Context(), &user.KratosID); err != nil {
 			log.add("user_id", user.ID)
 			log.error("bulk delete: error deleting identity in kratos")
-			failedCount++
+			failures = append(failures, failedEntry{UserID: user.ID, Username: user.Username, Name: user.NameFirst + " " + user.NameLast, Reason: "error deleting identity"})
 			continue
 		}
 		if err := srv.WithUserContext(r).DeleteUser(int(user.ID)); err != nil {
 			log.add("user_id", user.ID)
 			log.error("bulk delete: error deleting user")
-			failedCount++
+			failures = append(failures, failedEntry{UserID: user.ID, Username: user.Username, Name: user.NameFirst + " " + user.NameLast, Reason: "error deleting user"})
 			continue
 		}
 		successCount++
 	}
-	return writeJsonResponse(w, http.StatusOK, map[string]int{
+	return writeJsonResponse(w, http.StatusOK, map[string]any{
 		"success_count": successCount,
-		"failed_count":  failedCount,
+		"failed_count":  len(failures),
+		"failures":      failures,
 	})
 }

--- a/frontend-v2/src/components/Pagination.tsx
+++ b/frontend-v2/src/components/Pagination.tsx
@@ -79,8 +79,9 @@ export function Pagination({
               value={itemsPerPage}
               onChange={(e) => {
                 onItemsPerPageChange(Number(e.target.value));
+                onPageChange(1); // Reset to first page when changing items per page
               }}
-              className="bg-white dark:bg-[#262626] text-gray-900 dark:text-white px-3 py-1.5 rounded border border-gray-200 dark:border-[#404040] text-sm outline-hidden focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px]"
+              className="bg-white dark:bg-[#262626] text-gray-900 dark:text-white px-3 py-1.5 rounded border border-gray-200 dark:border-[#404040] text-sm focus:outline-none focus:ring-2 focus:ring-[#556830] dark:focus:ring-[#8fb55e]"
             >
               <option value={20}>20</option>
               <option value={40}>40</option>
@@ -95,7 +96,7 @@ export function Pagination({
           <button
             onClick={() => onPageChange(currentPage - 1)}
             disabled={currentPage === 1}
-            className="p-2 rounded-lg border border-gray-200 dark:border-[#404040] text-gray-600 dark:text-gray-400 hover:bg-[#E2E7EA] dark:hover:bg-[#262626] disabled:opacity-50 disabled:cursor-not-allowed transition-colors outline-hidden focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px]"
+            className="p-2 rounded-lg border border-gray-200 dark:border-[#404040] text-gray-600 dark:text-gray-400 hover:bg-[#E2E7EA] dark:hover:bg-[#262626] disabled:opacity-50 disabled:cursor-not-allowed transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-gray-300 focus-visible:border-gray-300"
             aria-label="Previous page"
           >
             <ChevronLeftIcon className="size-5" />
@@ -118,19 +119,19 @@ export function Pagination({
               const pageNum = page as number;
               const isActive = pageNum === currentPage;
 
-              return (
-                <button
-                  key={pageNum}
-                  onClick={() => onPageChange(pageNum)}
-                  className={`px-3 py-2 rounded-lg text-sm font-medium transition-colors outline-hidden focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] ${
-                    isActive
-                      ? 'bg-[#556830] dark:bg-[#556830] text-white'
-                      : 'text-gray-600 dark:text-gray-400 hover:bg-[#E2E7EA] dark:hover:bg-[#262626]'
-                  }`}
-                >
-                  {pageNum}
-                </button>
-              );
+                return (
+                  <button
+                    key={pageNum}
+                    onClick={() => onPageChange(pageNum)}
+                    className={`px-3 py-2 rounded-lg text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-gray-300 ${
+                      isActive
+                        ? 'bg-[#556830] dark:bg-[#556830] text-white'
+                        : 'text-gray-600 dark:text-gray-400 hover:bg-[#E2E7EA] dark:hover:bg-[#262626]'
+                    }`}
+                  >
+                    {pageNum}
+                  </button>
+                );
             })}
           </div>
 
@@ -138,7 +139,7 @@ export function Pagination({
           <button
             onClick={() => onPageChange(currentPage + 1)}
             disabled={currentPage === totalPages}
-            className="p-2 rounded-lg border border-gray-200 dark:border-[#404040] text-gray-600 dark:text-gray-400 hover:bg-[#E2E7EA] dark:hover:bg-[#262626] disabled:opacity-50 disabled:cursor-not-allowed transition-colors outline-hidden focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px]"
+            className="p-2 rounded-lg border border-gray-200 dark:border-[#404040] text-gray-600 dark:text-gray-400 hover:bg-[#E2E7EA] dark:hover:bg-[#262626] disabled:opacity-50 disabled:cursor-not-allowed transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-gray-300 focus-visible:border-gray-300"
             aria-label="Next page"
           >
             <ChevronRightIcon className="size-5" />

--- a/frontend-v2/src/components/Pagination.tsx
+++ b/frontend-v2/src/components/Pagination.tsx
@@ -79,7 +79,6 @@ export function Pagination({
               value={itemsPerPage}
               onChange={(e) => {
                 onItemsPerPageChange(Number(e.target.value));
-                onPageChange(1); // Reset to first page when changing items per page
               }}
               className="bg-white dark:bg-[#262626] text-gray-900 dark:text-white px-3 py-1.5 rounded border border-gray-200 dark:border-[#404040] text-sm outline-hidden focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px]"
             >

--- a/frontend-v2/src/components/Pagination.tsx
+++ b/frontend-v2/src/components/Pagination.tsx
@@ -96,7 +96,7 @@ export function Pagination({
           <button
             onClick={() => onPageChange(currentPage - 1)}
             disabled={currentPage === 1}
-            className="p-2 rounded-lg border border-gray-200 dark:border-[#404040] text-gray-600 dark:text-gray-400 hover:bg-[#E2E7EA] dark:hover:bg-[#262626] disabled:opacity-50 disabled:cursor-not-allowed transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-gray-300 focus-visible:border-gray-300"
+            className="p-2 rounded-lg border border-gray-200 dark:border-[#404040] text-gray-600 dark:text-gray-400 hover:bg-[#E2E7EA] dark:hover:bg-[#262626] disabled:opacity-50 disabled:cursor-not-allowed transition-colors outline-hidden focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px]"
             aria-label="Previous page"
           >
             <ChevronLeftIcon className="size-5" />
@@ -119,19 +119,19 @@ export function Pagination({
               const pageNum = page as number;
               const isActive = pageNum === currentPage;
 
-                return (
-                  <button
-                    key={pageNum}
-                    onClick={() => onPageChange(pageNum)}
-                    className={`px-3 py-2 rounded-lg text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-gray-300 ${
-                      isActive
-                        ? 'bg-[#556830] dark:bg-[#556830] text-white'
-                        : 'text-gray-600 dark:text-gray-400 hover:bg-[#E2E7EA] dark:hover:bg-[#262626]'
-                    }`}
-                  >
-                    {pageNum}
-                  </button>
-                );
+              return (
+                <button
+                  key={pageNum}
+                  onClick={() => onPageChange(pageNum)}
+                  className={`px-3 py-2 rounded-lg text-sm font-medium transition-colors outline-hidden focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] ${
+                    isActive
+                      ? 'bg-[#556830] dark:bg-[#556830] text-white'
+                      : 'text-gray-600 dark:text-gray-400 hover:bg-[#E2E7EA] dark:hover:bg-[#262626]'
+                  }`}
+                >
+                  {pageNum}
+                </button>
+              );
             })}
           </div>
 
@@ -139,7 +139,7 @@ export function Pagination({
           <button
             onClick={() => onPageChange(currentPage + 1)}
             disabled={currentPage === totalPages}
-            className="p-2 rounded-lg border border-gray-200 dark:border-[#404040] text-gray-600 dark:text-gray-400 hover:bg-[#E2E7EA] dark:hover:bg-[#262626] disabled:opacity-50 disabled:cursor-not-allowed transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-gray-300 focus-visible:border-gray-300"
+            className="p-2 rounded-lg border border-gray-200 dark:border-[#404040] text-gray-600 dark:text-gray-400 hover:bg-[#E2E7EA] dark:hover:bg-[#262626] disabled:opacity-50 disabled:cursor-not-allowed transition-colors outline-hidden focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px]"
             aria-label="Next page"
           >
             <ChevronRightIcon className="size-5" />

--- a/frontend-v2/src/components/Pagination.tsx
+++ b/frontend-v2/src/components/Pagination.tsx
@@ -81,7 +81,7 @@ export function Pagination({
                 onItemsPerPageChange(Number(e.target.value));
                 onPageChange(1); // Reset to first page when changing items per page
               }}
-              className="bg-white dark:bg-[#262626] text-gray-900 dark:text-white px-3 py-1.5 rounded border border-gray-200 dark:border-[#404040] text-sm focus:outline-none focus:ring-2 focus:ring-[#556830] dark:focus:ring-[#8fb55e]"
+              className="bg-white dark:bg-[#262626] text-gray-900 dark:text-white px-3 py-1.5 rounded border border-gray-200 dark:border-[#404040] text-sm outline-hidden focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px]"
             >
               <option value={20}>20</option>
               <option value={40}>40</option>

--- a/frontend-v2/src/components/residents/BulkActionDialogs.tsx
+++ b/frontend-v2/src/components/residents/BulkActionDialogs.tsx
@@ -37,6 +37,7 @@ export function BulkResetPasswordDialog({
     residents,
     onSuccess
 }: BulkDialogProps) {
+    const { toaster } = useToast();
     const [confirmInput, setConfirmInput] = useState('');
     const [loading, setLoading] = useState(false);
     const [results, setResults] = useState<BulkPasswordResult[]>([]);
@@ -75,6 +76,9 @@ export function BulkResetPasswordDialog({
         a.download = `bulk-passwords-${new Date().toISOString().slice(0, 10)}.csv`;
         a.click();
         URL.revokeObjectURL(url);
+        toaster('Password file downloaded successfully', ToastState.success);
+        onSuccess();
+        onOpenChange(false);
     };
 
     const handleClose = (value: boolean) => {

--- a/frontend-v2/src/components/residents/BulkActionDialogs.tsx
+++ b/frontend-v2/src/components/residents/BulkActionDialogs.tsx
@@ -76,7 +76,7 @@ export function BulkResetPasswordDialog({
         a.download = `bulk-passwords-${new Date().toISOString().slice(0, 10)}.csv`;
         a.click();
         URL.revokeObjectURL(url);
-        toaster('Password file downloaded successfully', ToastState.success);
+        toaster('Password file downloaded', ToastState.success);
         onSuccess();
         onOpenChange(false);
     };

--- a/frontend-v2/src/components/residents/BulkActionDialogs.tsx
+++ b/frontend-v2/src/components/residents/BulkActionDialogs.tsx
@@ -1,0 +1,378 @@
+import { useState, useEffect } from 'react';
+import API from '@/api/api';
+import {
+    User,
+    BulkPasswordResult,
+    ServerResponseOne,
+    ToastState
+} from '@/types';
+import { useToast } from '@/contexts/ToastContext';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import {
+    Dialog,
+    DialogContent,
+    DialogDescription,
+    DialogFooter,
+    DialogHeader,
+    DialogTitle
+} from '@/components/ui/dialog';
+import { AlertCircle, Download } from 'lucide-react';
+
+interface BulkDialogProps {
+    open: boolean;
+    onOpenChange: (open: boolean) => void;
+    residents: User[];
+    onSuccess: () => void;
+}
+
+function ResidentList({ residents }: { residents: User[] }) {
+    return (
+        <div className="max-h-40 overflow-y-auto border border-gray-200 rounded-lg divide-y divide-gray-100">
+            {residents.map((r) => (
+                <div
+                    key={r.id}
+                    className="flex items-center justify-between px-3 py-2 text-sm"
+                >
+                    <span className="font-medium text-gray-900">
+                        {r.name_last}, {r.name_first}
+                    </span>
+                    <span className="text-gray-500">{r.doc_id ?? ''}</span>
+                </div>
+            ))}
+        </div>
+    );
+}
+
+function CountConfirmInput({
+    count,
+    value,
+    onChange,
+    label
+}: {
+    count: number;
+    value: string;
+    onChange: (v: string) => void;
+    label?: string;
+}) {
+    return (
+        <div>
+            <Label>
+                {label ?? 'To confirm, type the number of residents'}:{' '}
+                <strong>{count}</strong>
+            </Label>
+            <Input
+                value={value}
+                onChange={(e) => onChange(e.target.value)}
+                placeholder={`Type ${count} to confirm`}
+                className="mt-2"
+            />
+        </div>
+    );
+}
+
+export function BulkResetPasswordDialog({
+    open,
+    onOpenChange,
+    residents,
+    onSuccess
+}: BulkDialogProps) {
+    const [confirmInput, setConfirmInput] = useState('');
+    const [loading, setLoading] = useState(false);
+    const [results, setResults] = useState<BulkPasswordResult[] | null>(null);
+
+    useEffect(() => {
+        if (!open) {
+            setConfirmInput('');
+            setResults(null);
+        }
+    }, [open]);
+
+    const handleGenerate = async () => {
+        setLoading(true);
+        const response = (await API.post<BulkPasswordResult[], object>(
+            'users/bulk/reset-password',
+            { user_ids: residents.map((r) => r.id) }
+        )) as ServerResponseOne<BulkPasswordResult[]>;
+        setLoading(false);
+
+        if (response.success) {
+            setResults(response.data);
+        }
+    };
+
+    const handleDownload = () => {
+        if (!results) return;
+        const header = 'Resident ID,Name,Username,Temporary Password';
+        const rows = results.map(
+            (r) => `${r.doc_id},${r.name},${r.username},${r.temp_password}`
+        );
+        const csv = [header, ...rows].join('\n');
+        const blob = new Blob([csv], { type: 'text/csv' });
+        const url = URL.createObjectURL(blob);
+        const a = document.createElement('a');
+        a.href = url;
+        a.download = `bulk-passwords-${new Date().toISOString().slice(0, 10)}.csv`;
+        a.click();
+        URL.revokeObjectURL(url);
+    };
+
+    const handleClose = (value: boolean) => {
+        if (!value && results) {
+            onSuccess();
+        }
+        onOpenChange(value);
+    };
+
+    return (
+        <Dialog open={open} onOpenChange={handleClose}>
+            <DialogContent>
+                <DialogHeader>
+                    <DialogTitle>Reset Passwords</DialogTitle>
+                    <DialogDescription>
+                        {results
+                            ? `Passwords generated for ${results.length} resident(s)`
+                            : `Generate temporary passwords for ${residents.length} resident(s)`}
+                    </DialogDescription>
+                </DialogHeader>
+                {results ? (
+                    <div className="py-4 space-y-4">
+                        <div className="bg-green-50 border border-green-200 rounded-lg p-4 text-sm text-green-800">
+                            Temporary passwords have been generated.
+                            Download the password file to share with
+                            residents securely.
+                        </div>
+                        <Button
+                            onClick={handleDownload}
+                            className="w-full gap-2 bg-[#556830] hover:bg-[#203622]"
+                        >
+                            <Download className="size-4" />
+                            Download Password File
+                        </Button>
+                    </div>
+                ) : (
+                    <div className="py-4 space-y-4">
+                        <ResidentList residents={residents} />
+                        <CountConfirmInput
+                            count={residents.length}
+                            value={confirmInput}
+                            onChange={setConfirmInput}
+                        />
+                    </div>
+                )}
+                <DialogFooter>
+                    {results ? (
+                        <Button
+                            onClick={() => handleClose(false)}
+                            className="bg-[#556830] hover:bg-[#203622]"
+                        >
+                            Done
+                        </Button>
+                    ) : (
+                        <>
+                            <Button
+                                variant="outline"
+                                onClick={() => onOpenChange(false)}
+                            >
+                                Cancel
+                            </Button>
+                            <Button
+                                onClick={() => void handleGenerate()}
+                                disabled={
+                                    confirmInput !==
+                                        String(residents.length) || loading
+                                }
+                                className="bg-[#556830] hover:bg-[#203622]"
+                            >
+                                Generate Passwords
+                            </Button>
+                        </>
+                    )}
+                </DialogFooter>
+            </DialogContent>
+        </Dialog>
+    );
+}
+
+export function BulkDeactivateDialog({
+    open,
+    onOpenChange,
+    residents,
+    onSuccess
+}: BulkDialogProps) {
+    const { toaster } = useToast();
+    const [confirmInput, setConfirmInput] = useState('');
+    const [loading, setLoading] = useState(false);
+
+    useEffect(() => {
+        if (!open) setConfirmInput('');
+    }, [open]);
+
+    const handleDeactivate = async () => {
+        setLoading(true);
+        const response = (await API.post<
+            { success_count: number; failed_count: number },
+            object
+        >('users/bulk/deactivate', {
+            user_ids: residents.map((r) => r.id)
+        })) as ServerResponseOne<{
+            success_count: number;
+            failed_count: number;
+        }>;
+        setLoading(false);
+
+        if (response.success) {
+            const { success_count, failed_count } = response.data;
+            const msg =
+                failed_count > 0
+                    ? `${success_count} resident(s) deactivated, ${failed_count} failed`
+                    : `${success_count} resident(s) deactivated`;
+            toaster(msg, failed_count > 0 ? ToastState.error : ToastState.success);
+            onOpenChange(false);
+            onSuccess();
+        } else {
+            toaster(
+                response.message ?? 'Failed to deactivate residents',
+                ToastState.error
+            );
+        }
+    };
+
+    return (
+        <Dialog open={open} onOpenChange={onOpenChange}>
+            <DialogContent>
+                <DialogHeader>
+                    <DialogTitle>Deactivate Residents</DialogTitle>
+                    <DialogDescription>
+                        You are about to deactivate {residents.length}{' '}
+                        resident(s).
+                    </DialogDescription>
+                </DialogHeader>
+                <div className="py-4 space-y-4">
+                    <div className="bg-orange-50 border border-orange-200 rounded-lg p-4 flex gap-3">
+                        <AlertCircle className="size-5 text-orange-600 shrink-0 mt-0.5" />
+                        <div className="text-sm text-orange-800">
+                            All selected residents will be withdrawn from
+                            active classes and programs. Their accounts will
+                            be locked and marked as Deactivated.
+                        </div>
+                    </div>
+                    <ResidentList residents={residents} />
+                    <CountConfirmInput
+                        count={residents.length}
+                        value={confirmInput}
+                        onChange={setConfirmInput}
+                    />
+                </div>
+                <DialogFooter>
+                    <Button
+                        variant="outline"
+                        onClick={() => onOpenChange(false)}
+                    >
+                        Cancel
+                    </Button>
+                    <Button
+                        onClick={() => void handleDeactivate()}
+                        disabled={
+                            confirmInput !== String(residents.length) ||
+                            loading
+                        }
+                        className="bg-orange-600 hover:bg-orange-700"
+                    >
+                        Deactivate {residents.length} Resident(s)
+                    </Button>
+                </DialogFooter>
+            </DialogContent>
+        </Dialog>
+    );
+}
+
+export function BulkDeleteDialog({
+    open,
+    onOpenChange,
+    residents,
+    onSuccess
+}: BulkDialogProps) {
+    const { toaster } = useToast();
+    const [confirmInput, setConfirmInput] = useState('');
+    const [loading, setLoading] = useState(false);
+
+    useEffect(() => {
+        if (!open) setConfirmInput('');
+    }, [open]);
+
+    const handleDelete = async () => {
+        setLoading(true);
+        const response = (await API.post<
+            { success_count: number; failed_count: number },
+            object
+        >('users/bulk/delete', {
+            user_ids: residents.map((r) => r.id)
+        })) as ServerResponseOne<{
+            success_count: number;
+            failed_count: number;
+        }>;
+        setLoading(false);
+
+        if (response.success) {
+            const { success_count, failed_count } = response.data;
+            const msg =
+                failed_count > 0
+                    ? `${success_count} resident(s) deleted, ${failed_count} failed`
+                    : `${success_count} resident(s) deleted`;
+            toaster(msg, failed_count > 0 ? ToastState.error : ToastState.success);
+            onOpenChange(false);
+            onSuccess();
+        } else {
+            toaster(
+                response.message ?? 'Failed to delete residents',
+                ToastState.error
+            );
+        }
+    };
+
+    return (
+        <Dialog open={open} onOpenChange={onOpenChange}>
+            <DialogContent>
+                <DialogHeader>
+                    <DialogTitle>Delete Residents</DialogTitle>
+                    <DialogDescription>
+                        Are you sure you want to delete {residents.length}{' '}
+                        resident(s)?
+                    </DialogDescription>
+                </DialogHeader>
+                <div className="py-4 space-y-4">
+                    <p className="text-sm text-red-600 font-medium">
+                        This action cannot be undone. All data associated
+                        with these residents will be permanently deleted.
+                    </p>
+                    <ResidentList residents={residents} />
+                    <CountConfirmInput
+                        count={residents.length}
+                        value={confirmInput}
+                        onChange={setConfirmInput}
+                    />
+                </div>
+                <DialogFooter>
+                    <Button
+                        variant="outline"
+                        onClick={() => onOpenChange(false)}
+                    >
+                        Cancel
+                    </Button>
+                    <Button
+                        onClick={() => void handleDelete()}
+                        disabled={
+                            confirmInput !== String(residents.length) ||
+                            loading
+                        }
+                        variant="destructive"
+                    >
+                        Delete {residents.length} Resident(s)
+                    </Button>
+                </DialogFooter>
+            </DialogContent>
+        </Dialog>
+    );
+}

--- a/frontend-v2/src/components/residents/BulkActionDialogs.tsx
+++ b/frontend-v2/src/components/residents/BulkActionDialogs.tsx
@@ -3,6 +3,9 @@ import API from '@/api/api';
 import {
     User,
     BulkPasswordResult,
+    BulkPasswordResponse,
+    BulkActionFailure,
+    BulkActionResponse,
     ServerResponseOne,
     ToastState
 } from '@/types';
@@ -41,24 +44,27 @@ export function BulkResetPasswordDialog({
     const [confirmInput, setConfirmInput] = useState('');
     const [loading, setLoading] = useState(false);
     const [results, setResults] = useState<BulkPasswordResult[]>([]);
+    const [failures, setFailures] = useState<BulkActionFailure[]>([]);
 
     useEffect(() => {
         if (!open) {
             setConfirmInput('');
             setResults([]);
+            setFailures([]);
         }
     }, [open]);
 
     const handleGenerate = async () => {
         setLoading(true);
-        const response = (await API.post<BulkPasswordResult[], object>(
+        const response = (await API.post<BulkPasswordResponse, object>(
             'users/bulk/reset-password',
             { user_ids: residents.map((r) => r.id) }
-        )) as ServerResponseOne<BulkPasswordResult[]>;
+        )) as ServerResponseOne<BulkPasswordResponse>;
         setLoading(false);
 
         if (response.success) {
-            setResults(response.data);
+            setResults(response.data.successes ?? []);
+            setFailures(response.data.failures ?? []);
         }
     };
 
@@ -172,16 +178,39 @@ export function BulkResetPasswordDialog({
                                 <CheckCircle className="size-5 text-green-600" />
                                 <div>
                                     <div className="font-medium text-sm text-green-900">
-                                        Passwords Generated!
+                                        Passwords Generated
                                     </div>
                                     <p className="text-sm text-green-700 mt-1">
-                                        {results.length} temporary passwords
-                                        have been created. Download the CSV
-                                        file to distribute to residents.
+                                        {results.length} temporary password
+                                        {results.length !== 1 ? 's' : ''} created.
+                                        Download the CSV file to distribute to
+                                        residents.
                                     </p>
                                 </div>
                             </div>
                         </div>
+
+                        {failures.length > 0 && (
+                            <div className="bg-red-50 border border-red-200 rounded-lg p-4">
+                                <div className="flex items-start gap-3">
+                                    <AlertCircle className="size-5 text-red-600 mt-0.5 flex-shrink-0" />
+                                    <div className="flex-1">
+                                        <div className="font-medium text-sm text-red-900 mb-1">
+                                            {failures.length} failed
+                                        </div>
+                                        <div className="bg-white border border-red-200 rounded p-3 max-h-32 overflow-y-auto">
+                                            <ul className="text-sm text-gray-700 space-y-1">
+                                                {failures.map((f) => (
+                                                    <li key={f.user_id}>
+                                                        {'\u2022'} {f.name} ({f.username}): {f.reason}
+                                                    </li>
+                                                ))}
+                                            </ul>
+                                        </div>
+                                    </div>
+                                </div>
+                            </div>
+                        )}
 
                         <DialogFooter>
                             <Button
@@ -215,26 +244,23 @@ export function BulkDeactivateDialog({
 
     const handleDeactivate = async () => {
         setLoading(true);
-        const response = (await API.post<
-            { success_count: number; failed_count: number },
-            object
-        >('users/bulk/deactivate', {
+        const response = (await API.post<BulkActionResponse, object>(
+            'users/bulk/deactivate', {
             user_ids: residents.map((r) => r.id)
-        })) as ServerResponseOne<{
-            success_count: number;
-            failed_count: number;
-        }>;
+        })) as ServerResponseOne<BulkActionResponse>;
         setLoading(false);
 
         if (response.success) {
-            const { success_count, failed_count } = response.data;
+            const { success_count, failures } = response.data;
+            const failedCount = failures?.length ?? 0;
+            const failedNames = failures?.map((f) => f.name).join(', ');
             const msg =
-                failed_count > 0
-                    ? `${success_count} resident${success_count > 1 ? 's' : ''} deactivated, ${failed_count} failed`
-                    : `${success_count} resident${success_count > 1 ? 's' : ''} deactivated`;
+                failedCount > 0
+                    ? `${success_count} resident${success_count !== 1 ? 's' : ''} deactivated, ${failedCount} failed: ${failedNames}`
+                    : `${success_count} resident${success_count !== 1 ? 's' : ''} deactivated`;
             toaster(
                 msg,
-                failed_count > 0 ? ToastState.error : ToastState.success
+                failedCount > 0 ? ToastState.error : ToastState.success
             );
             onOpenChange(false);
             onSuccess();
@@ -334,26 +360,23 @@ export function BulkDeleteDialog({
 
     const handleDelete = async () => {
         setLoading(true);
-        const response = (await API.post<
-            { success_count: number; failed_count: number },
-            object
-        >('users/bulk/delete', {
+        const response = (await API.post<BulkActionResponse, object>(
+            'users/bulk/delete', {
             user_ids: residents.map((r) => r.id)
-        })) as ServerResponseOne<{
-            success_count: number;
-            failed_count: number;
-        }>;
+        })) as ServerResponseOne<BulkActionResponse>;
         setLoading(false);
 
         if (response.success) {
-            const { success_count, failed_count } = response.data;
+            const { success_count, failures } = response.data;
+            const failedCount = failures?.length ?? 0;
+            const failedNames = failures?.map((f) => f.name).join(', ');
             const msg =
-                failed_count > 0
-                    ? `${success_count} resident${success_count > 1 ? 's' : ''} deleted, ${failed_count} failed`
-                    : `${success_count} resident${success_count > 1 ? 's' : ''} deleted`;
+                failedCount > 0
+                    ? `${success_count} resident${success_count !== 1 ? 's' : ''} deleted, ${failedCount} failed: ${failedNames}`
+                    : `${success_count} resident${success_count !== 1 ? 's' : ''} deleted`;
             toaster(
                 msg,
-                failed_count > 0 ? ToastState.error : ToastState.success
+                failedCount > 0 ? ToastState.error : ToastState.success
             );
             onOpenChange(false);
             onSuccess();

--- a/frontend-v2/src/components/residents/BulkActionDialogs.tsx
+++ b/frontend-v2/src/components/residents/BulkActionDialogs.tsx
@@ -18,7 +18,7 @@ import {
     DialogHeader,
     DialogTitle
 } from '@/components/ui/dialog';
-import { AlertCircle, Download } from 'lucide-react';
+import { AlertCircle, CheckCircle, Download } from 'lucide-react';
 
 interface BulkDialogProps {
     open: boolean;
@@ -27,49 +27,8 @@ interface BulkDialogProps {
     onSuccess: () => void;
 }
 
-function ResidentList({ residents }: { residents: User[] }) {
-    return (
-        <div className="max-h-40 overflow-y-auto border border-gray-200 rounded-lg divide-y divide-gray-100">
-            {residents.map((r) => (
-                <div
-                    key={r.id}
-                    className="flex items-center justify-between px-3 py-2 text-sm"
-                >
-                    <span className="font-medium text-gray-900">
-                        {r.name_last}, {r.name_first}
-                    </span>
-                    <span className="text-gray-500">{r.doc_id ?? ''}</span>
-                </div>
-            ))}
-        </div>
-    );
-}
-
-function CountConfirmInput({
-    count,
-    value,
-    onChange,
-    label
-}: {
-    count: number;
-    value: string;
-    onChange: (v: string) => void;
-    label?: string;
-}) {
-    return (
-        <div>
-            <Label>
-                {label ?? 'To confirm, type the number of residents'}:{' '}
-                <strong>{count}</strong>
-            </Label>
-            <Input
-                value={value}
-                onChange={(e) => onChange(e.target.value)}
-                placeholder={`Type ${count} to confirm`}
-                className="mt-2"
-            />
-        </div>
-    );
+function formatNameLastFirst(r: User) {
+    return `${r.name_last}, ${r.name_first}`;
 }
 
 export function BulkResetPasswordDialog({
@@ -80,12 +39,12 @@ export function BulkResetPasswordDialog({
 }: BulkDialogProps) {
     const [confirmInput, setConfirmInput] = useState('');
     const [loading, setLoading] = useState(false);
-    const [results, setResults] = useState<BulkPasswordResult[] | null>(null);
+    const [results, setResults] = useState<BulkPasswordResult[]>([]);
 
     useEffect(() => {
         if (!open) {
             setConfirmInput('');
-            setResults(null);
+            setResults([]);
         }
     }, [open]);
 
@@ -103,7 +62,7 @@ export function BulkResetPasswordDialog({
     };
 
     const handleDownload = () => {
-        if (!results) return;
+        if (results.length === 0) return;
         const header = 'Resident ID,Name,Username,Temporary Password';
         const rows = results.map(
             (r) => `${r.doc_id},${r.name},${r.username},${r.temp_password}`
@@ -119,7 +78,7 @@ export function BulkResetPasswordDialog({
     };
 
     const handleClose = (value: boolean) => {
-        if (!value && results) {
+        if (!value && results.length > 0) {
             onSuccess();
         }
         onOpenChange(value);
@@ -127,50 +86,63 @@ export function BulkResetPasswordDialog({
 
     return (
         <Dialog open={open} onOpenChange={handleClose}>
-            <DialogContent>
+            <DialogContent className="max-w-2xl">
                 <DialogHeader>
-                    <DialogTitle>Reset Passwords</DialogTitle>
+                    <DialogTitle>Bulk Reset Passwords</DialogTitle>
                     <DialogDescription>
-                        {results
-                            ? `Passwords generated for ${results.length} resident(s)`
-                            : `Generate temporary passwords for ${residents.length} resident(s)`}
+                        Generate new temporary passwords for{' '}
+                        {residents.length} selected resident
+                        {residents.length > 1 ? 's' : ''}
                     </DialogDescription>
                 </DialogHeader>
-                {results ? (
-                    <div className="py-4 space-y-4">
-                        <div className="bg-green-50 border border-green-200 rounded-lg p-4 text-sm text-green-800">
-                            Temporary passwords have been generated.
-                            Download the password file to share with
-                            residents securely.
+
+                {results.length === 0 ? (
+                    <>
+                        <div className="bg-blue-50 border border-blue-200 rounded-lg p-4">
+                            <div className="flex items-start gap-3">
+                                <AlertCircle className="size-5 text-blue-600 mt-0.5 flex-shrink-0" />
+                                <div className="flex-1">
+                                    <div className="font-medium text-sm text-blue-900 mb-1">
+                                        Selected Residents
+                                    </div>
+                                    <p className="text-sm text-blue-800 mb-2">
+                                        New temporary passwords will be
+                                        generated for:
+                                    </p>
+                                    <div className="bg-white border border-blue-200 rounded p-3 max-h-48 overflow-y-auto">
+                                        <ul className="text-sm text-gray-700 space-y-1">
+                                            {residents.map((r) => (
+                                                <li key={r.id}>
+                                                    {'\u2022'}{' '}
+                                                    {formatNameLastFirst(r)} (
+                                                    {r.doc_id ?? ''})
+                                                </li>
+                                            ))}
+                                        </ul>
+                                    </div>
+                                </div>
+                            </div>
                         </div>
-                        <Button
-                            onClick={handleDownload}
-                            className="w-full gap-2 bg-[#556830] hover:bg-[#203622]"
-                        >
-                            <Download className="size-4" />
-                            Download Password File
-                        </Button>
-                    </div>
-                ) : (
-                    <div className="py-4 space-y-4">
-                        <ResidentList residents={residents} />
-                        <CountConfirmInput
-                            count={residents.length}
-                            value={confirmInput}
-                            onChange={setConfirmInput}
-                        />
-                    </div>
-                )}
-                <DialogFooter>
-                    {results ? (
-                        <Button
-                            onClick={() => handleClose(false)}
-                            className="bg-[#556830] hover:bg-[#203622]"
-                        >
-                            Done
-                        </Button>
-                    ) : (
-                        <>
+
+                        <div className="space-y-2">
+                            <Label htmlFor="bulk-reset-confirm">
+                                Type{' '}
+                                <span className="font-mono font-semibold">
+                                    {residents.length}
+                                </span>{' '}
+                                to confirm
+                            </Label>
+                            <Input
+                                id="bulk-reset-confirm"
+                                value={confirmInput}
+                                onChange={(e) =>
+                                    setConfirmInput(e.target.value)
+                                }
+                                placeholder={`Type ${residents.length}`}
+                            />
+                        </div>
+
+                        <DialogFooter>
                             <Button
                                 variant="outline"
                                 onClick={() => onOpenChange(false)}
@@ -187,9 +159,37 @@ export function BulkResetPasswordDialog({
                             >
                                 Generate Passwords
                             </Button>
-                        </>
-                    )}
-                </DialogFooter>
+                        </DialogFooter>
+                    </>
+                ) : (
+                    <>
+                        <div className="bg-green-50 border border-green-200 rounded-lg p-4">
+                            <div className="flex items-center gap-3">
+                                <CheckCircle className="size-5 text-green-600" />
+                                <div>
+                                    <div className="font-medium text-sm text-green-900">
+                                        Passwords Generated!
+                                    </div>
+                                    <p className="text-sm text-green-700 mt-1">
+                                        {results.length} temporary passwords
+                                        have been created. Download the CSV
+                                        file to distribute to residents.
+                                    </p>
+                                </div>
+                            </div>
+                        </div>
+
+                        <DialogFooter>
+                            <Button
+                                onClick={handleDownload}
+                                className="bg-[#556830] hover:bg-[#203622]"
+                            >
+                                <Download className="size-4 mr-2" />
+                                Download Password File
+                            </Button>
+                        </DialogFooter>
+                    </>
+                )}
             </DialogContent>
         </Dialog>
     );
@@ -226,9 +226,12 @@ export function BulkDeactivateDialog({
             const { success_count, failed_count } = response.data;
             const msg =
                 failed_count > 0
-                    ? `${success_count} resident(s) deactivated, ${failed_count} failed`
-                    : `${success_count} resident(s) deactivated`;
-            toaster(msg, failed_count > 0 ? ToastState.error : ToastState.success);
+                    ? `${success_count} resident${success_count > 1 ? 's' : ''} deactivated, ${failed_count} failed`
+                    : `${success_count} resident${success_count > 1 ? 's' : ''} deactivated`;
+            toaster(
+                msg,
+                failed_count > 0 ? ToastState.error : ToastState.success
+            );
             onOpenChange(false);
             onSuccess();
         } else {
@@ -245,26 +248,49 @@ export function BulkDeactivateDialog({
                 <DialogHeader>
                     <DialogTitle>Deactivate Residents</DialogTitle>
                     <DialogDescription>
-                        You are about to deactivate {residents.length}{' '}
-                        resident(s).
+                        Deactivate {residents.length} selected resident
+                        {residents.length > 1 ? 's' : ''}
                     </DialogDescription>
                 </DialogHeader>
-                <div className="py-4 space-y-4">
-                    <div className="bg-orange-50 border border-orange-200 rounded-lg p-4 flex gap-3">
-                        <AlertCircle className="size-5 text-orange-600 shrink-0 mt-0.5" />
-                        <div className="text-sm text-orange-800">
-                            All selected residents will be withdrawn from
-                            active classes and programs. Their accounts will
-                            be locked and marked as Deactivated.
+
+                <div className="bg-orange-50 border border-orange-200 rounded-lg p-4">
+                    <div className="flex items-start gap-3">
+                        <AlertCircle className="size-5 text-orange-600 mt-0.5 flex-shrink-0" />
+                        <div className="flex-1">
+                            <div className="font-medium text-sm text-orange-900 mb-1">
+                                This will deactivate these accounts
+                            </div>
+                            <div className="bg-white border border-orange-200 rounded p-3 max-h-48 overflow-y-auto mt-2">
+                                <ul className="text-sm text-gray-700 space-y-1">
+                                    {residents.map((r) => (
+                                        <li key={r.id}>
+                                            {'\u2022'}{' '}
+                                            {formatNameLastFirst(r)} (
+                                            {r.doc_id ?? ''})
+                                        </li>
+                                    ))}
+                                </ul>
+                            </div>
                         </div>
                     </div>
-                    <ResidentList residents={residents} />
-                    <CountConfirmInput
-                        count={residents.length}
+                </div>
+
+                <div className="space-y-2">
+                    <Label htmlFor="bulk-deactivate-confirm">
+                        Type{' '}
+                        <span className="font-mono font-semibold">
+                            {residents.length}
+                        </span>{' '}
+                        to confirm
+                    </Label>
+                    <Input
+                        id="bulk-deactivate-confirm"
                         value={confirmInput}
-                        onChange={setConfirmInput}
+                        onChange={(e) => setConfirmInput(e.target.value)}
+                        placeholder={`Type ${residents.length}`}
                     />
                 </div>
+
                 <DialogFooter>
                     <Button
                         variant="outline"
@@ -280,7 +306,7 @@ export function BulkDeactivateDialog({
                         }
                         className="bg-orange-600 hover:bg-orange-700"
                     >
-                        Deactivate {residents.length} Resident(s)
+                        Deactivate {residents.length} Accounts
                     </Button>
                 </DialogFooter>
             </DialogContent>
@@ -319,9 +345,12 @@ export function BulkDeleteDialog({
             const { success_count, failed_count } = response.data;
             const msg =
                 failed_count > 0
-                    ? `${success_count} resident(s) deleted, ${failed_count} failed`
-                    : `${success_count} resident(s) deleted`;
-            toaster(msg, failed_count > 0 ? ToastState.error : ToastState.success);
+                    ? `${success_count} resident${success_count > 1 ? 's' : ''} deleted, ${failed_count} failed`
+                    : `${success_count} resident${success_count > 1 ? 's' : ''} deleted`;
+            toaster(
+                msg,
+                failed_count > 0 ? ToastState.error : ToastState.success
+            );
             onOpenChange(false);
             onSuccess();
         } else {
@@ -338,22 +367,53 @@ export function BulkDeleteDialog({
                 <DialogHeader>
                     <DialogTitle>Delete Residents</DialogTitle>
                     <DialogDescription>
-                        Are you sure you want to delete {residents.length}{' '}
-                        resident(s)?
+                        Permanently delete {residents.length} selected
+                        resident{residents.length > 1 ? 's' : ''}
                     </DialogDescription>
                 </DialogHeader>
-                <div className="py-4 space-y-4">
-                    <p className="text-sm text-red-600 font-medium">
-                        This action cannot be undone. All data associated
-                        with these residents will be permanently deleted.
-                    </p>
-                    <ResidentList residents={residents} />
-                    <CountConfirmInput
-                        count={residents.length}
+
+                <div className="bg-red-50 border border-red-200 rounded-lg p-4">
+                    <div className="flex items-start gap-3">
+                        <AlertCircle className="size-5 text-red-600 mt-0.5 flex-shrink-0" />
+                        <div className="flex-1">
+                            <div className="font-medium text-sm text-red-900 mb-1">
+                                This action cannot be undone
+                            </div>
+                            <p className="text-sm text-red-800 mb-2">
+                                These resident accounts and all associated
+                                data will be permanently deleted:
+                            </p>
+                            <div className="bg-white border border-red-200 rounded p-3 max-h-48 overflow-y-auto">
+                                <ul className="text-sm text-gray-700 space-y-1">
+                                    {residents.map((r) => (
+                                        <li key={r.id}>
+                                            {'\u2022'}{' '}
+                                            {formatNameLastFirst(r)} (
+                                            {r.doc_id ?? ''})
+                                        </li>
+                                    ))}
+                                </ul>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+
+                <div className="space-y-2">
+                    <Label htmlFor="bulk-delete-confirm">
+                        Type{' '}
+                        <span className="font-mono font-semibold">
+                            {residents.length}
+                        </span>{' '}
+                        to confirm deletion
+                    </Label>
+                    <Input
+                        id="bulk-delete-confirm"
                         value={confirmInput}
-                        onChange={setConfirmInput}
+                        onChange={(e) => setConfirmInput(e.target.value)}
+                        placeholder={`Type ${residents.length}`}
                     />
                 </div>
+
                 <DialogFooter>
                     <Button
                         variant="outline"
@@ -367,9 +427,9 @@ export function BulkDeleteDialog({
                             confirmInput !== String(residents.length) ||
                             loading
                         }
-                        variant="destructive"
+                        className="bg-red-600 hover:bg-red-700"
                     >
-                        Delete {residents.length} Resident(s)
+                        Delete {residents.length} Residents
                     </Button>
                 </DialogFooter>
             </DialogContent>

--- a/frontend-v2/src/components/residents/BulkImportDialog.tsx
+++ b/frontend-v2/src/components/residents/BulkImportDialog.tsx
@@ -1,0 +1,398 @@
+import { useState } from 'react';
+import API from '@/api/api';
+import {
+    BulkUploadResponse,
+    InvalidUserRow,
+    ValidatedUserRow,
+    ServerResponseOne,
+    ToastState
+} from '@/types';
+import { useToast } from '@/contexts/ToastContext';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import {
+    Dialog,
+    DialogContent,
+    DialogDescription,
+    DialogFooter,
+    DialogHeader,
+    DialogTitle
+} from '@/components/ui/dialog';
+import { Upload, Download, AlertCircle, CheckCircle } from 'lucide-react';
+
+interface BulkImportDialogProps {
+    open: boolean;
+    onOpenChange: (open: boolean) => void;
+    onSuccess: () => void;
+}
+
+export function BulkImportDialog({
+    open,
+    onOpenChange,
+    onSuccess
+}: BulkImportDialogProps) {
+    const { toaster } = useToast();
+    const [step, setStep] = useState<'upload' | 'validation'>('upload');
+    const [uploadedFile, setUploadedFile] = useState<File | null>(null);
+    const [validRows, setValidRows] = useState<ValidatedUserRow[]>([]);
+    const [invalidRows, setInvalidRows] = useState<InvalidUserRow[]>([]);
+    const [errorCsvData, setErrorCsvData] = useState<string | undefined>();
+    const [validating, setValidating] = useState(false);
+    const [creating, setCreating] = useState(false);
+
+    const reset = () => {
+        setStep('upload');
+        setUploadedFile(null);
+        setValidRows([]);
+        setInvalidRows([]);
+        setErrorCsvData(undefined);
+    };
+
+    const handleOpenChange = (value: boolean) => {
+        if (!value) reset();
+        onOpenChange(value);
+    };
+
+    const handleFileUpload = (event: React.ChangeEvent<HTMLInputElement>) => {
+        const file = event.target.files?.[0];
+        if (file) setUploadedFile(file);
+    };
+
+    const handleDownloadTemplate = () => {
+        const csvContent =
+            'First Name,Last Name,Username,Resident ID\nJohn,Doe,johndoe,R1001\n';
+        const blob = new Blob([csvContent], { type: 'text/csv' });
+        const url = URL.createObjectURL(blob);
+        const a = document.createElement('a');
+        a.href = url;
+        a.download = 'resident_import_template.csv';
+        a.click();
+        URL.revokeObjectURL(url);
+    };
+
+    const handleValidateCSV = async () => {
+        if (!uploadedFile) return;
+        setValidating(true);
+        const formData = new FormData();
+        formData.append('file', uploadedFile);
+        const response = (await API.post<BulkUploadResponse, FormData>(
+            'users/bulk/upload',
+            formData
+        )) as ServerResponseOne<BulkUploadResponse>;
+        setValidating(false);
+
+        if (response.success) {
+            setValidRows(response.data.valid_rows ?? []);
+            setInvalidRows(response.data.invalid_rows ?? []);
+            setErrorCsvData(response.data.error_csv_data);
+            setStep('validation');
+        } else {
+            toaster(
+                response.message ?? 'Failed to validate CSV',
+                ToastState.error
+            );
+        }
+    };
+
+    const handleDownloadErrors = () => {
+        if (!errorCsvData) return;
+        const decoded = atob(errorCsvData);
+        const blob = new Blob([decoded], { type: 'text/csv' });
+        const url = URL.createObjectURL(blob);
+        const a = document.createElement('a');
+        a.href = url;
+        a.download = 'import_errors.csv';
+        a.click();
+        URL.revokeObjectURL(url);
+    };
+
+    const handleCreateAccounts = async () => {
+        if (validRows.length === 0) return;
+        setCreating(true);
+        const response = await API.post<string, ValidatedUserRow[]>(
+            'users/bulk/create',
+            validRows
+        );
+        setCreating(false);
+
+        if (response.success) {
+            toaster(
+                `${validRows.length} resident accounts created successfully`,
+                ToastState.success
+            );
+            handleOpenChange(false);
+            onSuccess();
+        } else {
+            toaster(
+                response.message ?? 'Failed to create accounts',
+                ToastState.error
+            );
+        }
+    };
+
+    return (
+        <Dialog open={open} onOpenChange={handleOpenChange}>
+            <DialogContent className="max-w-3xl">
+                <DialogHeader>
+                    <DialogTitle>Bulk Import Residents</DialogTitle>
+                    <DialogDescription>
+                        Import multiple resident accounts from a CSV file
+                    </DialogDescription>
+                </DialogHeader>
+                <div className="space-y-6 py-4">
+                    {step === 'upload' ? (
+                        <>
+                            <Label
+                                htmlFor="csv-upload"
+                                className="block cursor-pointer"
+                            >
+                                <div
+                                    className={`border-2 border-dashed rounded-lg p-8 transition-all ${
+                                        uploadedFile
+                                            ? 'border-green-500 bg-green-50 hover:bg-green-100'
+                                            : 'border-gray-300 hover:border-[#556830] hover:bg-gray-50'
+                                    }`}
+                                >
+                                    <div className="flex items-center gap-6">
+                                        {uploadedFile ? (
+                                            <div className="bg-green-500 rounded-full p-3 flex-shrink-0">
+                                                <CheckCircle className="size-8 text-white" />
+                                            </div>
+                                        ) : (
+                                            <Upload className="size-12 text-gray-400 flex-shrink-0" />
+                                        )}
+                                        <div className="flex-1">
+                                            <div
+                                                className={`text-base font-medium block mb-2 ${
+                                                    uploadedFile
+                                                        ? 'text-green-700'
+                                                        : 'text-[#556830]'
+                                                }`}
+                                            >
+                                                {uploadedFile
+                                                    ? 'File Selected'
+                                                    : 'Choose CSV File'}
+                                            </div>
+                                            <Input
+                                                id="csv-upload"
+                                                type="file"
+                                                accept=".csv"
+                                                onChange={handleFileUpload}
+                                                className="hidden"
+                                            />
+                                            {uploadedFile ? (
+                                                <div className="space-y-2">
+                                                    <div className="flex items-center gap-2">
+                                                        <span className="font-semibold text-green-900 text-lg">
+                                                            {uploadedFile.name}
+                                                        </span>
+                                                    </div>
+                                                    <button
+                                                        type="button"
+                                                        onClick={(e) => {
+                                                            e.preventDefault();
+                                                            document
+                                                                .getElementById(
+                                                                    'csv-upload'
+                                                                )
+                                                                ?.click();
+                                                        }}
+                                                        className="text-sm text-[#556830] hover:text-[#203622] underline font-medium"
+                                                    >
+                                                        Choose a different file
+                                                    </button>
+                                                </div>
+                                            ) : (
+                                                <p className="text-sm text-gray-500">
+                                                    Upload a CSV file with
+                                                    resident information
+                                                </p>
+                                            )}
+                                        </div>
+                                    </div>
+                                </div>
+                            </Label>
+
+                            <div className="bg-blue-50 border border-blue-200 rounded-lg p-4">
+                                <div className="flex items-start gap-3">
+                                    <Download className="size-5 text-blue-600 mt-0.5 flex-shrink-0" />
+                                    <div className="flex-1">
+                                        <div className="font-medium text-sm text-blue-900 mb-1">
+                                            Download Template
+                                        </div>
+                                        <p className="text-sm text-blue-800 mb-3">
+                                            Use our template to ensure your CSV
+                                            file is formatted correctly with all
+                                            required fields.
+                                        </p>
+                                        <Button
+                                            size="sm"
+                                            onClick={handleDownloadTemplate}
+                                            variant="outline"
+                                            className="border-blue-300 text-blue-700 hover:bg-blue-100"
+                                        >
+                                            <Download className="size-4 mr-2" />
+                                            Download Template
+                                        </Button>
+                                    </div>
+                                </div>
+                            </div>
+                        </>
+                    ) : (
+                        <div className="space-y-4">
+                            <div className="grid grid-cols-2 gap-4">
+                                <div className="bg-green-50 border border-green-200 rounded-lg p-4">
+                                    <div className="flex items-center gap-2 mb-1">
+                                        <CheckCircle className="size-5 text-green-600" />
+                                        <div className="font-medium text-green-900">
+                                            Valid Entries
+                                        </div>
+                                    </div>
+                                    <div className="text-2xl font-semibold text-green-700">
+                                        {validRows.length}
+                                    </div>
+                                    <div className="text-xs text-green-600 mt-1">
+                                        Ready to import
+                                    </div>
+                                </div>
+                                <div className="bg-red-50 border border-red-200 rounded-lg p-4">
+                                    <div className="flex items-center gap-2 mb-1">
+                                        <AlertCircle className="size-5 text-red-600" />
+                                        <div className="font-medium text-red-900">
+                                            Invalid Entries
+                                        </div>
+                                    </div>
+                                    <div className="text-2xl font-semibold text-red-700">
+                                        {invalidRows.length}
+                                    </div>
+                                    <div className="text-xs text-red-600 mt-1">
+                                        Need correction
+                                    </div>
+                                </div>
+                            </div>
+
+                            {invalidRows.length > 0 && (
+                                <div className="border-2 border-red-200 rounded-lg p-4">
+                                    <div className="flex items-start gap-3">
+                                        <AlertCircle className="size-5 text-red-600 mt-0.5 flex-shrink-0" />
+                                        <div className="flex-1">
+                                            <div className="font-medium text-sm text-red-900 mb-1">
+                                                Errors Found
+                                            </div>
+                                            <p className="text-sm text-gray-700 mb-3">
+                                                {invalidRows.length > 3
+                                                    ? `Showing first 3 of ${invalidRows.length} errors. Download the full error report to see all issues.`
+                                                    : 'The following rows have errors:'}
+                                            </p>
+
+                                            <div className="space-y-2 mb-4">
+                                                {invalidRows
+                                                    .slice(0, 3)
+                                                    .map((row, idx) => (
+                                                        <div
+                                                            key={idx}
+                                                            className="bg-gray-50 border border-gray-200 rounded p-3 text-sm"
+                                                        >
+                                                            <div className="font-medium text-gray-900 mb-1">
+                                                                Row{' '}
+                                                                {
+                                                                    row.row_number
+                                                                }
+                                                                :{' '}
+                                                                {
+                                                                    row.first_name
+                                                                }{' '}
+                                                                {row.last_name}
+                                                            </div>
+                                                            <div className="text-red-700 text-xs">
+                                                                {row.error_reasons.join(
+                                                                    ', '
+                                                                )}
+                                                            </div>
+                                                        </div>
+                                                    ))}
+                                            </div>
+
+                                            <Button
+                                                size="sm"
+                                                onClick={handleDownloadErrors}
+                                                variant="outline"
+                                                className="border-red-300 text-red-700 hover:bg-red-50"
+                                            >
+                                                <Download className="size-4 mr-2" />
+                                                Download Full Error Report
+                                            </Button>
+                                        </div>
+                                    </div>
+                                </div>
+                            )}
+
+                            {invalidRows.length === 0 && (
+                                <div className="bg-green-50 border border-green-200 rounded-lg p-4">
+                                    <div className="flex items-center gap-3">
+                                        <CheckCircle className="size-5 text-green-600" />
+                                        <div>
+                                            <div className="font-medium text-sm text-green-900">
+                                                All entries are valid!
+                                            </div>
+                                            <p className="text-sm text-green-700 mt-1">
+                                                You can proceed to create{' '}
+                                                {validRows.length} resident
+                                                accounts.
+                                            </p>
+                                        </div>
+                                    </div>
+                                </div>
+                            )}
+                        </div>
+                    )}
+                </div>
+                <DialogFooter>
+                    {step === 'upload' ? (
+                        <>
+                            <Button
+                                variant="outline"
+                                onClick={() => handleOpenChange(false)}
+                            >
+                                Cancel
+                            </Button>
+                            <Button
+                                onClick={() => void handleValidateCSV()}
+                                disabled={!uploadedFile || validating}
+                                className="bg-[#556830] hover:bg-[#203622]"
+                            >
+                                {validating ? 'Validating...' : 'Validate CSV'}
+                            </Button>
+                        </>
+                    ) : (
+                        <>
+                            <Button
+                                variant="outline"
+                                onClick={() => {
+                                    setStep('upload');
+                                    setValidRows([]);
+                                    setInvalidRows([]);
+                                    setErrorCsvData(undefined);
+                                }}
+                            >
+                                Back
+                            </Button>
+                            <Button
+                                onClick={() => void handleCreateAccounts()}
+                                disabled={
+                                    validRows.length === 0 || creating
+                                }
+                                className="bg-[#556830] hover:bg-[#203622]"
+                            >
+                                {creating
+                                    ? 'Creating...'
+                                    : `Create ${validRows.length} Accounts`}
+                            </Button>
+                        </>
+                    )}
+                </DialogFooter>
+            </DialogContent>
+        </Dialog>
+    );
+}

--- a/frontend-v2/src/components/residents/ResidentModals.tsx
+++ b/frontend-v2/src/components/residents/ResidentModals.tsx
@@ -137,7 +137,7 @@ export function EditResidentDialog({
                             className="mt-2"
                         />
                     </div>
-                    <DialogFooter>
+                    <DialogFooter className="mt-6">
                         <Button
                             variant="outline"
                             type="button"
@@ -363,42 +363,42 @@ export function DeactivateDialog({
                 <div className="py-4 space-y-4">
                     <ul className="space-y-2 text-sm text-gray-700">
                         <li className="flex gap-2">
-                            <span className="text-gray-400">-</span>
+                            <span className="text-gray-400">&bull;</span>
                             <span>
                                 The resident will be withdrawn from all active
                                 classes and programs.
                             </span>
                         </li>
                         <li className="flex gap-2">
-                            <span className="text-gray-400">-</span>
+                            <span className="text-gray-400">&bull;</span>
                             <span>
                                 The resident&apos;s account will be locked and
                                 marked as Deactivated.
                             </span>
                         </li>
                         <li className="flex gap-2">
-                            <span className="text-gray-400">-</span>
+                            <span className="text-gray-400">&bull;</span>
                             <span>
                                 Staff will no longer be able to edit this
                                 resident&apos;s account.
                             </span>
                         </li>
                         <li className="flex gap-2">
-                            <span className="text-gray-400">-</span>
+                            <span className="text-gray-400">&bull;</span>
                             <span>
                                 The resident will not be able to log in or
                                 enroll in new programs.
                             </span>
                         </li>
                         <li className="flex gap-2">
-                            <span className="text-gray-400">-</span>
+                            <span className="text-gray-400">&bull;</span>
                             <span>
                                 The time this account was deactivated will be
                                 recorded.
                             </span>
                         </li>
                         <li className="flex gap-2">
-                            <span className="text-gray-400">-</span>
+                            <span className="text-gray-400">&bull;</span>
                             <span>
                                 The resident&apos;s account history and
                                 favorites will be preserved and remain
@@ -566,7 +566,10 @@ export function TransferDialog({
             ? `/api/users/resident-verify?user_id=${resident.id}&facility_id=${transferFacilityId}&doc_id=${encodeURIComponent(resident.doc_id ?? '')}`
             : null
     );
-    const programConflicts = verifyResp?.data?.program_names ?? [];
+    const rawConflicts = verifyResp?.data?.program_names ?? [];
+    const programConflicts = [
+        ...new Set(rawConflicts.map((c) => c.program_name))
+    ];
 
     const handleTransfer = async () => {
         setLoading(true);
@@ -676,14 +679,13 @@ export function TransferDialog({
                                     </div>
                                     <div className="space-y-2">
                                         {programConflicts.map(
-                                            (conflict, idx) => (
+                                            (name, idx) => (
                                                 <div
                                                     key={idx}
                                                     className="text-sm text-gray-600 flex items-center gap-2"
                                                 >
                                                     <div className="size-1.5 rounded-full bg-gray-400" />
-                                                    {conflict.program_name} -{' '}
-                                                    {conflict.class_name}
+                                                    {name}
                                                 </div>
                                             )
                                         )}

--- a/frontend-v2/src/components/residents/ResidentModals.tsx
+++ b/frontend-v2/src/components/residents/ResidentModals.tsx
@@ -3,762 +3,753 @@ import { useForm } from 'react-hook-form';
 import useSWR from 'swr';
 import API from '@/api/api';
 import {
-    User,
-    Facility,
-    ValidResident,
-    ServerResponseOne,
-    ResetPasswordResponse,
-    ToastState
+  User,
+  Facility,
+  ValidResident,
+  ServerResponseOne,
+  ResetPasswordResponse,
+  ToastState
 } from '@/types';
 import { useToast } from '@/contexts/ToastContext';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import {
-    Dialog,
-    DialogContent,
-    DialogDescription,
-    DialogFooter,
-    DialogHeader,
-    DialogTitle
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle
 } from '@/components/ui/dialog';
 import {
-    Select,
-    SelectContent,
-    SelectItem,
-    SelectTrigger,
-    SelectValue
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue
 } from '@/components/ui/select';
 import { Copy, Check } from 'lucide-react';
 
 interface EditFormData {
-    name_first: string;
-    name_last: string;
-    doc_id: string;
+  name_first: string;
+  name_last: string;
+  doc_id: string;
 }
 
 interface EditResidentDialogProps {
-    open: boolean;
-    onOpenChange: (open: boolean) => void;
-    resident: User;
-    onSuccess: () => void;
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  resident: User;
+  onSuccess: () => void;
 }
 
 export function EditResidentDialog({
-    open,
-    onOpenChange,
-    resident,
-    onSuccess
+  open,
+  onOpenChange,
+  resident,
+  onSuccess
 }: EditResidentDialogProps) {
-    const { toaster } = useToast();
-    const form = useForm<EditFormData>();
+  const { toaster } = useToast();
+  const form = useForm<EditFormData>();
 
-    useEffect(() => {
-        if (open) {
-            form.reset({
-                name_first: resident.name_first,
-                name_last: resident.name_last,
-                doc_id: resident.doc_id ?? ''
-            });
-        }
-    }, [open, resident, form]);
+  useEffect(() => {
+    if (open) {
+      form.reset({
+        name_first: resident.name_first,
+        name_last: resident.name_last,
+        doc_id: resident.doc_id ?? ''
+      });
+    }
+  }, [open, resident, form]);
 
-    const handleSave = async (data: EditFormData) => {
-        const response = await API.patch<User, object>(
-            `users/${resident.id}`,
-            data
-        );
-        if (response.success) {
-            toaster('Resident updated successfully', ToastState.success);
-            onOpenChange(false);
-            onSuccess();
-        } else {
-            toaster(
-                response.message ?? 'Failed to update resident',
-                ToastState.error
-            );
-        }
-    };
-
-    return (
-        <Dialog open={open} onOpenChange={onOpenChange}>
-            <DialogContent>
-                <DialogHeader>
-                    <DialogTitle>Edit Resident Profile</DialogTitle>
-                    <DialogDescription>
-                        Update resident information
-                    </DialogDescription>
-                </DialogHeader>
-                <form
-                    onSubmit={(e) => {
-                        e.preventDefault();
-                        void form.handleSubmit(
-                            (d) => void handleSave(d)
-                        )(e);
-                    }}
-                    className="space-y-4 py-4"
-                >
-                    <div className="grid grid-cols-2 gap-4">
-                        <div>
-                            <Label htmlFor="edit-first">First Name</Label>
-                            <Input
-                                id="edit-first"
-                                {...form.register('name_first', {
-                                    required: true
-                                })}
-                                className="mt-2"
-                            />
-                        </div>
-                        <div>
-                            <Label htmlFor="edit-last">Last Name</Label>
-                            <Input
-                                id="edit-last"
-                                {...form.register('name_last', {
-                                    required: true
-                                })}
-                                className="mt-2"
-                            />
-                        </div>
-                    </div>
-                    <div>
-                        <Label htmlFor="edit-username">Username</Label>
-                        <Input
-                            id="edit-username"
-                            value={resident.username}
-                            disabled
-                            className="mt-2 bg-muted"
-                        />
-                    </div>
-                    <div>
-                        <Label htmlFor="edit-doc-id">Resident ID</Label>
-                        <Input
-                            id="edit-doc-id"
-                            {...form.register('doc_id')}
-                            className="mt-2"
-                        />
-                    </div>
-                    <DialogFooter className="mt-6">
-                        <Button
-                            variant="outline"
-                            type="button"
-                            onClick={() => onOpenChange(false)}
-                        >
-                            Cancel
-                        </Button>
-                        <Button
-                            type="submit"
-                            className="bg-[#556830] hover:bg-[#203622]"
-                        >
-                            Save Changes
-                        </Button>
-                    </DialogFooter>
-                </form>
-            </DialogContent>
-        </Dialog>
+  const handleSave = async (data: EditFormData) => {
+    const response = await API.patch<User, object>(
+      `users/${resident.id}`,
+      data
     );
+    if (response.success) {
+      toaster(`${resident.name_first} ${resident.name_last}'s profile updated`, ToastState.success);
+      onOpenChange(false);
+      onSuccess();
+    } else {
+      toaster(
+        response.message ?? 'Failed to update resident',
+        ToastState.error
+      );
+    }
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>Edit Resident Profile</DialogTitle>
+          <DialogDescription>
+            Update resident information
+          </DialogDescription>
+        </DialogHeader>
+        <div className="space-y-4 py-4">
+          <div className="grid grid-cols-2 gap-4">
+            <div>
+              <Label htmlFor="edit-first">First Name</Label>
+              <Input
+                id="edit-first"
+                {...form.register('name_first', {
+                  required: true
+                })}
+                className="mt-2"
+              />
+            </div>
+            <div>
+              <Label htmlFor="edit-last">Last Name</Label>
+              <Input
+                id="edit-last"
+                {...form.register('name_last', {
+                  required: true
+                })}
+                className="mt-2"
+              />
+            </div>
+          </div>
+          <div>
+            <Label htmlFor="edit-username">Username</Label>
+            <Input
+              id="edit-username"
+              value={resident.username}
+              disabled
+              className="mt-2 bg-muted"
+            />
+          </div>
+          <div>
+            <Label htmlFor="edit-doc-id">Resident ID</Label>
+            <Input
+              id="edit-doc-id"
+              {...form.register('doc_id')}
+              className="mt-2"
+            />
+          </div>
+        </div>
+        <DialogFooter>
+          <Button
+            variant="outline"
+            onClick={() => onOpenChange(false)}
+          >
+            Cancel
+          </Button>
+          <Button
+            onClick={() => void form.handleSubmit((d) => void handleSave(d))()}
+            className="bg-[#556830] hover:bg-[#203622]"
+          >
+            Save Changes
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
 }
 
 interface ResetPasswordConfirmDialogProps {
-    open: boolean;
-    onOpenChange: (open: boolean) => void;
-    resident: User;
-    onSuccess: (tempPassword: string) => void;
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  resident: User;
+  onSuccess: (tempPassword: string) => void;
 }
 
 export function ResetPasswordConfirmDialog({
-    open,
-    onOpenChange,
-    resident,
-    onSuccess
+  open,
+  onOpenChange,
+  resident,
+  onSuccess
 }: ResetPasswordConfirmDialogProps) {
-    const { toaster } = useToast();
-    const [loading, setLoading] = useState(false);
+  const { toaster } = useToast();
+  const [loading, setLoading] = useState(false);
 
-    const handleConfirm = async () => {
-        setLoading(true);
-        const response = (await API.post<ResetPasswordResponse, object>(
-            `users/${resident.id}/student-password`,
-            {}
-        )) as ServerResponseOne<ResetPasswordResponse>;
-        setLoading(false);
+  const handleConfirm = async () => {
+    setLoading(true);
+    const response = (await API.post<ResetPasswordResponse, object>(
+      `users/${resident.id}/student-password`,
+      {}
+    )) as ServerResponseOne<ResetPasswordResponse>;
+    setLoading(false);
 
-        if (response.success) {
-            toaster('Password reset successfully', ToastState.success);
-            onOpenChange(false);
-            onSuccess(response.data.temp_password);
-        } else {
-            toaster('Failed to reset password', ToastState.error);
-        }
-    };
+    if (response.success) {
+      toaster(`Password reset for ${resident.name_first} ${resident.name_last}`, ToastState.success);
+      onOpenChange(false);
+      onSuccess(response.data.temp_password);
+    } else {
+      toaster('Failed to reset password', ToastState.error);
+    }
+  };
 
-    return (
-        <Dialog open={open} onOpenChange={onOpenChange}>
-            <DialogContent>
-                <DialogHeader>
-                    <DialogTitle>Reset Password</DialogTitle>
-                    <DialogDescription>
-                        Are you sure you want to reset {resident.name_first}{' '}
-                        {resident.name_last}&apos;s password?
-                    </DialogDescription>
-                </DialogHeader>
-                <div className="py-4">
-                    <p className="text-sm text-gray-600">
-                        This will generate a temporary password for the
-                        resident. They will be required to change it on their
-                        next login.
-                    </p>
-                </div>
-                <DialogFooter>
-                    <Button
-                        variant="outline"
-                        onClick={() => onOpenChange(false)}
-                    >
-                        Cancel
-                    </Button>
-                    <Button
-                        onClick={() => void handleConfirm()}
-                        disabled={loading}
-                        className="bg-[#556830] hover:bg-[#203622]"
-                    >
-                        Reset Password
-                    </Button>
-                </DialogFooter>
-            </DialogContent>
-        </Dialog>
-    );
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>Reset Password</DialogTitle>
+          <DialogDescription>
+            Are you sure you want to reset {resident.name_first}{' '}
+            {resident.name_last}&apos;s password?
+          </DialogDescription>
+        </DialogHeader>
+        <div className="py-4">
+          <p className="text-sm text-gray-600">
+            This will generate a temporary password for the
+            resident. They will be required to change it on their
+            next login.
+          </p>
+        </div>
+        <DialogFooter>
+          <Button
+            variant="outline"
+            onClick={() => onOpenChange(false)}
+          >
+            Cancel
+          </Button>
+          <Button
+            onClick={() => void handleConfirm()}
+            disabled={loading}
+            className="bg-[#556830] hover:bg-[#203622]"
+          >
+            Reset Password
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
 }
 
 interface ResetPasswordResultDialogProps {
-    open: boolean;
-    onOpenChange: (open: boolean) => void;
-    residentName: string;
-    tempPassword: string;
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  residentName: string;
+  tempPassword: string;
 }
 
 export function ResetPasswordResultDialog({
-    open,
-    onOpenChange,
-    residentName,
-    tempPassword
+  open,
+  onOpenChange,
+  residentName,
+  tempPassword
 }: ResetPasswordResultDialogProps) {
-    const [copied, setCopied] = useState(false);
+  const [copied, setCopied] = useState(false);
 
-    const handleCopy = () => {
-        void navigator.clipboard.writeText(tempPassword);
-        setCopied(true);
-        setTimeout(() => setCopied(false), 2000);
-    };
+  const handleCopy = () => {
+    void navigator.clipboard.writeText(tempPassword);
+    setCopied(true);
+    setTimeout(() => setCopied(false), 2000);
+  };
 
-    return (
-        <Dialog open={open} onOpenChange={onOpenChange}>
-            <DialogContent>
-                <DialogHeader>
-                    <DialogTitle>Password Reset</DialogTitle>
-                    <DialogDescription>
-                        New temporary password for {residentName}
-                    </DialogDescription>
-                </DialogHeader>
-                <div className="py-4">
-                    <div className="bg-gray-100 rounded-lg p-4 border border-gray-300">
-                        <div className="text-sm text-gray-600 mb-2">
-                            Temporary Password
-                        </div>
-                        <div className="flex items-center gap-2">
-                            <code className="flex-1 text-lg font-mono font-semibold text-[#203622]">
-                                {tempPassword}
-                            </code>
-                            <Button
-                                variant="outline"
-                                size="sm"
-                                onClick={handleCopy}
-                            >
-                                {copied ? (
-                                    <>
-                                        <Check className="size-4 mr-2" />
-                                        Copied!
-                                    </>
-                                ) : (
-                                    <>
-                                        <Copy className="size-4 mr-2" />
-                                        Copy
-                                    </>
-                                )}
-                            </Button>
-                        </div>
-                    </div>
-                    <p className="text-sm text-gray-600 mt-4">
-                        Share this password securely with the resident. They
-                        will be prompted to change it on their next login.
-                    </p>
-                </div>
-                <DialogFooter>
-                    <Button
-                        onClick={() => onOpenChange(false)}
-                        className="bg-[#556830] hover:bg-[#203622]"
-                    >
-                        Done
-                    </Button>
-                </DialogFooter>
-            </DialogContent>
-        </Dialog>
-    );
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>Password Reset</DialogTitle>
+          <DialogDescription>
+            New temporary password for {residentName}
+          </DialogDescription>
+        </DialogHeader>
+        <div className="py-4">
+          <div className="bg-gray-100 rounded-lg p-4 border border-gray-300">
+            <div className="text-sm text-gray-600 mb-2">
+              Temporary Password
+            </div>
+            <div className="flex items-center gap-2">
+              <code className="flex-1 text-lg font-mono font-semibold text-[#203622]">
+                {tempPassword}
+              </code>
+              <Button
+                variant="outline"
+                size="sm"
+                onClick={handleCopy}
+              >
+                {copied ? (
+                  <>
+                    <Check className="size-4 mr-2" />
+                    Copied!
+                  </>
+                ) : (
+                  <>
+                    <Copy className="size-4 mr-2" />
+                    Copy
+                  </>
+                )}
+              </Button>
+            </div>
+          </div>
+          <p className="text-sm text-gray-600 mt-4">
+            Share this password securely with the resident. They
+            will be prompted to change it on their next login.
+          </p>
+        </div>
+        <DialogFooter>
+          <Button
+            onClick={() => onOpenChange(false)}
+            className="bg-[#556830] hover:bg-[#203622]"
+          >
+            Done
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
 }
 
 interface DeactivateDialogProps {
-    open: boolean;
-    onOpenChange: (open: boolean) => void;
-    resident: User;
-    onSuccess: () => void;
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  resident: User;
+  onSuccess: () => void;
 }
 
 export function DeactivateDialog({
-    open,
-    onOpenChange,
-    resident,
-    onSuccess
+  open,
+  onOpenChange,
+  resident,
+  onSuccess
 }: DeactivateDialogProps) {
-    const { toaster } = useToast();
-    const [confirmInput, setConfirmInput] = useState('');
-    const [loading, setLoading] = useState(false);
+  const { toaster } = useToast();
+  const [confirmInput, setConfirmInput] = useState('');
+  const [loading, setLoading] = useState(false);
 
-    useEffect(() => {
-        if (!open) setConfirmInput('');
-    }, [open]);
+  useEffect(() => {
+    if (!open) setConfirmInput('');
+  }, [open]);
 
-    const handleDeactivate = async () => {
-        setLoading(true);
-        const response = await API.post<string, object>(
-            `users/${resident.id}/deactivate`,
-            {}
-        );
-        setLoading(false);
-
-        if (response.success) {
-            toaster(
-                `${resident.name_first} ${resident.name_last} has been deactivated`,
-                ToastState.success
-            );
-            onOpenChange(false);
-            onSuccess();
-        } else {
-            toaster(
-                response.message ?? 'Failed to deactivate resident',
-                ToastState.error
-            );
-        }
-    };
-
-    const displayId = resident.doc_id ?? '';
-
-    return (
-        <Dialog open={open} onOpenChange={onOpenChange}>
-            <DialogContent>
-                <DialogHeader>
-                    <DialogTitle>Deactivate Account</DialogTitle>
-                    <DialogDescription>
-                        You are about to deactivate {resident.name_first}{' '}
-                        {resident.name_last}&apos;s account.
-                    </DialogDescription>
-                </DialogHeader>
-                <div className="py-4 space-y-4">
-                    <ul className="space-y-2 text-sm text-gray-700">
-                        <li className="flex gap-2">
-                            <span className="text-gray-400">&bull;</span>
-                            <span>
-                                The resident will be withdrawn from all active
-                                classes and programs.
-                            </span>
-                        </li>
-                        <li className="flex gap-2">
-                            <span className="text-gray-400">&bull;</span>
-                            <span>
-                                The resident&apos;s account will be locked and
-                                marked as Deactivated.
-                            </span>
-                        </li>
-                        <li className="flex gap-2">
-                            <span className="text-gray-400">&bull;</span>
-                            <span>
-                                Staff will no longer be able to edit this
-                                resident&apos;s account.
-                            </span>
-                        </li>
-                        <li className="flex gap-2">
-                            <span className="text-gray-400">&bull;</span>
-                            <span>
-                                The resident will not be able to log in or
-                                enroll in new programs.
-                            </span>
-                        </li>
-                        <li className="flex gap-2">
-                            <span className="text-gray-400">&bull;</span>
-                            <span>
-                                The time this account was deactivated will be
-                                recorded.
-                            </span>
-                        </li>
-                        <li className="flex gap-2">
-                            <span className="text-gray-400">&bull;</span>
-                            <span>
-                                The resident&apos;s account history and
-                                favorites will be preserved and remain
-                                searchable.
-                            </span>
-                        </li>
-                    </ul>
-
-                    <div className="bg-orange-50 border border-orange-200 rounded-lg p-4">
-                        <Label htmlFor="deactivate-confirm">
-                            To confirm, type the Resident ID:{' '}
-                            <strong>{displayId}</strong>
-                        </Label>
-                        <Input
-                            id="deactivate-confirm"
-                            value={confirmInput}
-                            onChange={(e) => setConfirmInput(e.target.value)}
-                            placeholder="Type Resident ID to confirm"
-                            className="mt-2"
-                        />
-                    </div>
-                </div>
-                <DialogFooter>
-                    <Button
-                        variant="outline"
-                        onClick={() => onOpenChange(false)}
-                    >
-                        Cancel
-                    </Button>
-                    <Button
-                        onClick={() => void handleDeactivate()}
-                        disabled={confirmInput !== displayId || loading}
-                        className="bg-orange-600 hover:bg-orange-700"
-                    >
-                        Deactivate Account
-                    </Button>
-                </DialogFooter>
-            </DialogContent>
-        </Dialog>
+  const handleDeactivate = async () => {
+    setLoading(true);
+    const response = await API.post<string, object>(
+      `users/${resident.id}/deactivate`,
+      {}
     );
+    setLoading(false);
+
+    if (response.success) {
+      toaster(
+        `${resident.name_first} ${resident.name_last} has been deactivated`,
+        ToastState.success
+      );
+      onOpenChange(false);
+      onSuccess();
+    } else {
+      toaster(
+        response.message ?? 'Failed to deactivate resident',
+        ToastState.error
+      );
+    }
+  };
+
+  const displayId = resident.doc_id ?? '';
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>Deactivate Account</DialogTitle>
+          <DialogDescription>
+            You are about to deactivate {resident.name_first}{' '}
+            {resident.name_last}&apos;s account.
+          </DialogDescription>
+        </DialogHeader>
+        <div className="py-4 space-y-4">
+          <ul className="space-y-2 text-sm text-gray-700">
+            <li className="flex gap-2">
+              <span className="text-gray-400">&bull;</span>
+              <span>
+                The resident will be withdrawn from all active
+                classes and programs.
+              </span>
+            </li>
+            <li className="flex gap-2">
+              <span className="text-gray-400">&bull;</span>
+              <span>
+                The resident&apos;s account will be locked and
+                marked as Deactivated.
+              </span>
+            </li>
+            <li className="flex gap-2">
+              <span className="text-gray-400">&bull;</span>
+              <span>
+                Staff will no longer be able to edit this
+                resident&apos;s account.
+              </span>
+            </li>
+            <li className="flex gap-2">
+              <span className="text-gray-400">&bull;</span>
+              <span>
+                The resident will not be able to log in or
+                enroll in new programs.
+              </span>
+            </li>
+            <li className="flex gap-2">
+              <span className="text-gray-400">&bull;</span>
+              <span>
+                The time this account was deactivated will be
+                recorded.
+              </span>
+            </li>
+            <li className="flex gap-2">
+              <span className="text-gray-400">&bull;</span>
+              <span>
+                The resident&apos;s account history and
+                favorites will be preserved and remain
+                searchable.
+              </span>
+            </li>
+          </ul>
+
+          <div className="bg-orange-50 border border-orange-200 rounded-lg p-4">
+            <Label htmlFor="deactivate-confirm">
+              To confirm, type the Resident ID:{' '}
+              <strong>{displayId}</strong>
+            </Label>
+            <Input
+              id="deactivate-confirm"
+              value={confirmInput}
+              onChange={(e) => setConfirmInput(e.target.value)}
+              placeholder="Type Resident ID to confirm"
+              className="mt-2"
+            />
+          </div>
+        </div>
+        <DialogFooter>
+          <Button
+            variant="outline"
+            onClick={() => onOpenChange(false)}
+          >
+            Cancel
+          </Button>
+          <Button
+            onClick={() => void handleDeactivate()}
+            disabled={confirmInput !== displayId || loading}
+            className="bg-orange-600 hover:bg-orange-700"
+          >
+            Deactivate Account
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
 }
 
 interface DeleteDialogProps {
-    open: boolean;
-    onOpenChange: (open: boolean) => void;
-    resident: User;
-    onSuccess: () => void;
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  resident: User;
+  onSuccess: () => void;
 }
 
 export function DeleteDialog({
-    open,
-    onOpenChange,
-    resident,
-    onSuccess
+  open,
+  onOpenChange,
+  resident,
+  onSuccess
 }: DeleteDialogProps) {
-    const { toaster } = useToast();
-    const [confirmInput, setConfirmInput] = useState('');
-    const [loading, setLoading] = useState(false);
+  const { toaster } = useToast();
+  const [confirmInput, setConfirmInput] = useState('');
+  const [loading, setLoading] = useState(false);
 
-    useEffect(() => {
-        if (!open) setConfirmInput('');
-    }, [open]);
+  useEffect(() => {
+    if (!open) setConfirmInput('');
+  }, [open]);
 
-    const handleDelete = async () => {
-        setLoading(true);
-        const response = await API.delete(`users/${resident.id}`);
-        setLoading(false);
+  const handleDelete = async () => {
+    setLoading(true);
+    const response = await API.delete(`users/${resident.id}`);
+    setLoading(false);
 
-        if (response.success) {
-            toaster(
-                `${resident.name_first} ${resident.name_last} has been deleted`,
-                ToastState.success
-            );
-            onOpenChange(false);
-            onSuccess();
-        } else {
-            toaster(
-                response.message ?? 'Failed to delete resident',
-                ToastState.error
-            );
-        }
-    };
+    if (response.success) {
+      toaster(
+        `${resident.name_first} ${resident.name_last} has been deleted`,
+        ToastState.success
+      );
+      onOpenChange(false);
+      onSuccess();
+    } else {
+      toaster(
+        response.message ?? 'Failed to delete resident',
+        ToastState.error
+      );
+    }
+  };
 
-    const displayId = resident.doc_id ?? '';
+  const displayId = resident.doc_id ?? '';
 
-    return (
-        <Dialog open={open} onOpenChange={onOpenChange}>
-            <DialogContent>
-                <DialogHeader>
-                    <DialogTitle>Delete Resident</DialogTitle>
-                    <DialogDescription>
-                        Are you sure you want to delete {resident.name_first}{' '}
-                        {resident.name_last}?
-                    </DialogDescription>
-                </DialogHeader>
-                <div className="py-4 space-y-4">
-                    <p className="text-sm text-red-600 font-medium">
-                        This action cannot be undone. All data associated with
-                        this resident will be permanently deleted.
-                    </p>
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>Delete Resident</DialogTitle>
+          <DialogDescription>
+            Are you sure you want to delete {resident.name_first}{' '}
+            {resident.name_last}?
+          </DialogDescription>
+        </DialogHeader>
+        <div className="py-4 space-y-4">
+          <p className="text-sm text-red-600 font-medium">
+            This action cannot be undone. All data associated with
+            this resident will be permanently deleted.
+          </p>
 
-                    <div className="bg-red-50 border border-red-200 rounded-lg p-4">
-                        <Label htmlFor="delete-confirm">
-                            To confirm, type the Resident ID:{' '}
-                            <strong>{displayId}</strong>
-                        </Label>
-                        <Input
-                            id="delete-confirm"
-                            value={confirmInput}
-                            onChange={(e) => setConfirmInput(e.target.value)}
-                            placeholder="Type Resident ID to confirm"
-                            className="mt-2"
-                        />
-                    </div>
-                </div>
-                <DialogFooter>
-                    <Button
-                        variant="outline"
-                        onClick={() => onOpenChange(false)}
-                    >
-                        Cancel
-                    </Button>
-                    <Button
-                        onClick={() => void handleDelete()}
-                        disabled={confirmInput !== displayId || loading}
-                        variant="destructive"
-                    >
-                        Delete Resident
-                    </Button>
-                </DialogFooter>
-            </DialogContent>
-        </Dialog>
-    );
+          <div className="bg-red-50 border border-red-200 rounded-lg p-4">
+            <Label htmlFor="delete-confirm">
+              To confirm, type the Resident ID:{' '}
+              <strong>{displayId}</strong>
+            </Label>
+            <Input
+              id="delete-confirm"
+              value={confirmInput}
+              onChange={(e) => setConfirmInput(e.target.value)}
+              placeholder="Type Resident ID to confirm"
+              className="mt-2"
+            />
+          </div>
+        </div>
+        <DialogFooter>
+          <Button
+            variant="outline"
+            onClick={() => onOpenChange(false)}
+          >
+            Cancel
+          </Button>
+          <Button
+            onClick={() => void handleDelete()}
+            disabled={confirmInput !== displayId || loading}
+            variant="destructive"
+          >
+            Delete Resident
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
 }
 
 interface TransferDialogProps {
-    open: boolean;
-    onOpenChange: (open: boolean) => void;
-    resident: User;
-    facilities: Facility[];
-    onSuccess: () => void;
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  resident: User;
+  facilities: Facility[];
+  onSuccess: () => void;
 }
 
 export function TransferDialog({
-    open,
-    onOpenChange,
-    resident,
-    facilities,
-    onSuccess
+  open,
+  onOpenChange,
+  resident,
+  facilities,
+  onSuccess
 }: TransferDialogProps) {
-    const { toaster } = useToast();
-    const [transferFacilityId, setTransferFacilityId] = useState('');
-    const [confirmInput, setConfirmInput] = useState('');
-    const [loading, setLoading] = useState(false);
+  const { toaster } = useToast();
+  const [transferFacilityId, setTransferFacilityId] = useState('');
+  const [confirmInput, setConfirmInput] = useState('');
+  const [loading, setLoading] = useState(false);
 
-    useEffect(() => {
-        if (!open) {
-            setTransferFacilityId('');
-            setConfirmInput('');
-        }
-    }, [open]);
+  useEffect(() => {
+    if (!open) {
+      setTransferFacilityId('');
+      setConfirmInput('');
+    }
+  }, [open]);
 
-    const { data: verifyResp } = useSWR<ServerResponseOne<ValidResident>>(
-        open && transferFacilityId
-            ? `/api/users/resident-verify?user_id=${resident.id}&facility_id=${transferFacilityId}&doc_id=${encodeURIComponent(resident.doc_id ?? '')}`
-            : null
+  const { data: verifyResp } = useSWR<ServerResponseOne<ValidResident>>(
+    open && transferFacilityId
+      ? `/api/users/resident-verify?user_id=${resident.id}&facility_id=${transferFacilityId}&doc_id=${encodeURIComponent(resident.doc_id ?? '')}`
+      : null
+  );
+  const rawConflicts = verifyResp?.data?.program_names ?? [];
+  const programConflicts = [
+    ...new Set(rawConflicts.map((c) => c.program_name))
+  ];
+
+  const handleTransfer = async () => {
+    setLoading(true);
+    const response = await API.patch<string, object>(
+      'users/resident-transfer',
+      {
+        user_id: resident.id,
+        curr_facility_id:
+          resident.facility?.id ?? resident.facility_id,
+        trans_facility_id: Number(transferFacilityId)
+      }
     );
-    const rawConflicts = verifyResp?.data?.program_names ?? [];
-    const programConflicts = [
-        ...new Set(rawConflicts.map((c) => c.program_name))
-    ];
+    setLoading(false);
 
-    const handleTransfer = async () => {
-        setLoading(true);
-        const response = await API.patch<string, object>(
-            'users/resident-transfer',
-            {
-                user_id: resident.id,
-                curr_facility_id:
-                    resident.facility?.id ?? resident.facility_id,
-                trans_facility_id: Number(transferFacilityId)
-            }
-        );
-        setLoading(false);
+    if (response.success) {
+      toaster(
+        `${resident.name_first} ${resident.name_last} transferred to ${targetFacilityName}`,
+        ToastState.success
+      );
+      onOpenChange(false);
+      onSuccess();
+    } else {
+      toaster(
+        response.message ?? 'Failed to transfer resident',
+        ToastState.error
+      );
+    }
+  };
 
-        if (response.success) {
-            toaster(
-                `${resident.name_first} ${resident.name_last} transferred successfully`,
-                ToastState.success
-            );
-            onOpenChange(false);
-            onSuccess();
-        } else {
-            toaster(
-                response.message ?? 'Failed to transfer resident',
-                ToastState.error
-            );
-        }
-    };
+  const displayId = resident.doc_id ?? '';
+  const currentFacilityName =
+    resident.facility?.name ??
+    facilities.find((f) => f.id === resident.facility_id)?.name ??
+    'Unknown';
+  const targetFacilityName =
+    facilities.find((f) => String(f.id) === transferFacilityId)?.name ?? '';
 
-    const displayId = resident.doc_id ?? '';
-    const currentFacilityName =
-        resident.facility?.name ??
-        facilities.find((f) => f.id === resident.facility_id)?.name ??
-        'Unknown';
-    const targetFacilityName =
-        facilities.find((f) => String(f.id) === transferFacilityId)?.name ?? '';
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="max-w-2xl">
+        <DialogHeader>
+          <DialogTitle>Transfer Resident</DialogTitle>
+          <DialogDescription>
+            Move {resident.name_last}, {resident.name_first} to a
+            different facility
+          </DialogDescription>
+        </DialogHeader>
+        <div className="space-y-6 py-4">
+          <div className="space-y-3">
+            <div className="text-sm text-gray-600">
+              Current Facility:{' '}
+              <span className="font-medium text-gray-900">
+                {currentFacilityName}
+              </span>
+            </div>
+            <div>
+              <Label className="text-xs text-gray-500">
+                New Facility
+              </Label>
+              <Select
+                value={transferFacilityId}
+                onValueChange={setTransferFacilityId}
+              >
+                <SelectTrigger className="mt-1">
+                  <SelectValue placeholder="Select facility" />
+                </SelectTrigger>
+                <SelectContent>
+                  {facilities
+                    .filter(
+                      (f) =>
+                        f.id !==
+                        (resident.facility?.id ??
+                          resident.facility_id)
+                    )
+                    .map((f) => (
+                      <SelectItem
+                        key={f.id}
+                        value={String(f.id)}
+                      >
+                        {f.name}
+                      </SelectItem>
+                    ))}
+                </SelectContent>
+              </Select>
+            </div>
+          </div>
 
-    return (
-        <Dialog open={open} onOpenChange={onOpenChange}>
-            <DialogContent className="max-w-2xl">
-                <DialogHeader>
-                    <DialogTitle>Transfer Resident</DialogTitle>
-                    <DialogDescription>
-                        Move {resident.name_last}, {resident.name_first} to a
-                        different facility
-                    </DialogDescription>
-                </DialogHeader>
-                <div className="space-y-6 py-4">
-                    <div className="space-y-3">
-                        <div className="text-sm text-gray-600">
-                            Current Facility:{' '}
-                            <span className="font-medium text-gray-900">
-                                {currentFacilityName}
-                            </span>
-                        </div>
-                        <div>
-                            <Label className="text-xs text-gray-500">
-                                New Facility
-                            </Label>
-                            <Select
-                                value={transferFacilityId}
-                                onValueChange={setTransferFacilityId}
-                            >
-                                <SelectTrigger className="mt-1">
-                                    <SelectValue placeholder="Select facility" />
-                                </SelectTrigger>
-                                <SelectContent>
-                                    {facilities
-                                        .filter(
-                                            (f) =>
-                                                f.id !==
-                                                (resident.facility?.id ??
-                                                    resident.facility_id)
-                                        )
-                                        .map((f) => (
-                                            <SelectItem
-                                                key={f.id}
-                                                value={String(f.id)}
-                                            >
-                                                {f.name}
-                                            </SelectItem>
-                                        ))}
-                                </SelectContent>
-                            </Select>
-                        </div>
-                    </div>
-
-                    {transferFacilityId && (
-                        <>
-                            <div className="bg-orange-50 border border-orange-200 rounded-lg p-4">
-                                <div className="font-medium text-orange-900 text-sm mb-1">
-                                    Transfer will unenroll resident from all
-                                    classes
-                                </div>
-                                <div className="text-sm text-orange-800">
-                                    {resident.name_first} will be removed from
-                                    all active enrollments and must be
-                                    re-enrolled at the new facility.
-                                </div>
-                            </div>
-
-                            {programConflicts.length > 0 && (
-                                <div className="border border-gray-200 rounded-lg p-4">
-                                    <div className="font-medium text-sm text-gray-900 mb-3">
-                                        Programs not available at{' '}
-                                        {targetFacilityName}
-                                    </div>
-                                    <div className="space-y-2">
-                                        {programConflicts.map(
-                                            (name, idx) => (
-                                                <div
-                                                    key={idx}
-                                                    className="text-sm text-gray-600 flex items-center gap-2"
-                                                >
-                                                    <div className="size-1.5 rounded-full bg-gray-400" />
-                                                    {name}
-                                                </div>
-                                            )
-                                        )}
-                                    </div>
-                                </div>
-                            )}
-
-                            <div className="space-y-2">
-                                <div className="text-xs font-medium text-gray-500 uppercase tracking-wide">
-                                    What happens next
-                                </div>
-                                <div className="space-y-1.5 text-sm text-gray-700">
-                                    <div className="flex items-center gap-2">
-                                        <Check className="size-4 text-green-600 shrink-0" />
-                                        <span>
-                                            Account history and favorites will
-                                            be preserved
-                                        </span>
-                                    </div>
-                                    <div className="flex items-center gap-2">
-                                        <Check className="size-4 text-green-600 shrink-0" />
-                                        <span>
-                                            Resident can log in at{' '}
-                                            {targetFacilityName}
-                                        </span>
-                                    </div>
-                                </div>
-                            </div>
-
-                            <div className="border-t pt-4">
-                                <Label
-                                    htmlFor="transfer-confirm"
-                                    className="text-sm font-medium"
-                                >
-                                    Type{' '}
-                                    <span className="font-mono font-semibold text-[#203622]">
-                                        {displayId}
-                                    </span>{' '}
-                                    to confirm
-                                </Label>
-                                <Input
-                                    id="transfer-confirm"
-                                    value={confirmInput}
-                                    onChange={(e) =>
-                                        setConfirmInput(e.target.value)
-                                    }
-                                    placeholder="Enter Resident ID"
-                                    className="mt-2"
-                                />
-                            </div>
-                        </>
-                    )}
+          {transferFacilityId && (
+            <>
+              <div className="bg-orange-50 border border-orange-200 rounded-lg p-4">
+                <div className="font-medium text-orange-900 text-sm mb-1">
+                  Transfer will unenroll resident from all
+                  classes
                 </div>
-                <DialogFooter>
-                    <Button
-                        variant="outline"
-                        onClick={() => onOpenChange(false)}
-                    >
-                        Cancel
-                    </Button>
-                    <Button
-                        onClick={() => void handleTransfer()}
-                        disabled={
-                            !transferFacilityId ||
-                            confirmInput !== displayId ||
-                            loading
-                        }
-                        className="bg-[#556830] hover:bg-[#203622]"
-                    >
-                        Transfer Resident
-                    </Button>
-                </DialogFooter>
-            </DialogContent>
-        </Dialog>
-    );
+                <div className="text-sm text-orange-800">
+                  {resident.name_first} will be removed from
+                  all active enrollments and must be
+                  re-enrolled at the new facility.
+                </div>
+              </div>
+
+              {programConflicts.length > 0 && (
+                <div className="border border-gray-200 rounded-lg p-4">
+                  <div className="font-medium text-sm text-gray-900 mb-3">
+                    Programs not available at{' '}
+                    {targetFacilityName}
+                  </div>
+                  <div className="space-y-2">
+                    {programConflicts.map(
+                      (name, idx) => (
+                        <div
+                          key={idx}
+                          className="text-sm text-gray-600 flex items-center gap-2"
+                        >
+                          <div className="size-1.5 rounded-full bg-gray-400" />
+                          {name}
+                        </div>
+                      )
+                    )}
+                  </div>
+                </div>
+              )}
+
+              <div className="space-y-2">
+                <div className="text-xs font-medium text-gray-500 uppercase tracking-wide">
+                  What happens next
+                </div>
+                <div className="space-y-1.5 text-sm text-gray-700">
+                  <div className="flex items-center gap-2">
+                    <Check className="size-4 text-green-600 shrink-0" />
+                    <span>
+                      Account history and favorites will
+                      be preserved
+                    </span>
+                  </div>
+                  <div className="flex items-center gap-2">
+                    <Check className="size-4 text-green-600 shrink-0" />
+                    <span>
+                      Resident can log in at{' '}
+                      {targetFacilityName}
+                    </span>
+                  </div>
+                </div>
+              </div>
+
+              <div className="border-t pt-4">
+                <Label
+                  htmlFor="transfer-confirm"
+                  className="text-sm font-medium"
+                >
+                  Type{' '}
+                  <span className="font-mono font-semibold text-[#203622]">
+                    {displayId}
+                  </span>{' '}
+                  to confirm
+                </Label>
+                <Input
+                  id="transfer-confirm"
+                  value={confirmInput}
+                  onChange={(e) =>
+                    setConfirmInput(e.target.value)
+                  }
+                  placeholder="Enter Resident ID"
+                  className="mt-2"
+                />
+              </div>
+            </>
+          )}
+        </div>
+        <DialogFooter>
+          <Button
+            variant="outline"
+            onClick={() => onOpenChange(false)}
+          >
+            Cancel
+          </Button>
+          <Button
+            onClick={() => void handleTransfer()}
+            disabled={
+              !transferFacilityId ||
+              confirmInput !== displayId ||
+              loading
+            }
+            className="bg-[#556830] hover:bg-[#203622]"
+          >
+            Transfer Resident
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
 }

--- a/frontend-v2/src/components/residents/ResidentModals.tsx
+++ b/frontend-v2/src/components/residents/ResidentModals.tsx
@@ -1,0 +1,762 @@
+import { useState, useEffect } from 'react';
+import { useForm } from 'react-hook-form';
+import useSWR from 'swr';
+import API from '@/api/api';
+import {
+    User,
+    Facility,
+    ValidResident,
+    ServerResponseOne,
+    ResetPasswordResponse,
+    ToastState
+} from '@/types';
+import { useToast } from '@/contexts/ToastContext';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import {
+    Dialog,
+    DialogContent,
+    DialogDescription,
+    DialogFooter,
+    DialogHeader,
+    DialogTitle
+} from '@/components/ui/dialog';
+import {
+    Select,
+    SelectContent,
+    SelectItem,
+    SelectTrigger,
+    SelectValue
+} from '@/components/ui/select';
+import { Copy, Check } from 'lucide-react';
+
+interface EditFormData {
+    name_first: string;
+    name_last: string;
+    doc_id: string;
+}
+
+interface EditResidentDialogProps {
+    open: boolean;
+    onOpenChange: (open: boolean) => void;
+    resident: User;
+    onSuccess: () => void;
+}
+
+export function EditResidentDialog({
+    open,
+    onOpenChange,
+    resident,
+    onSuccess
+}: EditResidentDialogProps) {
+    const { toaster } = useToast();
+    const form = useForm<EditFormData>();
+
+    useEffect(() => {
+        if (open) {
+            form.reset({
+                name_first: resident.name_first,
+                name_last: resident.name_last,
+                doc_id: resident.doc_id ?? ''
+            });
+        }
+    }, [open, resident, form]);
+
+    const handleSave = async (data: EditFormData) => {
+        const response = await API.patch<User, object>(
+            `users/${resident.id}`,
+            data
+        );
+        if (response.success) {
+            toaster('Resident updated successfully', ToastState.success);
+            onOpenChange(false);
+            onSuccess();
+        } else {
+            toaster(
+                response.message ?? 'Failed to update resident',
+                ToastState.error
+            );
+        }
+    };
+
+    return (
+        <Dialog open={open} onOpenChange={onOpenChange}>
+            <DialogContent>
+                <DialogHeader>
+                    <DialogTitle>Edit Resident Profile</DialogTitle>
+                    <DialogDescription>
+                        Update resident information
+                    </DialogDescription>
+                </DialogHeader>
+                <form
+                    onSubmit={(e) => {
+                        e.preventDefault();
+                        void form.handleSubmit(
+                            (d) => void handleSave(d)
+                        )(e);
+                    }}
+                    className="space-y-4 py-4"
+                >
+                    <div className="grid grid-cols-2 gap-4">
+                        <div>
+                            <Label htmlFor="edit-first">First Name</Label>
+                            <Input
+                                id="edit-first"
+                                {...form.register('name_first', {
+                                    required: true
+                                })}
+                                className="mt-2"
+                            />
+                        </div>
+                        <div>
+                            <Label htmlFor="edit-last">Last Name</Label>
+                            <Input
+                                id="edit-last"
+                                {...form.register('name_last', {
+                                    required: true
+                                })}
+                                className="mt-2"
+                            />
+                        </div>
+                    </div>
+                    <div>
+                        <Label htmlFor="edit-username">Username</Label>
+                        <Input
+                            id="edit-username"
+                            value={resident.username}
+                            disabled
+                            className="mt-2 bg-muted"
+                        />
+                    </div>
+                    <div>
+                        <Label htmlFor="edit-doc-id">Resident ID</Label>
+                        <Input
+                            id="edit-doc-id"
+                            {...form.register('doc_id')}
+                            className="mt-2"
+                        />
+                    </div>
+                    <DialogFooter>
+                        <Button
+                            variant="outline"
+                            type="button"
+                            onClick={() => onOpenChange(false)}
+                        >
+                            Cancel
+                        </Button>
+                        <Button
+                            type="submit"
+                            className="bg-[#556830] hover:bg-[#203622]"
+                        >
+                            Save Changes
+                        </Button>
+                    </DialogFooter>
+                </form>
+            </DialogContent>
+        </Dialog>
+    );
+}
+
+interface ResetPasswordConfirmDialogProps {
+    open: boolean;
+    onOpenChange: (open: boolean) => void;
+    resident: User;
+    onSuccess: (tempPassword: string) => void;
+}
+
+export function ResetPasswordConfirmDialog({
+    open,
+    onOpenChange,
+    resident,
+    onSuccess
+}: ResetPasswordConfirmDialogProps) {
+    const { toaster } = useToast();
+    const [loading, setLoading] = useState(false);
+
+    const handleConfirm = async () => {
+        setLoading(true);
+        const response = (await API.post<ResetPasswordResponse, object>(
+            `users/${resident.id}/student-password`,
+            {}
+        )) as ServerResponseOne<ResetPasswordResponse>;
+        setLoading(false);
+
+        if (response.success) {
+            toaster('Password reset successfully', ToastState.success);
+            onOpenChange(false);
+            onSuccess(response.data.temp_password);
+        } else {
+            toaster('Failed to reset password', ToastState.error);
+        }
+    };
+
+    return (
+        <Dialog open={open} onOpenChange={onOpenChange}>
+            <DialogContent>
+                <DialogHeader>
+                    <DialogTitle>Reset Password</DialogTitle>
+                    <DialogDescription>
+                        Are you sure you want to reset {resident.name_first}{' '}
+                        {resident.name_last}&apos;s password?
+                    </DialogDescription>
+                </DialogHeader>
+                <div className="py-4">
+                    <p className="text-sm text-gray-600">
+                        This will generate a temporary password for the
+                        resident. They will be required to change it on their
+                        next login.
+                    </p>
+                </div>
+                <DialogFooter>
+                    <Button
+                        variant="outline"
+                        onClick={() => onOpenChange(false)}
+                    >
+                        Cancel
+                    </Button>
+                    <Button
+                        onClick={() => void handleConfirm()}
+                        disabled={loading}
+                        className="bg-[#556830] hover:bg-[#203622]"
+                    >
+                        Reset Password
+                    </Button>
+                </DialogFooter>
+            </DialogContent>
+        </Dialog>
+    );
+}
+
+interface ResetPasswordResultDialogProps {
+    open: boolean;
+    onOpenChange: (open: boolean) => void;
+    residentName: string;
+    tempPassword: string;
+}
+
+export function ResetPasswordResultDialog({
+    open,
+    onOpenChange,
+    residentName,
+    tempPassword
+}: ResetPasswordResultDialogProps) {
+    const [copied, setCopied] = useState(false);
+
+    const handleCopy = () => {
+        void navigator.clipboard.writeText(tempPassword);
+        setCopied(true);
+        setTimeout(() => setCopied(false), 2000);
+    };
+
+    return (
+        <Dialog open={open} onOpenChange={onOpenChange}>
+            <DialogContent>
+                <DialogHeader>
+                    <DialogTitle>Password Reset</DialogTitle>
+                    <DialogDescription>
+                        New temporary password for {residentName}
+                    </DialogDescription>
+                </DialogHeader>
+                <div className="py-4">
+                    <div className="bg-gray-100 rounded-lg p-4 border border-gray-300">
+                        <div className="text-sm text-gray-600 mb-2">
+                            Temporary Password
+                        </div>
+                        <div className="flex items-center gap-2">
+                            <code className="flex-1 text-lg font-mono font-semibold text-[#203622]">
+                                {tempPassword}
+                            </code>
+                            <Button
+                                variant="outline"
+                                size="sm"
+                                onClick={handleCopy}
+                            >
+                                {copied ? (
+                                    <>
+                                        <Check className="size-4 mr-2" />
+                                        Copied!
+                                    </>
+                                ) : (
+                                    <>
+                                        <Copy className="size-4 mr-2" />
+                                        Copy
+                                    </>
+                                )}
+                            </Button>
+                        </div>
+                    </div>
+                    <p className="text-sm text-gray-600 mt-4">
+                        Share this password securely with the resident. They
+                        will be prompted to change it on their next login.
+                    </p>
+                </div>
+                <DialogFooter>
+                    <Button
+                        onClick={() => onOpenChange(false)}
+                        className="bg-[#556830] hover:bg-[#203622]"
+                    >
+                        Done
+                    </Button>
+                </DialogFooter>
+            </DialogContent>
+        </Dialog>
+    );
+}
+
+interface DeactivateDialogProps {
+    open: boolean;
+    onOpenChange: (open: boolean) => void;
+    resident: User;
+    onSuccess: () => void;
+}
+
+export function DeactivateDialog({
+    open,
+    onOpenChange,
+    resident,
+    onSuccess
+}: DeactivateDialogProps) {
+    const { toaster } = useToast();
+    const [confirmInput, setConfirmInput] = useState('');
+    const [loading, setLoading] = useState(false);
+
+    useEffect(() => {
+        if (!open) setConfirmInput('');
+    }, [open]);
+
+    const handleDeactivate = async () => {
+        setLoading(true);
+        const response = await API.post<string, object>(
+            `users/${resident.id}/deactivate`,
+            {}
+        );
+        setLoading(false);
+
+        if (response.success) {
+            toaster(
+                `${resident.name_first} ${resident.name_last} has been deactivated`,
+                ToastState.success
+            );
+            onOpenChange(false);
+            onSuccess();
+        } else {
+            toaster(
+                response.message ?? 'Failed to deactivate resident',
+                ToastState.error
+            );
+        }
+    };
+
+    const displayId = resident.doc_id ?? '';
+
+    return (
+        <Dialog open={open} onOpenChange={onOpenChange}>
+            <DialogContent>
+                <DialogHeader>
+                    <DialogTitle>Deactivate Account</DialogTitle>
+                    <DialogDescription>
+                        You are about to deactivate {resident.name_first}{' '}
+                        {resident.name_last}&apos;s account.
+                    </DialogDescription>
+                </DialogHeader>
+                <div className="py-4 space-y-4">
+                    <ul className="space-y-2 text-sm text-gray-700">
+                        <li className="flex gap-2">
+                            <span className="text-gray-400">-</span>
+                            <span>
+                                The resident will be withdrawn from all active
+                                classes and programs.
+                            </span>
+                        </li>
+                        <li className="flex gap-2">
+                            <span className="text-gray-400">-</span>
+                            <span>
+                                The resident&apos;s account will be locked and
+                                marked as Deactivated.
+                            </span>
+                        </li>
+                        <li className="flex gap-2">
+                            <span className="text-gray-400">-</span>
+                            <span>
+                                Staff will no longer be able to edit this
+                                resident&apos;s account.
+                            </span>
+                        </li>
+                        <li className="flex gap-2">
+                            <span className="text-gray-400">-</span>
+                            <span>
+                                The resident will not be able to log in or
+                                enroll in new programs.
+                            </span>
+                        </li>
+                        <li className="flex gap-2">
+                            <span className="text-gray-400">-</span>
+                            <span>
+                                The time this account was deactivated will be
+                                recorded.
+                            </span>
+                        </li>
+                        <li className="flex gap-2">
+                            <span className="text-gray-400">-</span>
+                            <span>
+                                The resident&apos;s account history and
+                                favorites will be preserved and remain
+                                searchable.
+                            </span>
+                        </li>
+                    </ul>
+
+                    <div className="bg-orange-50 border border-orange-200 rounded-lg p-4">
+                        <Label htmlFor="deactivate-confirm">
+                            To confirm, type the Resident ID:{' '}
+                            <strong>{displayId}</strong>
+                        </Label>
+                        <Input
+                            id="deactivate-confirm"
+                            value={confirmInput}
+                            onChange={(e) => setConfirmInput(e.target.value)}
+                            placeholder="Type Resident ID to confirm"
+                            className="mt-2"
+                        />
+                    </div>
+                </div>
+                <DialogFooter>
+                    <Button
+                        variant="outline"
+                        onClick={() => onOpenChange(false)}
+                    >
+                        Cancel
+                    </Button>
+                    <Button
+                        onClick={() => void handleDeactivate()}
+                        disabled={confirmInput !== displayId || loading}
+                        className="bg-orange-600 hover:bg-orange-700"
+                    >
+                        Deactivate Account
+                    </Button>
+                </DialogFooter>
+            </DialogContent>
+        </Dialog>
+    );
+}
+
+interface DeleteDialogProps {
+    open: boolean;
+    onOpenChange: (open: boolean) => void;
+    resident: User;
+    onSuccess: () => void;
+}
+
+export function DeleteDialog({
+    open,
+    onOpenChange,
+    resident,
+    onSuccess
+}: DeleteDialogProps) {
+    const { toaster } = useToast();
+    const [confirmInput, setConfirmInput] = useState('');
+    const [loading, setLoading] = useState(false);
+
+    useEffect(() => {
+        if (!open) setConfirmInput('');
+    }, [open]);
+
+    const handleDelete = async () => {
+        setLoading(true);
+        const response = await API.delete(`users/${resident.id}`);
+        setLoading(false);
+
+        if (response.success) {
+            toaster(
+                `${resident.name_first} ${resident.name_last} has been deleted`,
+                ToastState.success
+            );
+            onOpenChange(false);
+            onSuccess();
+        } else {
+            toaster(
+                response.message ?? 'Failed to delete resident',
+                ToastState.error
+            );
+        }
+    };
+
+    const displayId = resident.doc_id ?? '';
+
+    return (
+        <Dialog open={open} onOpenChange={onOpenChange}>
+            <DialogContent>
+                <DialogHeader>
+                    <DialogTitle>Delete Resident</DialogTitle>
+                    <DialogDescription>
+                        Are you sure you want to delete {resident.name_first}{' '}
+                        {resident.name_last}?
+                    </DialogDescription>
+                </DialogHeader>
+                <div className="py-4 space-y-4">
+                    <p className="text-sm text-red-600 font-medium">
+                        This action cannot be undone. All data associated with
+                        this resident will be permanently deleted.
+                    </p>
+
+                    <div className="bg-red-50 border border-red-200 rounded-lg p-4">
+                        <Label htmlFor="delete-confirm">
+                            To confirm, type the Resident ID:{' '}
+                            <strong>{displayId}</strong>
+                        </Label>
+                        <Input
+                            id="delete-confirm"
+                            value={confirmInput}
+                            onChange={(e) => setConfirmInput(e.target.value)}
+                            placeholder="Type Resident ID to confirm"
+                            className="mt-2"
+                        />
+                    </div>
+                </div>
+                <DialogFooter>
+                    <Button
+                        variant="outline"
+                        onClick={() => onOpenChange(false)}
+                    >
+                        Cancel
+                    </Button>
+                    <Button
+                        onClick={() => void handleDelete()}
+                        disabled={confirmInput !== displayId || loading}
+                        variant="destructive"
+                    >
+                        Delete Resident
+                    </Button>
+                </DialogFooter>
+            </DialogContent>
+        </Dialog>
+    );
+}
+
+interface TransferDialogProps {
+    open: boolean;
+    onOpenChange: (open: boolean) => void;
+    resident: User;
+    facilities: Facility[];
+    onSuccess: () => void;
+}
+
+export function TransferDialog({
+    open,
+    onOpenChange,
+    resident,
+    facilities,
+    onSuccess
+}: TransferDialogProps) {
+    const { toaster } = useToast();
+    const [transferFacilityId, setTransferFacilityId] = useState('');
+    const [confirmInput, setConfirmInput] = useState('');
+    const [loading, setLoading] = useState(false);
+
+    useEffect(() => {
+        if (!open) {
+            setTransferFacilityId('');
+            setConfirmInput('');
+        }
+    }, [open]);
+
+    const { data: verifyResp } = useSWR<ServerResponseOne<ValidResident>>(
+        open && transferFacilityId
+            ? `/api/users/resident-verify?user_id=${resident.id}&facility_id=${transferFacilityId}&doc_id=${encodeURIComponent(resident.doc_id ?? '')}`
+            : null
+    );
+    const programConflicts = verifyResp?.data?.program_names ?? [];
+
+    const handleTransfer = async () => {
+        setLoading(true);
+        const response = await API.patch<string, object>(
+            'users/resident-transfer',
+            {
+                user_id: resident.id,
+                curr_facility_id:
+                    resident.facility?.id ?? resident.facility_id,
+                trans_facility_id: Number(transferFacilityId)
+            }
+        );
+        setLoading(false);
+
+        if (response.success) {
+            toaster(
+                `${resident.name_first} ${resident.name_last} transferred successfully`,
+                ToastState.success
+            );
+            onOpenChange(false);
+            onSuccess();
+        } else {
+            toaster(
+                response.message ?? 'Failed to transfer resident',
+                ToastState.error
+            );
+        }
+    };
+
+    const displayId = resident.doc_id ?? '';
+    const currentFacilityName =
+        resident.facility?.name ??
+        facilities.find((f) => f.id === resident.facility_id)?.name ??
+        'Unknown';
+    const targetFacilityName =
+        facilities.find((f) => String(f.id) === transferFacilityId)?.name ?? '';
+
+    return (
+        <Dialog open={open} onOpenChange={onOpenChange}>
+            <DialogContent className="max-w-2xl">
+                <DialogHeader>
+                    <DialogTitle>Transfer Resident</DialogTitle>
+                    <DialogDescription>
+                        Move {resident.name_last}, {resident.name_first} to a
+                        different facility
+                    </DialogDescription>
+                </DialogHeader>
+                <div className="space-y-6 py-4">
+                    <div className="space-y-3">
+                        <div className="text-sm text-gray-600">
+                            Current Facility:{' '}
+                            <span className="font-medium text-gray-900">
+                                {currentFacilityName}
+                            </span>
+                        </div>
+                        <div>
+                            <Label className="text-xs text-gray-500">
+                                New Facility
+                            </Label>
+                            <Select
+                                value={transferFacilityId}
+                                onValueChange={setTransferFacilityId}
+                            >
+                                <SelectTrigger className="mt-1">
+                                    <SelectValue placeholder="Select facility" />
+                                </SelectTrigger>
+                                <SelectContent>
+                                    {facilities
+                                        .filter(
+                                            (f) =>
+                                                f.id !==
+                                                (resident.facility?.id ??
+                                                    resident.facility_id)
+                                        )
+                                        .map((f) => (
+                                            <SelectItem
+                                                key={f.id}
+                                                value={String(f.id)}
+                                            >
+                                                {f.name}
+                                            </SelectItem>
+                                        ))}
+                                </SelectContent>
+                            </Select>
+                        </div>
+                    </div>
+
+                    {transferFacilityId && (
+                        <>
+                            <div className="bg-orange-50 border border-orange-200 rounded-lg p-4">
+                                <div className="font-medium text-orange-900 text-sm mb-1">
+                                    Transfer will unenroll resident from all
+                                    classes
+                                </div>
+                                <div className="text-sm text-orange-800">
+                                    {resident.name_first} will be removed from
+                                    all active enrollments and must be
+                                    re-enrolled at the new facility.
+                                </div>
+                            </div>
+
+                            {programConflicts.length > 0 && (
+                                <div className="border border-gray-200 rounded-lg p-4">
+                                    <div className="font-medium text-sm text-gray-900 mb-3">
+                                        Programs not available at{' '}
+                                        {targetFacilityName}
+                                    </div>
+                                    <div className="space-y-2">
+                                        {programConflicts.map(
+                                            (conflict, idx) => (
+                                                <div
+                                                    key={idx}
+                                                    className="text-sm text-gray-600 flex items-center gap-2"
+                                                >
+                                                    <div className="size-1.5 rounded-full bg-gray-400" />
+                                                    {conflict.program_name} -{' '}
+                                                    {conflict.class_name}
+                                                </div>
+                                            )
+                                        )}
+                                    </div>
+                                </div>
+                            )}
+
+                            <div className="space-y-2">
+                                <div className="text-xs font-medium text-gray-500 uppercase tracking-wide">
+                                    What happens next
+                                </div>
+                                <div className="space-y-1.5 text-sm text-gray-700">
+                                    <div className="flex items-center gap-2">
+                                        <Check className="size-4 text-green-600 shrink-0" />
+                                        <span>
+                                            Account history and favorites will
+                                            be preserved
+                                        </span>
+                                    </div>
+                                    <div className="flex items-center gap-2">
+                                        <Check className="size-4 text-green-600 shrink-0" />
+                                        <span>
+                                            Resident can log in at{' '}
+                                            {targetFacilityName}
+                                        </span>
+                                    </div>
+                                </div>
+                            </div>
+
+                            <div className="border-t pt-4">
+                                <Label
+                                    htmlFor="transfer-confirm"
+                                    className="text-sm font-medium"
+                                >
+                                    Type{' '}
+                                    <span className="font-mono font-semibold text-[#203622]">
+                                        {displayId}
+                                    </span>{' '}
+                                    to confirm
+                                </Label>
+                                <Input
+                                    id="transfer-confirm"
+                                    value={confirmInput}
+                                    onChange={(e) =>
+                                        setConfirmInput(e.target.value)
+                                    }
+                                    placeholder="Enter Resident ID"
+                                    className="mt-2"
+                                />
+                            </div>
+                        </>
+                    )}
+                </div>
+                <DialogFooter>
+                    <Button
+                        variant="outline"
+                        onClick={() => onOpenChange(false)}
+                    >
+                        Cancel
+                    </Button>
+                    <Button
+                        onClick={() => void handleTransfer()}
+                        disabled={
+                            !transferFacilityId ||
+                            confirmInput !== displayId ||
+                            loading
+                        }
+                        className="bg-[#556830] hover:bg-[#203622]"
+                    >
+                        Transfer Resident
+                    </Button>
+                </DialogFooter>
+            </DialogContent>
+        </Dialog>
+    );
+}

--- a/frontend-v2/src/layouts/AuthenticatedLayout.tsx
+++ b/frontend-v2/src/layouts/AuthenticatedLayout.tsx
@@ -37,13 +37,14 @@ export default function AuthenticatedLayout() {
     const isClassDetail = /^\/program-classes\/\d+\/detail$/.test(location.pathname);
     const isEventAttendance = /^\/program-classes\/\d+\/events\/\d+\/attendance\//.test(location.pathname);
     const isClassesPage = location.pathname === '/classes';
+    const isResidentsPage = location.pathname === '/residents';
     const isDashboard = location.pathname.startsWith('/dashboard');
     const isProgramsList = location.pathname === '/programs';
     const isFacilities = location.pathname === '/facilities';
     const isFullBleed =
-        isProgramDetail || isResidentProfile || isClassDetail || isEventAttendance || isClassesPage || isDashboard || isProgramsList || isFacilities;
+        isProgramDetail || isResidentProfile || isResidentsPage || isClassDetail || isEventAttendance || isClassesPage || isDashboard || isProgramsList || isFacilities;
     const fullBleedWrapperClass =
-        isDashboard || isProgramsList || isFacilities || isProgramDetail || isResidentProfile || isClassDetail || isClassesPage ? 'py-0' : 'py-4';
+        isDashboard || isProgramsList || isFacilities || isProgramDetail || isResidentProfile || isResidentsPage || isClassDetail || isClassesPage ? 'py-0' : 'py-4';
     const showBreadcrumbs = breadcrumbItems.length > 0 && !isProgramDetail && !isResidentProfile;
     const isFacilityView =
         isProgramDetail &&
@@ -90,7 +91,7 @@ export default function AuthenticatedLayout() {
 
     if (!user) return null;
 
-    const needsGrayBg = isResidentProfile || isClassesPage || (isProgramDetail && canSwitchFacility(user));
+    const needsGrayBg = isResidentProfile || isResidentsPage || isClassesPage || (isProgramDetail && canSwitchFacility(user));
     const rootClass = 'h-screen bg-background flex overflow-hidden';
     const contentClass = `flex-1 overflow-y-auto overflow-x-hidden ${needsGrayBg ? 'bg-[#E2E7EA]' : ''}`;
 

--- a/frontend-v2/src/pages/admin/StudentManagement.tsx
+++ b/frontend-v2/src/pages/admin/StudentManagement.tsx
@@ -46,11 +46,32 @@ import {
 } from '@/components/ui/select';
 import { Pagination } from '@/components/Pagination';
 import {
+    DropdownMenu,
+    DropdownMenuContent,
+    DropdownMenuItem,
+    DropdownMenuSeparator,
+    DropdownMenuTrigger
+} from '@/components/ui/dropdown-menu';
+import {
+    EditResidentDialog,
+    ResetPasswordConfirmDialog,
+    ResetPasswordResultDialog,
+    DeactivateDialog,
+    DeleteDialog,
+    TransferDialog
+} from '@/components/residents/ResidentModals';
+import {
     Search,
     Plus,
     Upload,
     ArrowUpDown,
-    Users as UsersIcon
+    Users as UsersIcon,
+    Edit,
+    KeyRound,
+    MoreVertical,
+    UserX,
+    Trash2,
+    ArrowRightLeft
 } from 'lucide-react';
 
 type SortField = 'name_last' | 'username' | 'doc_id' | 'facility_id' | 'last_login';
@@ -83,6 +104,14 @@ export default function StudentManagement() {
     const [sortField, setSortField] = useState<SortField>('name_last');
     const [sortDir, setSortDir] = useState<SortDir>('asc');
     const [addDialogOpen, setAddDialogOpen] = useState(false);
+    const [selectedUser, setSelectedUser] = useState<User | null>(null);
+    const [editOpen, setEditOpen] = useState(false);
+    const [resetConfirmOpen, setResetConfirmOpen] = useState(false);
+    const [resetResultOpen, setResetResultOpen] = useState(false);
+    const [tempPassword, setTempPassword] = useState('');
+    const [deactivateOpen, setDeactivateOpen] = useState(false);
+    const [deleteOpen, setDeleteOpen] = useState(false);
+    const [transferOpen, setTransferOpen] = useState(false);
 
     const facilityParam =
         showFacilityColumn && facilityFilter !== 'all'
@@ -156,6 +185,23 @@ export default function StudentManagement() {
                 ToastState.error
             );
         }
+    };
+
+    const handleMutate = () => {
+        void mutate();
+    };
+
+    const openAction = (
+        targetUser: User,
+        setter: (open: boolean) => void
+    ) => {
+        setSelectedUser(targetUser);
+        setter(true);
+    };
+
+    const handleResetSuccess = (password: string) => {
+        setTempPassword(password);
+        setResetResultOpen(true);
     };
 
     const SortableHeader = ({
@@ -408,9 +454,90 @@ export default function StudentManagement() {
                                                         No actions available
                                                     </span>
                                                 ) : (
-                                                    <span className="text-sm text-muted-foreground">
-                                                        --
-                                                    </span>
+                                                    <div className="flex items-center justify-end gap-1">
+                                                        <Button
+                                                            variant="ghost"
+                                                            size="sm"
+                                                            onClick={() =>
+                                                                openAction(
+                                                                    resident,
+                                                                    setEditOpen
+                                                                )
+                                                            }
+                                                        >
+                                                            <Edit className="size-4" />
+                                                        </Button>
+                                                        <Button
+                                                            variant="ghost"
+                                                            size="sm"
+                                                            onClick={() =>
+                                                                openAction(
+                                                                    resident,
+                                                                    setResetConfirmOpen
+                                                                )
+                                                            }
+                                                        >
+                                                            <KeyRound className="size-4" />
+                                                        </Button>
+                                                        <DropdownMenu>
+                                                            <DropdownMenuTrigger
+                                                                asChild
+                                                            >
+                                                                <Button
+                                                                    variant="ghost"
+                                                                    size="sm"
+                                                                >
+                                                                    <MoreVertical className="size-4" />
+                                                                </Button>
+                                                            </DropdownMenuTrigger>
+                                                            <DropdownMenuContent align="end">
+                                                                <DropdownMenuItem
+                                                                    onClick={() =>
+                                                                        openAction(
+                                                                            resident,
+                                                                            setDeactivateOpen
+                                                                        )
+                                                                    }
+                                                                    className="text-orange-600"
+                                                                >
+                                                                    <UserX className="size-4 mr-2" />
+                                                                    Deactivate
+                                                                    Account
+                                                                </DropdownMenuItem>
+                                                                {showFacilityColumn && (
+                                                                    <>
+                                                                        <DropdownMenuSeparator />
+                                                                        <DropdownMenuItem
+                                                                            onClick={() =>
+                                                                                openAction(
+                                                                                    resident,
+                                                                                    setTransferOpen
+                                                                                )
+                                                                            }
+                                                                        >
+                                                                            <ArrowRightLeft className="size-4 mr-2" />
+                                                                            Transfer
+                                                                            Resident
+                                                                        </DropdownMenuItem>
+                                                                    </>
+                                                                )}
+                                                                <DropdownMenuSeparator />
+                                                                <DropdownMenuItem
+                                                                    onClick={() =>
+                                                                        openAction(
+                                                                            resident,
+                                                                            setDeleteOpen
+                                                                        )
+                                                                    }
+                                                                    className="text-red-600"
+                                                                >
+                                                                    <Trash2 className="size-4 mr-2" />
+                                                                    Delete
+                                                                    Resident
+                                                                </DropdownMenuItem>
+                                                            </DropdownMenuContent>
+                                                        </DropdownMenu>
+                                                    </div>
                                                 )}
                                             </TableCell>
                                         </TableRow>
@@ -558,6 +685,52 @@ export default function StudentManagement() {
                         </form>
                     </DialogContent>
                 </Dialog>
+
+                {/* Action Dialogs */}
+                {selectedUser && (
+                    <>
+                        <EditResidentDialog
+                            open={editOpen}
+                            onOpenChange={setEditOpen}
+                            resident={selectedUser}
+                            onSuccess={handleMutate}
+                        />
+                        <ResetPasswordConfirmDialog
+                            open={resetConfirmOpen}
+                            onOpenChange={setResetConfirmOpen}
+                            resident={selectedUser}
+                            onSuccess={handleResetSuccess}
+                        />
+                        <ResetPasswordResultDialog
+                            open={resetResultOpen}
+                            onOpenChange={setResetResultOpen}
+                            residentName={`${selectedUser.name_first} ${selectedUser.name_last}`}
+                            tempPassword={tempPassword}
+                        />
+                        <DeactivateDialog
+                            open={deactivateOpen}
+                            onOpenChange={setDeactivateOpen}
+                            resident={selectedUser}
+                            onSuccess={handleMutate}
+                        />
+                        <DeleteDialog
+                            open={deleteOpen}
+                            onOpenChange={setDeleteOpen}
+                            resident={selectedUser}
+                            onSuccess={handleMutate}
+                        />
+                        {showFacilityColumn && (
+                            <TransferDialog
+                                open={transferOpen}
+                                onOpenChange={setTransferOpen}
+                                resident={selectedUser}
+                                facilities={facilities}
+                                onSuccess={handleMutate}
+                            />
+                        )}
+                    </>
+                )}
+            </div>
         </div>
     );
 }

--- a/frontend-v2/src/pages/admin/StudentManagement.tsx
+++ b/frontend-v2/src/pages/admin/StudentManagement.tsx
@@ -1,4 +1,4 @@
-import { useState, startTransition } from 'react';
+import { useState, useEffect, startTransition } from 'react';
 import useSWR from 'swr';
 import { useForm } from 'react-hook-form';
 import { useNavigate } from 'react-router-dom';
@@ -44,6 +44,7 @@ import {
     SelectTrigger,
     SelectValue
 } from '@/components/ui/select';
+import { Checkbox } from '@/components/ui/checkbox';
 import { Pagination } from '@/components/Pagination';
 import {
     DropdownMenu,
@@ -60,6 +61,11 @@ import {
     DeleteDialog,
     TransferDialog
 } from '@/components/residents/ResidentModals';
+import {
+    BulkResetPasswordDialog,
+    BulkDeactivateDialog,
+    BulkDeleteDialog
+} from '@/components/residents/BulkActionDialogs';
 import {
     Tooltip,
     TooltipContent,
@@ -116,6 +122,15 @@ export default function StudentManagement() {
     const [deactivateOpen, setDeactivateOpen] = useState(false);
     const [deleteOpen, setDeleteOpen] = useState(false);
     const [transferOpen, setTransferOpen] = useState(false);
+
+    const [selectedResidents, setSelectedResidents] = useState<Set<number>>(new Set());
+    const [bulkResetOpen, setBulkResetOpen] = useState(false);
+    const [bulkDeactivateOpen, setBulkDeactivateOpen] = useState(false);
+    const [bulkDeleteOpen, setBulkDeleteOpen] = useState(false);
+
+    useEffect(() => {
+        setSelectedResidents(new Set());
+    }, [searchTerm, facilityFilter, sortField, sortDir]);
 
     const facilityParam =
         showFacilityColumn && facilityFilter !== 'all'
@@ -192,6 +207,44 @@ export default function StudentManagement() {
     };
 
     const handleMutate = () => {
+        void mutate();
+    };
+
+    const activeResidents = userData.filter((r) => !r.deactivated_at);
+
+    const allPageSelected =
+        activeResidents.length > 0 &&
+        activeResidents.every((r) => selectedResidents.has(r.id));
+
+    const toggleSelectAll = () => {
+        setSelectedResidents((prev) => {
+            const next = new Set(prev);
+            if (allPageSelected) {
+                activeResidents.forEach((r) => next.delete(r.id));
+            } else {
+                activeResidents.forEach((r) => next.add(r.id));
+            }
+            return next;
+        });
+    };
+
+    const toggleSelectResident = (id: number) => {
+        setSelectedResidents((prev) => {
+            const next = new Set(prev);
+            if (next.has(id)) {
+                next.delete(id);
+            } else {
+                next.add(id);
+            }
+            return next;
+        });
+    };
+
+    const getSelectedUsers = () =>
+        userData.filter((r) => selectedResidents.has(r.id));
+
+    const handleBulkSuccess = () => {
+        setSelectedResidents(new Set());
         void mutate();
     };
 
@@ -365,6 +418,12 @@ export default function StudentManagement() {
                         <Table>
                             <TableHeader>
                                 <TableRow>
+                                    <TableHead className="w-12">
+                                        <Checkbox
+                                            checked={allPageSelected}
+                                            onCheckedChange={toggleSelectAll}
+                                        />
+                                    </TableHead>
                                     <SortableHeader field="name_last">
                                         Name
                                     </SortableHeader>
@@ -392,7 +451,7 @@ export default function StudentManagement() {
                                     <TableRow>
                                         <TableCell
                                             colSpan={
-                                                showFacilityColumn ? 6 : 5
+                                                showFacilityColumn ? 7 : 6
                                             }
                                             className="text-center py-12"
                                         >
@@ -415,6 +474,24 @@ export default function StudentManagement() {
                                                 )
                                             }
                                         >
+                                            <TableCell
+                                                onClick={(e) =>
+                                                    e.stopPropagation()
+                                                }
+                                            >
+                                                {!resident.deactivated_at && (
+                                                    <Checkbox
+                                                        checked={selectedResidents.has(
+                                                            resident.id
+                                                        )}
+                                                        onCheckedChange={() =>
+                                                            toggleSelectResident(
+                                                                resident.id
+                                                            )
+                                                        }
+                                                    />
+                                                )}
+                                            </TableCell>
                                             <TableCell className="font-medium">
                                                 <div className="flex items-center gap-2">
                                                     {resident.name_last},{' '}
@@ -747,6 +824,86 @@ export default function StudentManagement() {
                             />
                         )}
                     </>
+                )}
+
+                {/* Bulk Action Dialogs */}
+                <BulkResetPasswordDialog
+                    open={bulkResetOpen}
+                    onOpenChange={setBulkResetOpen}
+                    residents={getSelectedUsers()}
+                    onSuccess={handleBulkSuccess}
+                />
+                <BulkDeactivateDialog
+                    open={bulkDeactivateOpen}
+                    onOpenChange={setBulkDeactivateOpen}
+                    residents={getSelectedUsers()}
+                    onSuccess={handleBulkSuccess}
+                />
+                <BulkDeleteDialog
+                    open={bulkDeleteOpen}
+                    onOpenChange={setBulkDeleteOpen}
+                    residents={getSelectedUsers()}
+                    onSuccess={handleBulkSuccess}
+                />
+
+                {/* Bulk Action Bar */}
+                {selectedResidents.size > 0 && (
+                    <div className="fixed bottom-6 left-0 right-0 z-50 flex justify-center pointer-events-none">
+                    <div className="bg-[#E2E7EA] border border-gray-400 rounded-lg shadow-lg px-6 py-4 pointer-events-auto">
+                        <div className="flex items-center gap-6">
+                            <div className="text-sm">
+                                <span className="font-semibold text-[#203622]">
+                                    {selectedResidents.size}
+                                </span>
+                                <span className="text-gray-600 ml-1">
+                                    {selectedResidents.size === 1
+                                        ? 'resident'
+                                        : 'residents'}{' '}
+                                    selected
+                                </span>
+                            </div>
+                            <div className="flex gap-3">
+                                <Button
+                                    variant="outline"
+                                    size="sm"
+                                    onClick={() =>
+                                        setSelectedResidents(new Set())
+                                    }
+                                >
+                                    Clear Selection
+                                </Button>
+                                <Button
+                                    size="sm"
+                                    variant="outline"
+                                    onClick={() => setBulkResetOpen(true)}
+                                >
+                                    <KeyRound className="size-4 mr-2" />
+                                    Reset Passwords
+                                </Button>
+                                <Button
+                                    size="sm"
+                                    variant="outline"
+                                    onClick={() =>
+                                        setBulkDeactivateOpen(true)
+                                    }
+                                    className="text-orange-600 border-orange-300 hover:bg-orange-50"
+                                >
+                                    <UserX className="size-4 mr-2" />
+                                    Deactivate
+                                </Button>
+                                <Button
+                                    size="sm"
+                                    variant="outline"
+                                    onClick={() => setBulkDeleteOpen(true)}
+                                    className="text-red-600 border-red-300 hover:bg-red-50"
+                                >
+                                    <UsersIcon className="size-4 mr-2" />
+                                    Delete
+                                </Button>
+                            </div>
+                        </div>
+                    </div>
+                    </div>
                 )}
         </div>
     );

--- a/frontend-v2/src/pages/admin/StudentManagement.tsx
+++ b/frontend-v2/src/pages/admin/StudentManagement.tsx
@@ -730,7 +730,6 @@ export default function StudentManagement() {
                         )}
                     </>
                 )}
-            </div>
         </div>
     );
 }

--- a/frontend-v2/src/pages/admin/StudentManagement.tsx
+++ b/frontend-v2/src/pages/admin/StudentManagement.tsx
@@ -124,14 +124,14 @@ export default function StudentManagement() {
     const [deleteOpen, setDeleteOpen] = useState(false);
     const [transferOpen, setTransferOpen] = useState(false);
 
-    const [selectedResidents, setSelectedResidents] = useState<Set<number>>(new Set());
+    const [selectedResidents, setSelectedResidents] = useState<Map<number, User>>(new Map());
     const [bulkResetOpen, setBulkResetOpen] = useState(false);
     const [bulkDeactivateOpen, setBulkDeactivateOpen] = useState(false);
     const [bulkDeleteOpen, setBulkDeleteOpen] = useState(false);
     const [bulkImportOpen, setBulkImportOpen] = useState(false);
 
     useEffect(() => {
-        setSelectedResidents(new Set());
+        setSelectedResidents(new Map());
     }, [searchTerm, facilityFilter, sortField, sortDir]);
 
     const facilityParam =
@@ -224,33 +224,32 @@ export default function StudentManagement() {
 
     const toggleSelectAll = () => {
         setSelectedResidents((prev) => {
-            const next = new Set(prev);
+            const next = new Map(prev);
             if (allPageSelected) {
                 activeResidents.forEach((r) => next.delete(r.id));
             } else {
-                activeResidents.forEach((r) => next.add(r.id));
+                activeResidents.forEach((r) => next.set(r.id, r));
             }
             return next;
         });
     };
 
-    const toggleSelectResident = (id: number) => {
+    const toggleSelectResident = (resident: User) => {
         setSelectedResidents((prev) => {
-            const next = new Set(prev);
-            if (next.has(id)) {
-                next.delete(id);
+            const next = new Map(prev);
+            if (next.has(resident.id)) {
+                next.delete(resident.id);
             } else {
-                next.add(id);
+                next.set(resident.id, resident);
             }
             return next;
         });
     };
 
-    const getSelectedUsers = () =>
-        userData.filter((r) => selectedResidents.has(r.id));
+    const getSelectedUsers = () => Array.from(selectedResidents.values());
 
     const handleBulkSuccess = () => {
-        setSelectedResidents(new Set());
+        setSelectedResidents(new Map());
         void mutate();
         void mutateStats();
     };
@@ -493,7 +492,7 @@ export default function StudentManagement() {
                                                         )}
                                                         onCheckedChange={() =>
                                                             toggleSelectResident(
-                                                                resident.id
+                                                                resident
                                                             )
                                                         }
                                                     />
@@ -879,7 +878,7 @@ export default function StudentManagement() {
                                     variant="outline"
                                     size="sm"
                                     onClick={() =>
-                                        setSelectedResidents(new Set())
+                                        setSelectedResidents(new Map())
                                     }
                                 >
                                     Clear Selection

--- a/frontend-v2/src/pages/admin/StudentManagement.tsx
+++ b/frontend-v2/src/pages/admin/StudentManagement.tsx
@@ -44,14 +44,7 @@ import {
     SelectTrigger,
     SelectValue
 } from '@/components/ui/select';
-import {
-    Pagination,
-    PaginationContent,
-    PaginationItem,
-    PaginationLink,
-    PaginationNext,
-    PaginationPrevious
-} from '@/components/ui/pagination';
+import { Pagination } from '@/components/Pagination';
 import {
     Search,
     Plus,
@@ -81,7 +74,7 @@ export default function StudentManagement() {
     const navigate = useNavigate();
     const { toaster } = useToast();
     const { user } = useAuth();
-    const { page, perPage, setPage } = useUrlPagination(1, 20);
+    const { page, perPage, setPage, setPerPage } = useUrlPagination(1, 20);
 
     const showFacilityColumn = user ? canSwitchFacility(user) : false;
 
@@ -116,7 +109,7 @@ export default function StudentManagement() {
     const facilities = facilitiesResp?.data ?? [];
 
     const userData = data?.data ?? [];
-    const totalPages = data?.meta?.last_page ?? 1;
+    const totalItems = data?.meta?.total ?? 0;
 
     const addForm = useForm<StudentFormData>();
 
@@ -193,8 +186,7 @@ export default function StudentManagement() {
     const isFormValid = addForm.watch('name_first') && addForm.watch('name_last') && addForm.watch('username');
 
     return (
-        <div className="bg-[#E2E7EA] min-h-full">
-            <div className="max-w-7xl mx-auto px-6 py-8">
+        <div>
                 {/* Header */}
                 <div className="mb-8">
                     {user && !showFacilityColumn && (
@@ -223,6 +215,12 @@ export default function StudentManagement() {
                             <Button
                                 onClick={() => {
                                     addForm.reset();
+                                    if (showFacilityColumn && user) {
+                                        addForm.setValue(
+                                            'facility_id',
+                                            user.facility_id
+                                        );
+                                    }
                                     setAddDialogOpen(true);
                                 }}
                                 className="gap-2 bg-[#556830] hover:bg-[#203622]"
@@ -275,7 +273,7 @@ export default function StudentManagement() {
 
                 {/* Stats Cards */}
                 <div className="grid grid-cols-3 gap-4 mb-6">
-                    <div className="bg-white rounded-lg border border-gray-200 p-4">
+                    <div className="bg-white rounded-lg p-4">
                         <div className="text-sm text-gray-600 mb-1">
                             Total Residents
                         </div>
@@ -283,7 +281,7 @@ export default function StudentManagement() {
                             {stats?.total ?? '\u2014'}
                         </div>
                     </div>
-                    <div className="bg-white rounded-lg border border-gray-200 p-4">
+                    <div className="bg-white rounded-lg p-4">
                         <div className="text-sm text-gray-600 mb-1">
                             Active Accounts
                         </div>
@@ -291,7 +289,7 @@ export default function StudentManagement() {
                             {stats?.active ?? '\u2014'}
                         </div>
                     </div>
-                    <div className="bg-white rounded-lg border border-gray-200 p-4">
+                    <div className="bg-white rounded-lg p-4">
                         <div className="text-sm text-gray-600 mb-1">
                             Inactive Accounts
                         </div>
@@ -307,13 +305,13 @@ export default function StudentManagement() {
                         Failed to load residents.
                     </div>
                 ) : isLoading ? (
-                    <div className="bg-white rounded-lg border border-gray-200 p-4 space-y-3">
+                    <div className="bg-white rounded-lg p-4 space-y-3">
                         {Array.from({ length: 5 }).map((_, i) => (
                             <Skeleton key={i} className="h-10 w-full" />
                         ))}
                     </div>
                 ) : (
-                    <div className="bg-white rounded-lg border border-gray-200">
+                    <div className="bg-white rounded-lg">
                         <Table>
                             <TableHeader>
                                 <TableRow>
@@ -419,78 +417,15 @@ export default function StudentManagement() {
                             </TableBody>
                         </Table>
 
-                        {/* Pagination */}
-                        {totalPages > 1 && (
-                            <div className="border-t border-gray-200 px-4 py-3">
-                                <Pagination>
-                                    <PaginationContent>
-                                        <PaginationItem>
-                                            <PaginationPrevious
-                                                onClick={() =>
-                                                    page > 1 &&
-                                                    setPage(page - 1)
-                                                }
-                                                className={
-                                                    page <= 1
-                                                        ? 'pointer-events-none opacity-50'
-                                                        : 'cursor-pointer'
-                                                }
-                                            />
-                                        </PaginationItem>
-                                        {Array.from(
-                                            {
-                                                length: Math.min(totalPages, 5)
-                                            },
-                                            (_, i) => {
-                                                let pageNum: number;
-                                                if (totalPages <= 5) {
-                                                    pageNum = i + 1;
-                                                } else if (page <= 3) {
-                                                    pageNum = i + 1;
-                                                } else if (
-                                                    page >=
-                                                    totalPages - 2
-                                                ) {
-                                                    pageNum =
-                                                        totalPages - 4 + i;
-                                                } else {
-                                                    pageNum = page - 2 + i;
-                                                }
-                                                return (
-                                                    <PaginationItem
-                                                        key={pageNum}
-                                                    >
-                                                        <PaginationLink
-                                                            onClick={() =>
-                                                                setPage(pageNum)
-                                                            }
-                                                            isActive={
-                                                                pageNum === page
-                                                            }
-                                                            className="cursor-pointer"
-                                                        >
-                                                            {pageNum}
-                                                        </PaginationLink>
-                                                    </PaginationItem>
-                                                );
-                                            }
-                                        )}
-                                        <PaginationItem>
-                                            <PaginationNext
-                                                onClick={() =>
-                                                    page < totalPages &&
-                                                    setPage(page + 1)
-                                                }
-                                                className={
-                                                    page >= totalPages
-                                                        ? 'pointer-events-none opacity-50'
-                                                        : 'cursor-pointer'
-                                                }
-                                            />
-                                        </PaginationItem>
-                                    </PaginationContent>
-                                </Pagination>
-                            </div>
+                        {totalItems > perPage && (
+                            <Pagination
+                                currentPage={page}
+                                totalItems={totalItems}
+                                itemsPerPage={perPage}
+                                onPageChange={setPage}
+                                onItemsPerPageChange={setPerPage}
+                                itemLabel="residents"
+                            />
                         )}
                     </div>
                 )}
@@ -511,83 +446,99 @@ export default function StudentManagement() {
                                     (d) => void handleAddUser(d)
                                 )(e);
                             }}
-                            className="space-y-4 py-4"
                         >
-                            <div className="grid grid-cols-2 gap-4">
+                            <div className="space-y-4 py-4">
+                                <div className="grid grid-cols-2 gap-4">
+                                    <div>
+                                        <Label htmlFor="add-first">
+                                            First Name
+                                        </Label>
+                                        <Input
+                                            id="add-first"
+                                            placeholder="First name"
+                                            {...addForm.register('name_first', {
+                                                required: true
+                                            })}
+                                            className="mt-2"
+                                        />
+                                    </div>
+                                    <div>
+                                        <Label htmlFor="add-last">
+                                            Last Name
+                                        </Label>
+                                        <Input
+                                            id="add-last"
+                                            placeholder="Last name"
+                                            {...addForm.register('name_last', {
+                                                required: true
+                                            })}
+                                            className="mt-2"
+                                        />
+                                    </div>
+                                </div>
                                 <div>
-                                    <Label htmlFor="add-first">
-                                        First Name
+                                    <Label htmlFor="add-username">
+                                        Username
                                     </Label>
                                     <Input
-                                        id="add-first"
-                                        placeholder="First name"
-                                        {...addForm.register('name_first', {
+                                        id="add-username"
+                                        placeholder="Enter username for login"
+                                        {...addForm.register('username', {
                                             required: true
                                         })}
                                         className="mt-2"
                                     />
                                 </div>
                                 <div>
-                                    <Label htmlFor="add-last">Last Name</Label>
+                                    <Label htmlFor="add-doc-id">
+                                        Resident ID
+                                    </Label>
                                     <Input
-                                        id="add-last"
-                                        placeholder="Last name"
-                                        {...addForm.register('name_last', {
-                                            required: true
-                                        })}
+                                        id="add-doc-id"
+                                        placeholder="e.g., R001"
+                                        {...addForm.register('doc_id')}
                                         className="mt-2"
                                     />
                                 </div>
+                                {showFacilityColumn && (
+                                    <div>
+                                        <Label htmlFor="add-facility">
+                                            Facility
+                                        </Label>
+                                        <Select
+                                            value={
+                                                addForm.watch('facility_id')
+                                                    ? String(
+                                                          addForm.watch(
+                                                              'facility_id'
+                                                          )
+                                                      )
+                                                    : undefined
+                                            }
+                                            onValueChange={(v) =>
+                                                addForm.setValue(
+                                                    'facility_id',
+                                                    Number(v)
+                                                )
+                                            }
+                                        >
+                                            <SelectTrigger className="mt-2">
+                                                <SelectValue placeholder="Select facility" />
+                                            </SelectTrigger>
+                                            <SelectContent>
+                                                {facilities.map((f) => (
+                                                    <SelectItem
+                                                        key={f.id}
+                                                        value={String(f.id)}
+                                                    >
+                                                        {f.name}
+                                                    </SelectItem>
+                                                ))}
+                                            </SelectContent>
+                                        </Select>
+                                    </div>
+                                )}
                             </div>
-                            <div>
-                                <Label htmlFor="add-username">Username</Label>
-                                <Input
-                                    id="add-username"
-                                    placeholder="Enter username for login"
-                                    {...addForm.register('username', {
-                                        required: true
-                                    })}
-                                    className="mt-2"
-                                />
-                            </div>
-                            <div>
-                                <Label htmlFor="add-doc-id">Resident ID</Label>
-                                <Input
-                                    id="add-doc-id"
-                                    placeholder="e.g., R001"
-                                    {...addForm.register('doc_id')}
-                                    className="mt-2"
-                                />
-                            </div>
-                            {showFacilityColumn && (
-                                <div>
-                                    <Label htmlFor="add-facility">
-                                        Facility
-                                    </Label>
-                                    <Select
-                                        onValueChange={(v) =>
-                                            addForm.setValue(
-                                                'facility_id',
-                                                Number(v)
-                                            )
-                                        }
-                                    >
-                                        <SelectTrigger className="mt-2">
-                                            <SelectValue placeholder="Select facility" />
-                                        </SelectTrigger>
-                                        <SelectContent>
-                                            {facilities.map((f) => (
-                                                <SelectItem
-                                                    key={f.id}
-                                                    value={String(f.id)}
-                                                >
-                                                    {f.name}
-                                                </SelectItem>
-                                            ))}
-                                        </SelectContent>
-                                    </Select>
-                                </div>
-                            )}
                             <DialogFooter>
                                 <Button
                                     variant="outline"
@@ -607,7 +558,6 @@ export default function StudentManagement() {
                         </form>
                     </DialogContent>
                 </Dialog>
-            </div>
         </div>
     );
 }

--- a/frontend-v2/src/pages/admin/StudentManagement.tsx
+++ b/frontend-v2/src/pages/admin/StudentManagement.tsx
@@ -539,7 +539,7 @@ export default function StudentManagement() {
                                     </div>
                                 )}
                             </div>
-                            <DialogFooter className="pt-2">
+                            <DialogFooter className="pt-4">
                                 <Button
                                     variant="outline"
                                     type="button"

--- a/frontend-v2/src/pages/admin/StudentManagement.tsx
+++ b/frontend-v2/src/pages/admin/StudentManagement.tsx
@@ -154,7 +154,9 @@ export default function StudentManagement() {
     const { data: facilitiesResp } = useSWR<ServerResponseMany<Facility>>(
         showFacilityColumn ? '/api/facilities' : null
     );
-    const facilities = facilitiesResp?.data ?? [];
+    const facilities = [...(facilitiesResp?.data ?? [])].sort((a, b) =>
+        a.name.localeCompare(b.name)
+    );
 
     const userData = data?.data ?? [];
     const totalItems = data?.meta?.total ?? 0;
@@ -289,7 +291,7 @@ export default function StudentManagement() {
     const isFormValid = addForm.watch('name_first') && addForm.watch('name_last') && addForm.watch('username');
 
     return (
-        <div className="py-4">
+        <div className="max-w-7xl mx-auto px-6 py-8">
                 {/* Header */}
                 <div className="mb-8">
                     {user && !showFacilityColumn && (

--- a/frontend-v2/src/pages/admin/StudentManagement.tsx
+++ b/frontend-v2/src/pages/admin/StudentManagement.tsx
@@ -180,7 +180,7 @@ export default function StudentManagement() {
 
         if (response.success) {
             setAddDialogOpen(false);
-            toaster('Resident added successfully', ToastState.success);
+            toaster(`Resident ${formData.name_first} ${formData.name_last} added successfully`, ToastState.success);
             addForm.reset();
             void mutate();
         } else {
@@ -464,6 +464,7 @@ export default function StudentManagement() {
                                                                 <Button
                                                                     variant="ghost"
                                                                     size="sm"
+                                                                    className="h-8 w-8 p-0"
                                                                     onClick={() =>
                                                                         openAction(
                                                                             resident,
@@ -474,13 +475,14 @@ export default function StudentManagement() {
                                                                     <Edit className="size-4" />
                                                                 </Button>
                                                             </TooltipTrigger>
-                                                            <TooltipContent>Edit Profile</TooltipContent>
+                                                            <TooltipContent>Edit resident</TooltipContent>
                                                         </Tooltip>
                                                         <Tooltip>
                                                             <TooltipTrigger asChild>
                                                                 <Button
                                                                     variant="ghost"
                                                                     size="sm"
+                                                                    className="h-8 w-8 p-0"
                                                                     onClick={() =>
                                                                         openAction(
                                                                             resident,
@@ -491,24 +493,21 @@ export default function StudentManagement() {
                                                                     <KeyRound className="size-4" />
                                                                 </Button>
                                                             </TooltipTrigger>
-                                                            <TooltipContent>Reset Password</TooltipContent>
+                                                            <TooltipContent>Reset password</TooltipContent>
                                                         </Tooltip>
                                                         <DropdownMenu>
-                                                            <Tooltip>
-                                                                <TooltipTrigger asChild>
-                                                                    <DropdownMenuTrigger
-                                                                        asChild
-                                                                    >
-                                                                        <Button
-                                                                            variant="ghost"
-                                                                            size="sm"
-                                                                        >
-                                                                            <MoreVertical className="size-4" />
-                                                                        </Button>
-                                                                    </DropdownMenuTrigger>
-                                                                </TooltipTrigger>
-                                                                <TooltipContent>More Actions</TooltipContent>
-                                                            </Tooltip>
+                                                            <DropdownMenuTrigger
+                                                                asChild
+                                                            >
+                                                                <Button
+                                                                    variant="ghost"
+                                                                    size="sm"
+                                                                    className="h-8 w-8 p-0"
+                                                                >
+                                                                    <MoreVertical className="size-4" />
+                                                                    <span className="sr-only">More actions</span>
+                                                                </Button>
+                                                            </DropdownMenuTrigger>
                                                             <DropdownMenuContent align="end">
                                                                 <DropdownMenuItem
                                                                     onClick={() =>

--- a/frontend-v2/src/pages/admin/StudentManagement.tsx
+++ b/frontend-v2/src/pages/admin/StudentManagement.tsx
@@ -148,7 +148,7 @@ export default function StudentManagement() {
         showFacilityColumn && facilityFilter !== 'all'
             ? `?facility_id=${facilityFilter}`
             : '';
-    const { data: statsResp } = useSWR<ServerResponseOne<UserStatsData>>(
+    const { data: statsResp, mutate: mutateStats } = useSWR<ServerResponseOne<UserStatsData>>(
         `/api/users/stats${statsParam}`
     );
     const stats = statsResp?.data;
@@ -202,6 +202,7 @@ export default function StudentManagement() {
             toaster(`Resident ${formData.name_first} ${formData.name_last} added successfully`, ToastState.success);
             addForm.reset();
             void mutate();
+            void mutateStats();
         } else {
             toaster(
                 response.message || 'Failed to create resident',
@@ -212,6 +213,7 @@ export default function StudentManagement() {
 
     const handleMutate = () => {
         void mutate();
+        void mutateStats();
     };
 
     const activeResidents = userData.filter((r) => !r.deactivated_at);
@@ -250,6 +252,7 @@ export default function StudentManagement() {
     const handleBulkSuccess = () => {
         setSelectedResidents(new Set());
         void mutate();
+        void mutateStats();
     };
 
     const openAction = (

--- a/frontend-v2/src/pages/admin/StudentManagement.tsx
+++ b/frontend-v2/src/pages/admin/StudentManagement.tsx
@@ -61,6 +61,11 @@ import {
     TransferDialog
 } from '@/components/residents/ResidentModals';
 import {
+    Tooltip,
+    TooltipContent,
+    TooltipTrigger
+} from '@/components/ui/tooltip';
+import {
     Search,
     Plus,
     Upload,
@@ -70,8 +75,7 @@ import {
     KeyRound,
     MoreVertical,
     UserX,
-    Trash2,
-    ArrowRightLeft
+    Trash2
 } from 'lucide-react';
 
 type SortField = 'name_last' | 'username' | 'doc_id' | 'facility_id' | 'last_login';
@@ -455,41 +459,56 @@ export default function StudentManagement() {
                                                     </span>
                                                 ) : (
                                                     <div className="flex items-center justify-end gap-1">
-                                                        <Button
-                                                            variant="ghost"
-                                                            size="sm"
-                                                            onClick={() =>
-                                                                openAction(
-                                                                    resident,
-                                                                    setEditOpen
-                                                                )
-                                                            }
-                                                        >
-                                                            <Edit className="size-4" />
-                                                        </Button>
-                                                        <Button
-                                                            variant="ghost"
-                                                            size="sm"
-                                                            onClick={() =>
-                                                                openAction(
-                                                                    resident,
-                                                                    setResetConfirmOpen
-                                                                )
-                                                            }
-                                                        >
-                                                            <KeyRound className="size-4" />
-                                                        </Button>
-                                                        <DropdownMenu>
-                                                            <DropdownMenuTrigger
-                                                                asChild
-                                                            >
+                                                        <Tooltip>
+                                                            <TooltipTrigger asChild>
                                                                 <Button
                                                                     variant="ghost"
                                                                     size="sm"
+                                                                    onClick={() =>
+                                                                        openAction(
+                                                                            resident,
+                                                                            setEditOpen
+                                                                        )
+                                                                    }
                                                                 >
-                                                                    <MoreVertical className="size-4" />
+                                                                    <Edit className="size-4" />
                                                                 </Button>
-                                                            </DropdownMenuTrigger>
+                                                            </TooltipTrigger>
+                                                            <TooltipContent>Edit Profile</TooltipContent>
+                                                        </Tooltip>
+                                                        <Tooltip>
+                                                            <TooltipTrigger asChild>
+                                                                <Button
+                                                                    variant="ghost"
+                                                                    size="sm"
+                                                                    onClick={() =>
+                                                                        openAction(
+                                                                            resident,
+                                                                            setResetConfirmOpen
+                                                                        )
+                                                                    }
+                                                                >
+                                                                    <KeyRound className="size-4" />
+                                                                </Button>
+                                                            </TooltipTrigger>
+                                                            <TooltipContent>Reset Password</TooltipContent>
+                                                        </Tooltip>
+                                                        <DropdownMenu>
+                                                            <Tooltip>
+                                                                <TooltipTrigger asChild>
+                                                                    <DropdownMenuTrigger
+                                                                        asChild
+                                                                    >
+                                                                        <Button
+                                                                            variant="ghost"
+                                                                            size="sm"
+                                                                        >
+                                                                            <MoreVertical className="size-4" />
+                                                                        </Button>
+                                                                    </DropdownMenuTrigger>
+                                                                </TooltipTrigger>
+                                                                <TooltipContent>More Actions</TooltipContent>
+                                                            </Tooltip>
                                                             <DropdownMenuContent align="end">
                                                                 <DropdownMenuItem
                                                                     onClick={() =>
@@ -515,7 +534,7 @@ export default function StudentManagement() {
                                                                                 )
                                                                             }
                                                                         >
-                                                                            <ArrowRightLeft className="size-4 mr-2" />
+                                                                            <UsersIcon className="size-4 mr-2" />
                                                                             Transfer
                                                                             Resident
                                                                         </DropdownMenuItem>

--- a/frontend-v2/src/pages/admin/StudentManagement.tsx
+++ b/frontend-v2/src/pages/admin/StudentManagement.tsx
@@ -66,6 +66,7 @@ import {
     BulkDeactivateDialog,
     BulkDeleteDialog
 } from '@/components/residents/BulkActionDialogs';
+import { BulkImportDialog } from '@/components/residents/BulkImportDialog';
 import {
     Tooltip,
     TooltipContent,
@@ -127,6 +128,7 @@ export default function StudentManagement() {
     const [bulkResetOpen, setBulkResetOpen] = useState(false);
     const [bulkDeactivateOpen, setBulkDeactivateOpen] = useState(false);
     const [bulkDeleteOpen, setBulkDeleteOpen] = useState(false);
+    const [bulkImportOpen, setBulkImportOpen] = useState(false);
 
     useEffect(() => {
         setSelectedResidents(new Set());
@@ -310,9 +312,9 @@ export default function StudentManagement() {
                         </div>
                         <div className="flex items-center gap-2">
                             <Button
+                                onClick={() => setBulkImportOpen(true)}
                                 variant="outline"
                                 className="gap-2"
-                                disabled
                             >
                                 <Upload className="size-4" />
                                 Bulk Import
@@ -846,6 +848,11 @@ export default function StudentManagement() {
                     onOpenChange={setBulkDeleteOpen}
                     residents={getSelectedUsers()}
                     onSuccess={handleBulkSuccess}
+                />
+                <BulkImportDialog
+                    open={bulkImportOpen}
+                    onOpenChange={setBulkImportOpen}
+                    onSuccess={() => void mutate()}
                 />
 
                 {/* Bulk Action Bar */}

--- a/frontend-v2/src/pages/admin/StudentManagement.tsx
+++ b/frontend-v2/src/pages/admin/StudentManagement.tsx
@@ -44,7 +44,14 @@ import {
     SelectTrigger,
     SelectValue
 } from '@/components/ui/select';
-import { Pagination } from '@/components/Pagination';
+import {
+    Pagination,
+    PaginationContent,
+    PaginationItem,
+    PaginationLink,
+    PaginationNext,
+    PaginationPrevious
+} from '@/components/ui/pagination';
 import {
     Search,
     Plus,
@@ -53,7 +60,7 @@ import {
     Users as UsersIcon
 } from 'lucide-react';
 
-type SortField = 'name_last' | 'username' | 'doc_id' | 'facility_id' | 'last_login';
+type SortField = 'name_last' | 'username' | 'doc_id' | 'last_login';
 type SortDir = 'asc' | 'desc';
 
 interface StudentFormData {
@@ -74,7 +81,7 @@ export default function StudentManagement() {
     const navigate = useNavigate();
     const { toaster } = useToast();
     const { user } = useAuth();
-    const { page, perPage, setPage, setPerPage } = useUrlPagination(1, 20);
+    const { page, perPage, setPage } = useUrlPagination(1, 20);
 
     const showFacilityColumn = user ? canSwitchFacility(user) : false;
 
@@ -109,7 +116,7 @@ export default function StudentManagement() {
     const facilities = facilitiesResp?.data ?? [];
 
     const userData = data?.data ?? [];
-    const totalItems = data?.meta?.total ?? 0;
+    const totalPages = data?.meta?.last_page ?? 1;
 
     const addForm = useForm<StudentFormData>();
 
@@ -186,7 +193,8 @@ export default function StudentManagement() {
     const isFormValid = addForm.watch('name_first') && addForm.watch('name_last') && addForm.watch('username');
 
     return (
-        <div className="py-4">
+        <div className="bg-[#E2E7EA] min-h-full">
+            <div className="max-w-7xl mx-auto px-6 py-8">
                 {/* Header */}
                 <div className="mb-8">
                     {user && !showFacilityColumn && (
@@ -196,7 +204,7 @@ export default function StudentManagement() {
                     )}
                     <div className="flex items-center justify-between">
                         <div>
-                            <h1 className="text-[#203622]">
+                            <h1 className="text-2xl font-semibold text-[#203622]">
                                 Residents
                             </h1>
                             <p className="text-gray-600 mt-1">
@@ -215,12 +223,6 @@ export default function StudentManagement() {
                             <Button
                                 onClick={() => {
                                     addForm.reset();
-                                    if (showFacilityColumn && user) {
-                                        addForm.setValue(
-                                            'facility_id',
-                                            user.facility_id
-                                        );
-                                    }
                                     setAddDialogOpen(true);
                                 }}
                                 className="gap-2 bg-[#556830] hover:bg-[#203622]"
@@ -273,7 +275,7 @@ export default function StudentManagement() {
 
                 {/* Stats Cards */}
                 <div className="grid grid-cols-3 gap-4 mb-6">
-                    <div className="bg-white rounded-lg p-4">
+                    <div className="bg-white rounded-lg border border-gray-200 p-4">
                         <div className="text-sm text-gray-600 mb-1">
                             Total Residents
                         </div>
@@ -281,7 +283,7 @@ export default function StudentManagement() {
                             {stats?.total ?? '\u2014'}
                         </div>
                     </div>
-                    <div className="bg-white rounded-lg p-4">
+                    <div className="bg-white rounded-lg border border-gray-200 p-4">
                         <div className="text-sm text-gray-600 mb-1">
                             Active Accounts
                         </div>
@@ -289,7 +291,7 @@ export default function StudentManagement() {
                             {stats?.active ?? '\u2014'}
                         </div>
                     </div>
-                    <div className="bg-white rounded-lg p-4">
+                    <div className="bg-white rounded-lg border border-gray-200 p-4">
                         <div className="text-sm text-gray-600 mb-1">
                             Inactive Accounts
                         </div>
@@ -305,13 +307,13 @@ export default function StudentManagement() {
                         Failed to load residents.
                     </div>
                 ) : isLoading ? (
-                    <div className="bg-white rounded-lg p-4 space-y-3">
+                    <div className="bg-white rounded-lg border border-gray-200 p-4 space-y-3">
                         {Array.from({ length: 5 }).map((_, i) => (
                             <Skeleton key={i} className="h-10 w-full" />
                         ))}
                     </div>
                 ) : (
-                    <div className="bg-white rounded-lg">
+                    <div className="bg-white rounded-lg border border-gray-200">
                         <Table>
                             <TableHeader>
                                 <TableRow>
@@ -325,9 +327,7 @@ export default function StudentManagement() {
                                         Resident ID
                                     </SortableHeader>
                                     {showFacilityColumn && (
-                                        <SortableHeader field="facility_id">
-                                            Facility
-                                        </SortableHeader>
+                                        <TableHead>Facility</TableHead>
                                     )}
                                     <SortableHeader field="last_login">
                                         Last Active
@@ -419,14 +419,79 @@ export default function StudentManagement() {
                             </TableBody>
                         </Table>
 
-                        <Pagination
-                            currentPage={page}
-                            totalItems={totalItems}
-                            itemsPerPage={perPage}
-                            onPageChange={setPage}
-                            onItemsPerPageChange={setPerPage}
-                            itemLabel="residents"
-                        />
+                        {/* Pagination */}
+                        {totalPages > 1 && (
+                            <div className="border-t border-gray-200 px-4 py-3">
+                                <Pagination>
+                                    <PaginationContent>
+                                        <PaginationItem>
+                                            <PaginationPrevious
+                                                onClick={() =>
+                                                    page > 1 &&
+                                                    setPage(page - 1)
+                                                }
+                                                className={
+                                                    page <= 1
+                                                        ? 'pointer-events-none opacity-50'
+                                                        : 'cursor-pointer'
+                                                }
+                                            />
+                                        </PaginationItem>
+                                        {Array.from(
+                                            {
+                                                length: Math.min(totalPages, 5)
+                                            },
+                                            (_, i) => {
+                                                let pageNum: number;
+                                                if (totalPages <= 5) {
+                                                    pageNum = i + 1;
+                                                } else if (page <= 3) {
+                                                    pageNum = i + 1;
+                                                } else if (
+                                                    page >=
+                                                    totalPages - 2
+                                                ) {
+                                                    pageNum =
+                                                        totalPages - 4 + i;
+                                                } else {
+                                                    pageNum = page - 2 + i;
+                                                }
+                                                return (
+                                                    <PaginationItem
+                                                        key={pageNum}
+                                                    >
+                                                        <PaginationLink
+                                                            onClick={() =>
+                                                                setPage(pageNum)
+                                                            }
+                                                            isActive={
+                                                                pageNum === page
+                                                            }
+                                                            className="cursor-pointer"
+                                                        >
+                                                            {pageNum}
+                                                        </PaginationLink>
+                                                    </PaginationItem>
+                                                );
+                                            }
+                                        )}
+                                        <PaginationItem>
+                                            <PaginationNext
+                                                onClick={() =>
+                                                    page < totalPages &&
+                                                    setPage(page + 1)
+                                                }
+                                                className={
+                                                    page >= totalPages
+                                                        ? 'pointer-events-none opacity-50'
+                                                        : 'cursor-pointer'
+                                                }
+                                            />
+                                        </PaginationItem>
+                                    </PaginationContent>
+                                </Pagination>
+                            </div>
+                        )}
                     </div>
                 )}
 
@@ -446,100 +511,84 @@ export default function StudentManagement() {
                                     (d) => void handleAddUser(d)
                                 )(e);
                             }}
+                            className="space-y-4 py-4"
                         >
-                            <div className="space-y-4 py-4">
-                                <div className="grid grid-cols-2 gap-4">
-                                    <div>
-                                        <Label htmlFor="add-first">
-                                            First Name
-                                        </Label>
-                                        <Input
-                                            id="add-first"
-                                            placeholder="First name"
-                                            {...addForm.register('name_first', {
-                                                required: true
-                                            })}
-                                            className="mt-2"
-                                        />
-                                    </div>
-                                    <div>
-                                        <Label htmlFor="add-last">
-                                            Last Name
-                                        </Label>
-                                        <Input
-                                            id="add-last"
-                                            placeholder="Last name"
-                                            {...addForm.register('name_last', {
-                                                required: true
-                                            })}
-                                            className="mt-2"
-                                        />
-                                    </div>
-                                </div>
+                            <div className="grid grid-cols-2 gap-4">
                                 <div>
-                                    <Label htmlFor="add-username">
-                                        Username
+                                    <Label htmlFor="add-first">
+                                        First Name
                                     </Label>
                                     <Input
-                                        id="add-username"
-                                        placeholder="Enter username for login"
-                                        {...addForm.register('username', {
+                                        id="add-first"
+                                        placeholder="First name"
+                                        {...addForm.register('name_first', {
                                             required: true
                                         })}
                                         className="mt-2"
                                     />
                                 </div>
                                 <div>
-                                    <Label htmlFor="add-doc-id">
-                                        Resident ID
-                                    </Label>
+                                    <Label htmlFor="add-last">Last Name</Label>
                                     <Input
-                                        id="add-doc-id"
-                                        placeholder="e.g., R001"
-                                        {...addForm.register('doc_id')}
+                                        id="add-last"
+                                        placeholder="Last name"
+                                        {...addForm.register('name_last', {
+                                            required: true
+                                        })}
                                         className="mt-2"
                                     />
                                 </div>
-                                {showFacilityColumn && (
-                                    <div>
-                                        <Label htmlFor="add-facility">
-                                            Facility
-                                        </Label>
-                                        <Select
-                                            value={
-                                                addForm.watch('facility_id')
-                                                    ? String(
-                                                          addForm.watch(
-                                                              'facility_id'
-                                                          )
-                                                      )
-                                                    : undefined
-                                            }
-                                            onValueChange={(v) =>
-                                                addForm.setValue(
-                                                    'facility_id',
-                                                    Number(v)
-                                                )
-                                            }
-                                        >
-                                            <SelectTrigger className="mt-2">
-                                                <SelectValue placeholder="Select facility" />
-                                            </SelectTrigger>
-                                            <SelectContent>
-                                                {facilities.map((f) => (
-                                                    <SelectItem
-                                                        key={f.id}
-                                                        value={String(f.id)}
-                                                    >
-                                                        {f.name}
-                                                    </SelectItem>
-                                                ))}
-                                            </SelectContent>
-                                        </Select>
-                                    </div>
-                                )}
                             </div>
-                            <DialogFooter className="pt-2">
+                            <div>
+                                <Label htmlFor="add-username">Username</Label>
+                                <Input
+                                    id="add-username"
+                                    placeholder="Enter username for login"
+                                    {...addForm.register('username', {
+                                        required: true
+                                    })}
+                                    className="mt-2"
+                                />
+                            </div>
+                            <div>
+                                <Label htmlFor="add-doc-id">Resident ID</Label>
+                                <Input
+                                    id="add-doc-id"
+                                    placeholder="e.g., R001"
+                                    {...addForm.register('doc_id')}
+                                    className="mt-2"
+                                />
+                            </div>
+                            {showFacilityColumn && (
+                                <div>
+                                    <Label htmlFor="add-facility">
+                                        Facility
+                                    </Label>
+                                    <Select
+                                        onValueChange={(v) =>
+                                            addForm.setValue(
+                                                'facility_id',
+                                                Number(v)
+                                            )
+                                        }
+                                    >
+                                        <SelectTrigger className="mt-2">
+                                            <SelectValue placeholder="Select facility" />
+                                        </SelectTrigger>
+                                        <SelectContent>
+                                            {facilities.map((f) => (
+                                                <SelectItem
+                                                    key={f.id}
+                                                    value={String(f.id)}
+                                                >
+                                                    {f.name}
+                                                </SelectItem>
+                                            ))}
+                                        </SelectContent>
+                                    </Select>
+                                </div>
+                            )}
+                            <DialogFooter>
                                 <Button
                                     variant="outline"
                                     type="button"
@@ -558,6 +607,7 @@ export default function StudentManagement() {
                         </form>
                     </DialogContent>
                 </Dialog>
+            </div>
         </div>
     );
 }

--- a/frontend-v2/src/pages/admin/StudentManagement.tsx
+++ b/frontend-v2/src/pages/admin/StudentManagement.tsx
@@ -53,7 +53,7 @@ import {
     Users as UsersIcon
 } from 'lucide-react';
 
-type SortField = 'name_last' | 'username' | 'doc_id' | 'last_login';
+type SortField = 'name_last' | 'username' | 'doc_id' | 'facility_id' | 'last_login';
 type SortDir = 'asc' | 'desc';
 
 interface StudentFormData {
@@ -186,7 +186,7 @@ export default function StudentManagement() {
     const isFormValid = addForm.watch('name_first') && addForm.watch('name_last') && addForm.watch('username');
 
     return (
-        <div>
+        <div className="py-4">
                 {/* Header */}
                 <div className="mb-8">
                     {user && !showFacilityColumn && (
@@ -196,7 +196,7 @@ export default function StudentManagement() {
                     )}
                     <div className="flex items-center justify-between">
                         <div>
-                            <h1 className="text-2xl font-semibold text-[#203622]">
+                            <h1 className="text-[#203622]">
                                 Residents
                             </h1>
                             <p className="text-gray-600 mt-1">
@@ -325,7 +325,9 @@ export default function StudentManagement() {
                                         Resident ID
                                     </SortableHeader>
                                     {showFacilityColumn && (
-                                        <TableHead>Facility</TableHead>
+                                        <SortableHeader field="facility_id">
+                                            Facility
+                                        </SortableHeader>
                                     )}
                                     <SortableHeader field="last_login">
                                         Last Active
@@ -417,16 +419,14 @@ export default function StudentManagement() {
                             </TableBody>
                         </Table>
 
-                        {totalItems > perPage && (
-                            <Pagination
-                                currentPage={page}
-                                totalItems={totalItems}
-                                itemsPerPage={perPage}
-                                onPageChange={setPage}
-                                onItemsPerPageChange={setPerPage}
-                                itemLabel="residents"
-                            />
-                        )}
+                        <Pagination
+                            currentPage={page}
+                            totalItems={totalItems}
+                            itemsPerPage={perPage}
+                            onPageChange={setPage}
+                            onItemsPerPageChange={setPerPage}
+                            itemLabel="residents"
+                        />
                     </div>
                 )}
 
@@ -539,7 +539,7 @@ export default function StudentManagement() {
                                     </div>
                                 )}
                             </div>
-                            <DialogFooter>
+                            <DialogFooter className="pt-2">
                                 <Button
                                     variant="outline"
                                     type="button"

--- a/frontend-v2/src/pages/admin/StudentManagement.tsx
+++ b/frontend-v2/src/pages/admin/StudentManagement.tsx
@@ -273,7 +273,7 @@ export default function StudentManagement() {
 
                 {/* Stats Cards */}
                 <div className="grid grid-cols-3 gap-4 mb-6">
-                    <div className="bg-white rounded-lg p-4">
+                    <div className="bg-white rounded-lg border border-gray-200 p-4">
                         <div className="text-sm text-gray-600 mb-1">
                             Total Residents
                         </div>
@@ -281,7 +281,7 @@ export default function StudentManagement() {
                             {stats?.total ?? '\u2014'}
                         </div>
                     </div>
-                    <div className="bg-white rounded-lg p-4">
+                    <div className="bg-white rounded-lg border border-gray-200 p-4">
                         <div className="text-sm text-gray-600 mb-1">
                             Active Accounts
                         </div>
@@ -289,7 +289,7 @@ export default function StudentManagement() {
                             {stats?.active ?? '\u2014'}
                         </div>
                     </div>
-                    <div className="bg-white rounded-lg p-4">
+                    <div className="bg-white rounded-lg border border-gray-200 p-4">
                         <div className="text-sm text-gray-600 mb-1">
                             Inactive Accounts
                         </div>
@@ -311,7 +311,7 @@ export default function StudentManagement() {
                         ))}
                     </div>
                 ) : (
-                    <div className="bg-white rounded-lg">
+                    <div className="bg-white rounded-lg border border-gray-200">
                         <Table>
                             <TableHeader>
                                 <TableRow>

--- a/frontend-v2/src/types/user.ts
+++ b/frontend-v2/src/types/user.ts
@@ -104,6 +104,14 @@ export interface BulkUploadResponse {
     error_csv_data?: string;
 }
 
+export interface BulkPasswordResult {
+    user_id: number;
+    username: string;
+    name: string;
+    doc_id: string;
+    temp_password: string;
+}
+
 export enum FilterResidentNames {
     'Resident Name (A-Z)' = 'name_last asc',
     'Resident Name (Z-A)' = 'name_last desc'

--- a/frontend-v2/src/types/user.ts
+++ b/frontend-v2/src/types/user.ts
@@ -112,6 +112,24 @@ export interface BulkPasswordResult {
     temp_password: string;
 }
 
+export interface BulkPasswordResponse {
+    successes: BulkPasswordResult[];
+    failures: BulkActionFailure[];
+}
+
+export interface BulkActionFailure {
+    user_id: number;
+    username: string;
+    name: string;
+    reason: string;
+}
+
+export interface BulkActionResponse {
+    success_count: number;
+    failed_count: number;
+    failures: BulkActionFailure[];
+}
+
 export enum FilterResidentNames {
     'Resident Name (A-Z)' = 'name_last asc',
     'Resident Name (Z-A)' = 'name_last desc'

--- a/frontend-v2/src/types/user.ts
+++ b/frontend-v2/src/types/user.ts
@@ -36,6 +36,7 @@ export interface User {
     session_id: string;
     created_at: string;
     updated_at: string;
+    facility_id: number;
     facility: Facility;
     feature_access: FeatureAccess[];
     timezone: string;


### PR DESCRIPTION
## Pre-Submission PR Checklist

- [x] No debug/console/fmt.Println statements
- [x] Unnecessary development comments removed
- [x] All acceptance criteria verified
- [x] Functions according to **ticket specifications**
- [x] Tested manually where applicable
- [x] Branch rebased with latest main
- [x] No business logic exists within the database layer

## Description of the change
Adds bulk selection and bulk action dialogs to the Residents table. Residents can be selected across pages using checkboxes, with a floating action bar that appears at the bottom of the screen. Three new bulk operations are supported: reset passwords, deactivate,
  and delete.

  Backend:
  - 3 new POST endpoints under /api/users/bulk/ — reset-password, deactivate, delete
  - All endpoints batch-fetch users in a single query, filter by facility for non-system/dept admins, and loop sequentially with skip-on-error per user
  - Reset password returns [{user_id, username, name, doc_id, temp_password}] for client-side CSV generation
  - Deactivate and delete return {success_count, failed_count}

  Frontend:
  - Header checkbox selects/deselects all non-deactivated residents on the current page
  - Individual row checkboxes toggle without triggering row navigation
  - Deactivated rows have no checkbox
  - Selection persists across page changes, clears on search/filter/sort changes
  - Floating action bar (centered, matches prototype) with Clear Selection, Reset Passwords, Deactivate, and Delete buttons
  - BulkResetPasswordDialog: 2-step flow (confirm with count -> results with CSV download)
  - BulkDeactivateDialog: orange warning with resident list, count confirmation
  - BulkDeleteDialog: red warning with resident list, count confirmation
  - After any bulk action, selection clears and table refreshes via SWR mutate



## Screenshot(s)
## This PR
<img width="1483" height="896" alt="image" src="https://github.com/user-attachments/assets/33e34fb4-fdac-4f6e-bcef-a17e72c1f86c" />


## prototype
<img width="1497" height="611" alt="image" src="https://github.com/user-attachments/assets/af3b02cf-5c67-4608-b9be-aa388aff0748" />



## This PR
<img width="655" height="662" alt="image" src="https://github.com/user-attachments/assets/1bd875ab-9583-4a83-b1e0-647112faeb2e" />

## Prototype 
<img width="670" height="648" alt="image" src="https://github.com/user-attachments/assets/ab4940f1-814b-4e2d-ad2c-d5419c80b4b6" />

## This PR
<img width="658" height="355" alt="image" src="https://github.com/user-attachments/assets/dcf4b7f7-3598-4ec2-af5a-e6c133852b2d" />

## Prototype 
<img width="652" height="348" alt="image" src="https://github.com/user-attachments/assets/0616b796-9ac7-40a1-baaf-cc8927c32dd4" />

## This PR
<img width="646" height="430" alt="image" src="https://github.com/user-attachments/assets/23ba594b-0486-441c-b2b9-b90ed8dc7594" />

## Prototype 
<img width="663" height="445" alt="image" src="https://github.com/user-attachments/assets/c1e72a38-7ad6-4182-9b01-db556fe5b865" />

## This PR
<img width="633" height="493" alt="image" src="https://github.com/user-attachments/assets/05b6c7a6-ce6c-4438-886f-162ce8a76ae4" />

## Prototype 
<img width="636" height="498" alt="image" src="https://github.com/user-attachments/assets/fea765b5-58b6-4edf-90b5-8f47ed5f326c" />

## Additional context
Chose to center the bulk actions bar and not drop "selected" to the row below, it looks cleaner in my personal opinion and I was unable to get it to center/match the prototype exactly without adjusting the navbar. 


