### PR TITLE
refactor: add and remove logic to consolidate schedule popout to remove duplicated code

### DIFF
--- a/frontend/src/components/schedule/SessionDetailSheet.tsx
+++ b/frontend/src/components/schedule/SessionDetailSheet.tsx
@@ -202,6 +202,7 @@ export function SessionDetailSheet({
         !hasAttendance &&
         !isCancelled &&
         !isRescheduledFrom &&
+        !isRescheduledTo &&
         !isCancelledReschedule;
 
     const eventId = instance.event_id ?? instance.id;

--- a/frontend/src/components/schedule/SessionDetailSheet.tsx
+++ b/frontend/src/components/schedule/SessionDetailSheet.tsx
@@ -21,9 +21,11 @@ import {
 import { CancelEventModal } from '@/components/schedule/CancelEventModal';
 import { ChangeInstructorModal } from '@/components/schedule/ChangeInstructorModal';
 import { ChangeRoomModal } from '@/components/schedule/ChangeRoomModal';
-import { RescheduleSessionModal } from './RescheduleSessionModal';
-import { SessionDisplay } from './SessionsTab';
-import { findActiveOverride } from './session-utils';
+import { RescheduleSessionModal } from '@/pages/class-detail/RescheduleSessionModal';
+import {
+    findActiveOverride,
+    type SessionDisplay
+} from '@/pages/class-detail/session-utils';
 import {
     FacilityProgramClassEvent,
     ProgramClassEvent,
@@ -50,6 +52,26 @@ interface SessionDetailSheetProps {
     onUndoCancel?: () => void;
     onUndoReschedule?: () => void;
     allSessions?: SessionDisplay[];
+
+    // Optional variant hooks for calendar/admin-schedule usage.
+    /** Program name shown under the class title in Class Details. */
+    programName?: string;
+    /** Render the "Active" status badge (class_status === Active). */
+    showActiveBadge?: boolean;
+    /** Suppress the Rescheduled / Rescheduled-Class badges in the header. */
+    hideRescheduledBadge?: boolean;
+    /** Override the cancellation-undo button label (default: "Undo Cancellation"). */
+    cancellationActionLabel?: string;
+    /** When set, "Reschedule This Class" fires this callback instead of opening the built-in modal. */
+    onReschedule?: () => void;
+    /** Render a "Take Attendance" action (past + scheduled + not completed/cancelled). */
+    onTakeAttendance?: () => void;
+    /** Render a "View Full Class Details →" link at the bottom. */
+    onViewClassDetails?: () => void;
+    /** Pre-built FacilityProgramClassEvent for the cancel/change-room/change-instructor modals. If omitted, one is synthesized from session + classEvents. */
+    facilityEvent?: FacilityProgramClassEvent;
+    /** Force-disable the modify actions block (Reschedule/Cancel/Change Instructor/Change Room) regardless of session flags. */
+    disableModifyActions?: boolean;
 }
 
 function buildFacilityEvent(
@@ -113,7 +135,16 @@ export function SessionDetailSheet({
     onUndo,
     onUndoCancel,
     onUndoReschedule,
-    allSessions = []
+    allSessions = [],
+    programName,
+    showActiveBadge = false,
+    hideRescheduledBadge = false,
+    cancellationActionLabel = 'Undo Cancellation',
+    onReschedule,
+    onTakeAttendance,
+    onViewClassDetails,
+    facilityEvent: facilityEventOverride,
+    disableModifyActions = false
 }: SessionDetailSheetProps) {
     const [showCancelModal, setShowCancelModal] = useState(false);
     const [showRescheduleModal, setShowRescheduleModal] = useState(false);
@@ -167,6 +198,7 @@ export function SessionDetailSheet({
     } = session;
 
     const canModify =
+        !disableModifyActions &&
         !hasAttendance &&
         !isCancelled &&
         !isRescheduledFrom &&
@@ -187,7 +219,8 @@ export function SessionDetailSheet({
         day: 'numeric'
     });
 
-    const facilityEvent = buildFacilityEvent(session, classId, classEvents);
+    const facilityEvent =
+        facilityEventOverride ?? buildFacilityEvent(session, classId, classEvents);
 
     const getStatusBadge = () => {
         if (isCancelled || isCancelledReschedule) {
@@ -200,7 +233,7 @@ export function SessionDetailSheet({
                 </Badge>
             );
         }
-        if (isRescheduledFrom) {
+        if (isRescheduledFrom && !hideRescheduledBadge) {
             return (
                 <Badge
                     variant="outline"
@@ -210,7 +243,7 @@ export function SessionDetailSheet({
                 </Badge>
             );
         }
-        if (isRescheduledTo) {
+        if (isRescheduledTo && !hideRescheduledBadge) {
             return (
                 <Badge
                     variant="outline"
@@ -227,6 +260,16 @@ export function SessionDetailSheet({
                     className="bg-green-50 text-[#556830] border-green-200"
                 >
                     Completed
+                </Badge>
+            );
+        }
+        if (showActiveBadge) {
+            return (
+                <Badge
+                    variant="outline"
+                    className="bg-green-50 text-[#556830] border-green-200"
+                >
+                    Active
                 </Badge>
             );
         }
@@ -254,6 +297,12 @@ export function SessionDetailSheet({
         onUndo();
         onClose();
     };
+
+    const showTakeAttendance =
+        !!onTakeAttendance &&
+        session.isPast &&
+        !isCancelled &&
+        !hasAttendance;
 
     return (
         <>
@@ -299,6 +348,11 @@ export function SessionDetailSheet({
                                         <div className="text-[#203622]">
                                             {className}
                                         </div>
+                                        {programName && (
+                                            <div className="text-sm text-gray-500">
+                                                {programName}
+                                            </div>
+                                        )}
                                     </div>
                                 </div>
                                 <div className="flex items-start gap-3">
@@ -322,16 +376,16 @@ export function SessionDetailSheet({
                                         </div>
                                         <div
                                             className={`text-[#203622] ${
-                                                originalRoom || isCancelled || isRescheduledFrom || isCancelledReschedule
+                                                !!originalRoom || isCancelled || isRescheduledFrom || isCancelledReschedule
                                                     ? 'line-through'
                                                     : ''
                                             }`}
                                         >
-                                            {originalRoom || room}
+                                            {originalRoom ?? room}
                                         </div>
                                     </div>
                                 </div>
-                                {(originalInstructorName || instructorName) && (
+                                {(originalInstructorName ?? instructorName) && (
                                     <div className="flex items-start gap-3">
                                         <Users className="size-5 text-gray-400 mt-0.5 flex-shrink-0" />
                                         <div className="flex-1 min-w-0">
@@ -340,12 +394,12 @@ export function SessionDetailSheet({
                                             </div>
                                             <div
                                                 className={`text-[#203622] ${
-                                                    originalInstructorName || isCancelled || isRescheduledFrom || isCancelledReschedule
+                                                    !!originalInstructorName || isCancelled || isRescheduledFrom || isCancelledReschedule
                                                         ? 'line-through'
                                                         : ''
                                                 }`}
                                             >
-                                                {originalInstructorName || instructorName}
+                                                {originalInstructorName ?? instructorName}
                                             </div>
                                         </div>
                                     </div>
@@ -358,7 +412,7 @@ export function SessionDetailSheet({
                             isRescheduledFrom ||
                             isRescheduledTo ||
                             hasAttendance ||
-                            (!isCancelled && (originalInstructorName || originalRoom))) && (
+                            (!isCancelled && (originalInstructorName ?? originalRoom))) && (
                             <div className="pt-6 border-t border-gray-200">
                                 <h4 className="text-sm text-gray-700 mb-3">
                                     Status
@@ -414,7 +468,7 @@ export function SessionDetailSheet({
                                                 }}
                                                 className="w-full"
                                             >
-                                                Undo Cancellation
+                                                {cancellationActionLabel}
                                             </Button>
                                         </div>
                                         {rescheduledDate && (
@@ -482,7 +536,7 @@ export function SessionDetailSheet({
                                     </div>
                                 )}
 
-                                {isRescheduledTo && rescheduledDate && (
+                                {isRescheduledTo && (
                                     <div className="space-y-3">
                                         <div className="flex items-start gap-2">
                                             <CalendarClock className="size-4 text-blue-700 mt-0.5 flex-shrink-0" />
@@ -490,14 +544,16 @@ export function SessionDetailSheet({
                                                 <div className="text-sm text-gray-900 mb-1">
                                                     Rescheduled Class
                                                 </div>
-                                                <p className="text-sm text-gray-600">
-                                                    Originally scheduled for{' '}
-                                                    {new Date(rescheduledDate + 'T00:00:00').toLocaleDateString('en-US', {
-                                                        weekday: 'long',
-                                                        month: 'long',
-                                                        day: 'numeric'
-                                                    })}
-                                                </p>
+                                                {rescheduledDate && (
+                                                    <p className="text-sm text-gray-600">
+                                                        Originally scheduled for{' '}
+                                                        {new Date(rescheduledDate + 'T00:00:00').toLocaleDateString('en-US', {
+                                                            weekday: 'long',
+                                                            month: 'long',
+                                                            day: 'numeric'
+                                                        })}
+                                                    </p>
+                                                )}
                                             </div>
                                         </div>
                                         <Button
@@ -536,7 +592,7 @@ export function SessionDetailSheet({
                                             }}
                                             className="w-full"
                                         >
-                                            Undo Cancellation
+                                            {cancellationActionLabel}
                                         </Button>
                                     </div>
                                 )}
@@ -562,53 +618,82 @@ export function SessionDetailSheet({
                             </div>
                         )}
 
-                        {canModify && (
+                        {(canModify || showTakeAttendance) && (
                             <div className="pt-6 border-t border-gray-200">
                                 <h4 className="text-sm text-gray-700 mb-3">
                                     Actions
                                 </h4>
                                 <div className="space-y-2">
-                                    <Button
-                                        variant="outline"
-                                        onClick={() =>
-                                            setShowRescheduleModal(true)
-                                        }
-                                        className="w-full justify-start border-gray-300 hover:bg-gray-50"
-                                    >
-                                        <CalendarClock className="size-4 mr-2" />
-                                        Reschedule This Class
-                                    </Button>
-                                    <Button
-                                        variant="outline"
-                                        onClick={() =>
-                                            setShowCancelModal(true)
-                                        }
-                                        className="w-full justify-start border-gray-300 text-red-600 hover:bg-red-50 hover:text-red-700 hover:border-red-200"
-                                    >
-                                        <CalendarOff className="size-4 mr-2" />
-                                        Cancel This Class
-                                    </Button>
-                                    <Button
-                                        variant="outline"
-                                        onClick={() =>
-                                            setShowChangeInstructor(true)
-                                        }
-                                        className="w-full justify-start border-gray-300 hover:bg-gray-50"
-                                    >
-                                        <Users className="size-4 mr-2" />
-                                        Change Instructor
-                                    </Button>
-                                    <Button
-                                        variant="outline"
-                                        onClick={() =>
-                                            setShowChangeRoom(true)
-                                        }
-                                        className="w-full justify-start border-gray-300 hover:bg-gray-50"
-                                    >
-                                        <MapPin className="size-4 mr-2" />
-                                        Change Room
-                                    </Button>
+                                    {showTakeAttendance && onTakeAttendance && (
+                                        <Button
+                                            className="w-full justify-start bg-[#556830] hover:bg-[#203622] text-white"
+                                            onClick={onTakeAttendance}
+                                        >
+                                            <CheckCircle className="size-4 mr-2" />
+                                            Take Attendance
+                                        </Button>
+                                    )}
+                                    {canModify && (
+                                        <>
+                                            <Button
+                                                variant="outline"
+                                                onClick={() => {
+                                                    if (onReschedule) {
+                                                        onReschedule();
+                                                    } else {
+                                                        setShowRescheduleModal(true);
+                                                    }
+                                                }}
+                                                className="w-full justify-start border-gray-300 hover:bg-gray-50"
+                                            >
+                                                <CalendarClock className="size-4 mr-2" />
+                                                Reschedule This Class
+                                            </Button>
+                                            <Button
+                                                variant="outline"
+                                                onClick={() =>
+                                                    setShowCancelModal(true)
+                                                }
+                                                className="w-full justify-start border-gray-300 text-red-600 hover:bg-red-50 hover:text-red-700 hover:border-red-200"
+                                            >
+                                                <CalendarOff className="size-4 mr-2" />
+                                                Cancel This Class
+                                            </Button>
+                                            <Button
+                                                variant="outline"
+                                                onClick={() =>
+                                                    setShowChangeInstructor(true)
+                                                }
+                                                className="w-full justify-start border-gray-300 hover:bg-gray-50"
+                                            >
+                                                <Users className="size-4 mr-2" />
+                                                Change Instructor
+                                            </Button>
+                                            <Button
+                                                variant="outline"
+                                                onClick={() =>
+                                                    setShowChangeRoom(true)
+                                                }
+                                                className="w-full justify-start border-gray-300 hover:bg-gray-50"
+                                            >
+                                                <MapPin className="size-4 mr-2" />
+                                                Change Room
+                                            </Button>
+                                        </>
+                                    )}
                                 </div>
+                            </div>
+                        )}
+
+                        {onViewClassDetails && !isCancelled && (
+                            <div className="pt-6 border-t border-gray-200">
+                                <Button
+                                    variant="outline"
+                                    className="w-full justify-start"
+                                    onClick={onViewClassDetails}
+                                >
+                                    View Full Class Details →
+                                </Button>
                             </div>
                         )}
                     </div>
@@ -625,7 +710,7 @@ export function SessionDetailSheet({
                 }}
             />
 
-            {showRescheduleModal && (
+            {showRescheduleModal && !onReschedule && (
                 <RescheduleSessionModal
                     open={showRescheduleModal}
                     onClose={() => setShowRescheduleModal(false)}

--- a/frontend/src/pages/Schedule.tsx
+++ b/frontend/src/pages/Schedule.tsx
@@ -1,8 +1,6 @@
 import React, { useMemo, useState } from 'react';
 import { useParams, useNavigate } from 'react-router-dom';
-import { toast } from 'sonner';
 import useSWR from 'swr';
-import API from '@/api/api';
 import { toZonedTime } from 'date-fns-tz';
 import { Calendar as BigCalendar, momentLocalizer, View } from 'react-big-calendar';
 // react-big-calendar types are incompatible with @types/react@18 (missing `refs`)
@@ -18,15 +16,6 @@ import {
     Facility
 } from '@/types';
 import {
-    Sheet,
-    SheetContent,
-    SheetHeader,
-    SheetTitle,
-    SheetDescription
-} from '@/components/ui/sheet';
-import { Button } from '@/components/ui/button';
-import { Badge } from '@/components/ui/badge';
-import {
     Select,
     SelectContent,
     SelectItem,
@@ -34,22 +23,12 @@ import {
     SelectValue
 } from '@/components/ui/select';
 import { Skeleton } from '@/components/ui/skeleton';
-import { CancelEventModal } from '@/components/schedule/CancelEventModal';
 import { RescheduleEventModal } from '@/components/schedule/RescheduleEventModal';
 import { RescheduleSessionModal } from '@/components/schedule/RescheduleSessionModal';
 import { RescheduleSeriesModal } from '@/components/schedule/RescheduleSeriesModal';
 import { RestoreEventModal } from '@/components/schedule/RestoreEventModal';
-import { ChangeRoomModal } from '@/components/schedule/ChangeRoomModal';
-import { ChangeInstructorModal } from '@/components/schedule/ChangeInstructorModal';
-import {
-    Calendar as CalendarIcon,
-    Clock,
-    MapPin,
-    Users,
-    CalendarClock,
-    CalendarOff,
-    CheckCircle
-} from 'lucide-react';
+import { SessionDetailSheet } from '@/components/schedule/SessionDetailSheet';
+import type { SessionDisplay } from '@/pages/class-detail/session-utils';
 
 const localizer = momentLocalizer(moment);
 
@@ -61,6 +40,80 @@ interface CalendarEvent {
     start: Date;
     end: Date;
     resource: FacilityProgramClassEvent;
+}
+
+function toDateString(d: Date): string {
+    const y = d.getFullYear();
+    const m = String(d.getMonth() + 1).padStart(2, '0');
+    const day = String(d.getDate()).padStart(2, '0');
+    return `${y}-${m}-${day}`;
+}
+
+function toClassTimeRange(start: Date, end: Date): string {
+    const fmt = (d: Date) =>
+        `${String(d.getHours()).padStart(2, '0')}:${String(d.getMinutes()).padStart(2, '0')}`;
+    return `${fmt(start)}-${fmt(end)}`;
+}
+
+function facilityEventToSessionDisplay(
+    event: FacilityProgramClassEvent
+): SessionDisplay {
+    const start = event.start;
+    const end = event.end;
+    const now = new Date();
+    const isToday = now.toDateString() === start.toDateString();
+    const isPast = now > end;
+    const isUpcoming = !isPast;
+    const hasAttendance = event.class_status === SelectedClassStatus.Completed;
+    const isCancelled = event.is_cancelled;
+    const linked = event.linked_override_event as
+        | FacilityProgramClassEvent
+        | null
+        | undefined;
+    const isRescheduledTo = !isCancelled && event.is_override && !!linked;
+
+    let rescheduledDate: string | undefined;
+    if (linked?.start) {
+        const linkedStart =
+            linked.start instanceof Date ? linked.start : new Date(linked.start);
+        if (!Number.isNaN(linkedStart.getTime())) {
+            rescheduledDate = toDateString(linkedStart);
+        }
+    }
+
+    return {
+        instance: {
+            id: event.id,
+            class_id: event.class_id,
+            duration: event.duration,
+            room_id: event.room_id,
+            recurrence_rule: event.recurrence_rule,
+            is_cancelled: event.is_cancelled,
+            instructor_id: event.instructor_id ?? null,
+            overrides: event.overrides ?? [],
+            reason: event.reason ?? null,
+            event_id: event.id,
+            date: toDateString(start),
+            class_time: toClassTimeRange(start, end),
+            attendance_records: [],
+            override_id: event.override_id || undefined
+        },
+        dateObj: start,
+        dayName: start.toLocaleDateString('en-US', { weekday: 'long' }),
+        isToday,
+        isPast,
+        isUpcoming,
+        hasAttendance,
+        isCancelled,
+        isRescheduledFrom: false,
+        isRescheduledTo,
+        isCancelledReschedule: false,
+        rescheduledDate,
+        rescheduleOverrideId: event.override_id || undefined,
+        cancellationReason: event.reason ?? undefined,
+        attendedCount: 0,
+        totalEnrolled: 0
+    };
 }
 
 export default function Schedule() {
@@ -77,16 +130,12 @@ export default function Schedule() {
     const [showAllClasses, setShowAllClasses] = useState(false);
     const [selectedEvent, setSelectedEvent] = useState<FacilityProgramClassEvent | null>(null);
     const [showSheet, setShowSheet] = useState(false);
-    const [showCancel, setShowCancel] = useState(false);
     const [showReschedule, setShowReschedule] = useState(false);
     const [showRescheduleSingle, setShowRescheduleSingle] = useState(false);
     const [showRescheduleSeries, setShowRescheduleSeries] = useState(false);
     const [showRestore, setShowRestore] = useState(false);
-    const [showChangeRoom, setShowChangeRoom] = useState(false);
-    const [showChangeInstructor, setShowChangeInstructor] = useState(false);
-    const [undoingReschedule, setUndoingReschedule] = useState(false);
 
-const isDepAdmin = user ? isDeptAdmin(user) : false;
+    const isDepAdmin = user ? isDeptAdmin(user) : false;
     const activeFacilityId = selectedFacilityId || (user ? String(user.facility.id) : '');
     const timezone = user?.timezone ?? 'UTC';
 
@@ -165,6 +214,14 @@ const isDepAdmin = user ? isDeptAdmin(user) : false;
         return facilities.find((f) => String(f.id) === activeFacilityId)?.name ?? user.facility.name;
     }, [isDepAdmin, facilities, activeFacilityId, user]);
 
+    const sessionView = useMemo(
+        () =>
+            showSheet && selectedEvent
+                ? facilityEventToSessionDisplay(selectedEvent)
+                : null,
+        [showSheet, selectedEvent]
+    );
+
     // Early return after all hooks
     if (!user) return null;
 
@@ -177,11 +234,6 @@ const isDepAdmin = user ? isDeptAdmin(user) : false;
             return false;
         if (class_id && selectedEvent.class_id.toString() !== class_id) return false;
         return true;
-    };
-
-    const isEventToday = (event: FacilityProgramClassEvent | null) => {
-        if (!event) return false;
-        return new Date().toDateString() === new Date(event.start).toDateString();
     };
 
     const isPastEvent = (event: FacilityProgramClassEvent | null) => {
@@ -222,20 +274,30 @@ const isDepAdmin = user ? isDeptAdmin(user) : false;
         setShowSheet(false);
     };
 
-    async function handleUndoReschedule() {
+    const handleTakeAttendance = () => {
         if (!selectedEvent) return;
-        setUndoingReschedule(true);
-        const resp = await API.delete(`program-classes/${selectedEvent.class_id}/events/${selectedEvent.override_id}`);
-        setUndoingReschedule(false);
-        if (resp.success) {
-            toast.success('Reschedule undone');
-            handleModalSuccess();
-        } else {
-            toast.error(resp.message || 'Failed to undo reschedule');
-        }
-    }
+        const d = selectedEvent.start;
+        const date = toDateString(d);
+        setShowSheet(false);
+        navigate(
+            `/program-classes/${selectedEvent.class_id}/events/${selectedEvent.id}/attendance/${date}`
+        );
+    };
 
+    const handleViewClassDetails = () => {
+        if (!selectedEvent) return;
+        setShowSheet(false);
+        navigate(`/program-classes/${selectedEvent.class_id}/detail`);
+    };
 
+    const handleRescheduleClick = () => {
+        setShowReschedule(true);
+    };
+
+    const handleCancellationAction = () => {
+        // For calendar: opens RestoreEventModal (which handles both single-override undo and series-restore).
+        setShowRestore(true);
+    };
 
     const subtitle = isDepAdmin ? `Viewing: ${selectedFacilityName}` : 'Manage class schedules';
 
@@ -247,6 +309,16 @@ const isDepAdmin = user ? isDeptAdmin(user) : false;
             </div>
         );
     }
+
+    const past = isPastEvent(selectedEvent);
+    const cancellationActionLabel = selectedEvent?.is_override
+        ? 'Undo Cancellation'
+        : 'Restore Future Sessions';
+    const disableModifyActions = past || !canUpdateEvent();
+    const showActiveBadge =
+        !!selectedEvent &&
+        !selectedEvent.is_cancelled &&
+        selectedEvent.class_status === SelectedClassStatus.Active;
 
     return (
         <div className="bg-[#E7EAED] dark:bg-[#0a0a0a] min-h-screen overflow-x-hidden">
@@ -272,502 +344,173 @@ const isDepAdmin = user ? isDeptAdmin(user) : false;
                     )}
                 </div>
 
-            {/* Filters — hidden in class-specific view */}
-            {!class_id && (
-                <div className="bg-white border border-gray-200 rounded-lg p-4">
-                    <div className="grid grid-cols-1 gap-4 md:grid-cols-3">
-                        {isDepAdmin && (
+                {/* Filters — hidden in class-specific view */}
+                {!class_id && (
+                    <div className="bg-white border border-gray-200 rounded-lg p-4">
+                        <div className="grid grid-cols-1 gap-4 md:grid-cols-3">
+                            {isDepAdmin && (
+                                <div>
+                                    <label className="text-sm font-medium text-[#203622] mb-2 block">
+                                        Facility
+                                    </label>
+                                    <Select
+                                        value={activeFacilityId}
+                                        onValueChange={(val) => {
+                                            setSelectedFacilityId(val);
+                                            setSelectedProgram('all');
+                                            setSelectedInstructor('all');
+                                        }}
+                                    >
+                                        <SelectTrigger>
+                                            <SelectValue />
+                                        </SelectTrigger>
+                                        <SelectContent>
+                                            {facilities.map((f) => (
+                                                <SelectItem key={f.id} value={String(f.id)}>
+                                                    {f.name}
+                                                </SelectItem>
+                                            ))}
+                                        </SelectContent>
+                                    </Select>
+                                </div>
+                            )}
+
                             <div>
                                 <label className="text-sm font-medium text-[#203622] mb-2 block">
-                                    Facility
+                                    Program
                                 </label>
-                                <Select
-                                    value={activeFacilityId}
-                                    onValueChange={(val) => {
-                                        setSelectedFacilityId(val);
-                                        setSelectedProgram('all');
-                                        setSelectedInstructor('all');
-                                    }}
-                                >
+                                <Select value={selectedProgram} onValueChange={setSelectedProgram}>
                                     <SelectTrigger>
-                                        <SelectValue />
+                                        <SelectValue placeholder="All Programs" />
                                     </SelectTrigger>
                                     <SelectContent>
-                                        {facilities.map((f) => (
-                                            <SelectItem key={f.id} value={String(f.id)}>
-                                                {f.name}
+                                        <SelectItem value="all">All Programs</SelectItem>
+                                        {availablePrograms.map((p) => (
+                                            <SelectItem key={p.id} value={String(p.id)}>
+                                                {p.name}
                                             </SelectItem>
                                         ))}
                                     </SelectContent>
                                 </Select>
                             </div>
-                        )}
 
-                        <div>
-                            <label className="text-sm font-medium text-[#203622] mb-2 block">
-                                Program
-                            </label>
-                            <Select value={selectedProgram} onValueChange={setSelectedProgram}>
-                                <SelectTrigger>
-                                    <SelectValue placeholder="All Programs" />
-                                </SelectTrigger>
-                                <SelectContent>
-                                    <SelectItem value="all">All Programs</SelectItem>
-                                    {availablePrograms.map((p) => (
-                                        <SelectItem key={p.id} value={String(p.id)}>
-                                            {p.name}
-                                        </SelectItem>
-                                    ))}
-                                </SelectContent>
-                            </Select>
-                        </div>
-
-                        <div>
-                            <label className="text-sm font-medium text-[#203622] mb-2 block">
-                                Instructor
-                            </label>
-                            <Select value={selectedInstructor} onValueChange={setSelectedInstructor}>
-                                <SelectTrigger>
-                                    <SelectValue placeholder="All Instructors" />
-                                </SelectTrigger>
-                                <SelectContent>
-                                    <SelectItem value="all">All Instructors</SelectItem>
-                                    {availableInstructors.map((i) => (
-                                        <SelectItem key={i} value={i}>
-                                            {i}
-                                        </SelectItem>
-                                    ))}
-                                </SelectContent>
-                            </Select>
+                            <div>
+                                <label className="text-sm font-medium text-[#203622] mb-2 block">
+                                    Instructor
+                                </label>
+                                <Select value={selectedInstructor} onValueChange={setSelectedInstructor}>
+                                    <SelectTrigger>
+                                        <SelectValue placeholder="All Instructors" />
+                                    </SelectTrigger>
+                                    <SelectContent>
+                                        <SelectItem value="all">All Instructors</SelectItem>
+                                        {availableInstructors.map((i) => (
+                                            <SelectItem key={i} value={i}>
+                                                {i}
+                                            </SelectItem>
+                                        ))}
+                                    </SelectContent>
+                                </Select>
+                            </div>
                         </div>
                     </div>
+                )}
+
+                {/* Calendar */}
+                <div
+                    className="bg-white border border-gray-200 rounded-lg p-6 unlocked-calendar"
+                    style={{ height: '700px' }}
+                >
+                    <Calendar
+                        localizer={localizer}
+                        events={calendarEvents}
+                        startAccessor="start"
+                        endAccessor="end"
+                        view={currentView}
+                        onView={setCurrentView}
+                        date={currentDate}
+                        onNavigate={setCurrentDate}
+                        onSelectEvent={handleSelectEvent}
+                        eventPropGetter={eventStyleGetter}
+                        views={['month', 'week', 'day', 'agenda']}
+                        style={{ height: '100%' }}
+                        min={new Date(0, 0, 0, 0, 0, 0, 0)}
+                        max={new Date(0, 0, 0, 23, 59, 59, 999)}
+                        scrollToTime={SCROLL_TO_TIME}
+                    />
                 </div>
-            )}
 
-            {/* Calendar */}
-            <div
-                className="bg-white border border-gray-200 rounded-lg p-6 unlocked-calendar"
-                style={{ height: '700px' }}
-            >
-                <Calendar
-                    localizer={localizer}
-                    events={calendarEvents}
-                    startAccessor="start"
-                    endAccessor="end"
-                    view={currentView}
-                    onView={setCurrentView}
-                    date={currentDate}
-                    onNavigate={setCurrentDate}
-                    onSelectEvent={handleSelectEvent}
-                    eventPropGetter={eventStyleGetter}
-                    views={['month', 'week', 'day', 'agenda']}
-                    style={{ height: '100%' }}
-                    min={new Date(0, 0, 0, 0, 0, 0, 0)}
-                    max={new Date(0, 0, 0, 23, 59, 59, 999)}
-                    scrollToTime={SCROLL_TO_TIME}
-                />
-            </div>
-
-                {/* Event Detail Sheet */}
-                <Sheet open={showSheet} onOpenChange={setShowSheet}>
-                    <SheetContent className="w-[400px] sm:w-[500px] p-0">
-                        {selectedEvent && (
-                            <>
-                                <SheetHeader className="sr-only">
-                                    <SheetTitle>Class Instance Details</SheetTitle>
-                                    <SheetDescription>
-                                        View and manage this class instance
-                                    </SheetDescription>
-                                </SheetHeader>
-
-                            <div className="border-b border-gray-200 px-6 py-4">
-                                <h3
-                                    className={`text-[#203622] mb-2 ${
-                                        selectedEvent.is_cancelled ? 'line-through' : ''
-                                    }`}
-                                >
-                                    {selectedEvent.start.toLocaleDateString('en-US', {
-                                        weekday: 'long',
-                                        month: 'long',
-                                        day: 'numeric',
-                                        year: 'numeric'
-                                    })}
-                                </h3>
-                                <div className="flex items-center gap-2 flex-wrap">
-                                    {selectedEvent.is_cancelled && (
-                                        <Badge
-                                            variant="outline"
-                                            className="bg-gray-100 text-gray-700 border-gray-300"
-                                        >
-                                            Cancelled
-                                        </Badge>
-                                    )}
-                                    {selectedEvent.class_status === SelectedClassStatus.Completed && (
-                                        <Badge
-                                            variant="outline"
-                                            className="bg-green-50 text-[#556830] border-green-200"
-                                        >
-                                            Completed
-                                        </Badge>
-                                    )}
-                                    {!selectedEvent.is_cancelled &&
-                                        selectedEvent.class_status === SelectedClassStatus.Scheduled &&
-                                        isPastEvent(selectedEvent) && (
-                                            <Badge
-                                                variant="outline"
-                                                className="bg-amber-50 text-amber-700 border-amber-300"
-                                            >
-                                                Missing Attendance
-                                            </Badge>
-                                        )}
-                                    {!selectedEvent.is_cancelled &&
-                                        selectedEvent.class_status === SelectedClassStatus.Scheduled &&
-                                        !isPastEvent(selectedEvent) && (
-                                            <Badge
-                                                variant="outline"
-                                                className="bg-gray-50 text-gray-600 border-gray-200"
-                                            >
-                                                Scheduled
-                                            </Badge>
-                                        )}
-                                    {!selectedEvent.is_cancelled &&
-                                        selectedEvent.class_status === SelectedClassStatus.Active && (
-                                            <Badge
-                                                variant="outline"
-                                                className="bg-green-50 text-[#556830] border-green-200"
-                                            >
-                                                Active
-                                            </Badge>
-                                        )}
-                                    {isEventToday(selectedEvent) && (
-                                        <span className="text-sm text-blue-600">• Today's class</span>
-                                    )}
-                                </div>
-                            </div>
-
-                            <div className="px-6 py-6 space-y-6 flex-1 overflow-y-auto min-h-0">
-                                <div>
-                                    <h4 className="text-sm text-gray-700 mb-3">Class Details</h4>
-                                    <div className="space-y-3">
-                                        <div className="flex items-start gap-3">
-                                            <CalendarIcon className="size-5 text-gray-400 mt-0.5 flex-shrink-0" />
-                                            <div className="flex-1 min-w-0">
-                                                <div className="text-sm text-gray-600 mb-0.5">Class</div>
-                                                <div className="text-[#203622]">{selectedEvent.title}</div>
-                                                <div className="text-sm text-gray-500">
-                                                    {selectedEvent.program_name}
-                                                </div>
-                                            </div>
-                                        </div>
-                                        <div className="flex items-start gap-3">
-                                            <Clock className="size-5 text-gray-400 mt-0.5 flex-shrink-0" />
-                                            <div className="flex-1 min-w-0">
-                                                <div className="text-sm text-gray-600 mb-0.5">Time</div>
-                                                <div
-                                                    className={`text-[#203622] ${
-                                                        selectedEvent.is_cancelled ? 'line-through' : ''
-                                                    }`}
-                                                >
-                                                    {selectedEvent.start.toLocaleTimeString('en-US', {
-                                                        hour: 'numeric',
-                                                        minute: '2-digit'
-                                                    })}{' '}
-                                                    -{' '}
-                                                    {selectedEvent.end.toLocaleTimeString('en-US', {
-                                                        hour: 'numeric',
-                                                        minute: '2-digit'
-                                                    })}
-                                                </div>
-                                            </div>
-                                        </div>
-                                        {(selectedEvent.original_room || selectedEvent.room) && (
-                                            <div className="flex items-start gap-3">
-                                                <MapPin className="size-5 text-gray-400 mt-0.5 flex-shrink-0" />
-                                                <div className="flex-1 min-w-0">
-                                                    <div className="text-sm text-gray-600 mb-0.5">Room</div>
-                                                    <div
-                                                        className={`text-[#203622] ${
-                                                            selectedEvent.original_room || selectedEvent.is_cancelled ? 'line-through' : ''
-                                                        }`}
-                                                    >
-                                                        {selectedEvent.original_room || selectedEvent.room}
-                                                    </div>
-                                                </div>
-                                            </div>
-                                        )}
-                                        {(selectedEvent.original_instructor_name || selectedEvent.instructor_name) && (
-                                            <div className="flex items-start gap-3">
-                                                <Users className="size-5 text-gray-400 mt-0.5 flex-shrink-0" />
-                                                <div className="flex-1 min-w-0">
-                                                    <div className="text-sm text-gray-600 mb-0.5">
-                                                        Instructor
-                                                    </div>
-                                                    <div
-                                                        className={`text-[#203622] ${
-                                                            selectedEvent.original_instructor_name || selectedEvent.is_cancelled ? 'line-through' : ''
-                                                        }`}
-                                                    >
-                                                        {selectedEvent.original_instructor_name || selectedEvent.instructor_name}
-                                                    </div>
-                                                </div>
-                                            </div>
-                                        )}
-                                    </div>
-                                </div>
-
-                                {(() => {
-                                    const past = isPastEvent(selectedEvent);
-                                    const showTakeAttendance =
-                                        past &&
-                                        !selectedEvent.is_cancelled &&
-                                        selectedEvent.class_status !== SelectedClassStatus.Completed;
-                                    const showFutureActions = !past && canUpdateEvent();
-                                    const showStatus = selectedEvent.is_cancelled;
-                                    const isRescheduled = selectedEvent.is_override && !selectedEvent.is_cancelled && !!selectedEvent.linked_override_event && showFutureActions;
-                                    const isInstructorChanged = !!selectedEvent.original_instructor_name && !selectedEvent.is_cancelled;
-                                    const isRoomChanged = !!selectedEvent.original_room && !selectedEvent.is_cancelled;
-
-                                    if (!showTakeAttendance && !showFutureActions && !showStatus && !isRescheduled && !isInstructorChanged && !isRoomChanged) return null;
-
-                                    return (
-                                        <>
-                                            {isInstructorChanged && (
-                                                <div className="pt-6 border-t border-gray-200">
-                                                    <h4 className="text-sm text-gray-700 mb-3">Status</h4>
-                                                    <div className="flex items-start gap-2">
-                                                        <Users className="size-4 text-gray-600 mt-0.5 flex-shrink-0" />
-                                                        <div className="flex-1 min-w-0">
-                                                            <div className="text-sm text-gray-900 mb-1">Instructor Change</div>
-                                                            <p className="text-sm text-gray-600">
-                                                                Session Instructor: {selectedEvent.instructor_name}
-                                                            </p>
-                                                        </div>
-                                                    </div>
-                                                </div>
-                                            )}
-                                            {isRoomChanged && (
-                                                <div className="pt-6 border-t border-gray-200">
-                                                    <h4 className="text-sm text-gray-700 mb-3">Status</h4>
-                                                    <div className="flex items-start gap-2">
-                                                        <MapPin className="size-4 text-gray-600 mt-0.5 flex-shrink-0" />
-                                                        <div className="flex-1 min-w-0">
-                                                            <div className="text-sm text-gray-900 mb-1">Room Change</div>
-                                                            <p className="text-sm text-gray-600">
-                                                                Session Room: {selectedEvent.room}
-                                                            </p>
-                                                        </div>
-                                                    </div>
-                                                </div>
-                                            )}
-                                            {isRescheduled && (
-                                                <div className="pt-6 border-t border-gray-200">
-                                                    <h4 className="text-sm text-gray-700 mb-3">Status</h4>
-                                                    <div className="space-y-3">
-                                                        <div className="flex items-start gap-2">
-                                                            <CalendarClock className="size-4 text-gray-600 mt-0.5 flex-shrink-0" />
-                                                            <div className="text-sm text-gray-900">Rescheduled Class</div>
-                                                        </div>
-                                                        <Button
-                                                            variant="outline"
-                                                            size="sm"
-                                                            className="w-full"
-                                                            onClick={() => void handleUndoReschedule()}
-                                                            disabled={undoingReschedule}
-                                                        >
-                                                            {undoingReschedule ? 'Undoing...' : 'Undo Reschedule'}
-                                                        </Button>
-                                                    </div>
-                                                </div>
-                                            )}
-
-                                            {showStatus && (
-                                                <div className="pt-6 border-t border-gray-200">
-                                                    <h4 className="text-sm text-gray-700 mb-3">Status</h4>
-                                                    <div className="space-y-3">
-                                                        <div className="flex items-start gap-2">
-                                                            <CalendarOff className="size-4 text-gray-600 mt-0.5 flex-shrink-0" />
-                                                            <div className="flex-1 min-w-0">
-                                                                <div className="text-sm text-gray-900 mb-1">Class Cancelled</div>
-                                                                {selectedEvent.reason && (
-                                                                    <p className="text-sm text-gray-600">{selectedEvent.reason}</p>
-                                                                )}
-                                                            </div>
-                                                        </div>
-                                                        {showFutureActions && (
-                                                            <Button
-                                                                variant="outline"
-                                                                size="sm"
-                                                                className="w-full"
-                                                                onClick={() => {
-                                                                    setShowSheet(false);
-                                                                    setShowRestore(true);
-                                                                }}
-                                                            >
-                                                                {selectedEvent.is_override ? 'Undo Cancellation' : 'Restore Future Sessions'}
-                                                            </Button>
-                                                        )}
-                                                    </div>
-                                                </div>
-                                            )}
-
-                                            {(showTakeAttendance || (showFutureActions && !selectedEvent.is_cancelled && !isRescheduled)) && (
-                                                <div className="pt-6 border-t border-gray-200">
-                                                    <h4 className="text-sm text-gray-700 mb-3">Actions</h4>
-                                                    <div className="space-y-2">
-                                                        {showTakeAttendance && (
-                                                            <Button
-                                                                className="w-full justify-start bg-[#556830] hover:bg-[#203622] text-white"
-                                                                onClick={() => {
-                                                                    const d = selectedEvent.start;
-                                                                    const date = [
-                                                                        d.getFullYear(),
-                                                                        String(d.getMonth() + 1).padStart(2, '0'),
-                                                                        String(d.getDate()).padStart(2, '0')
-                                                                    ].join('-');
-                                                                    setShowSheet(false);
-                                                                    navigate(
-                                                                        `/program-classes/${selectedEvent.class_id}/events/${selectedEvent.id}/attendance/${date}`
-                                                                    );
-                                                                }}
-                                                            >
-                                                                <CheckCircle className="size-4 mr-2" />
-                                                                Take Attendance
-                                                            </Button>
-                                                        )}
-                                                        {showFutureActions && !selectedEvent.is_cancelled && !isRescheduled && (
-                                                            <>
-                                                                <Button
-                                                                    variant="outline"
-                                                                    className="w-full justify-start border-gray-300 hover:bg-gray-50"
-                                                                    onClick={() => {
-                                                                        setShowSheet(false);
-                                                                        setShowReschedule(true);
-                                                                    }}
-                                                                >
-                                                                    <CalendarClock className="size-4 mr-2" />
-                                                                    Reschedule This Class
-                                                                </Button>
-                                                                <Button
-                                                                    variant="outline"
-                                                                    className="w-full justify-start border-gray-300 text-red-600 hover:bg-red-50 hover:text-red-700 hover:border-red-200"
-                                                                    onClick={() => {
-                                                                        setShowSheet(false);
-                                                                        setShowCancel(true);
-                                                                    }}
-                                                                >
-                                                                    <CalendarOff className="size-4 mr-2" />
-                                                                    Cancel This Class
-                                                                </Button>
-                                                                <Button
-                                                                    variant="outline"
-                                                                    className="w-full justify-start border-gray-300 hover:bg-gray-50"
-                                                                    onClick={() => {
-                                                                        setShowSheet(false);
-                                                                        setShowChangeInstructor(true);
-                                                                    }}
-                                                                >
-                                                                    <Users className="size-4 mr-2" />
-                                                                    Change Instructor
-                                                                </Button>
-                                                                <Button
-                                                                    variant="outline"
-                                                                    className="w-full justify-start border-gray-300 hover:bg-gray-50"
-                                                                    onClick={() => {
-                                                                        setShowSheet(false);
-                                                                        setShowChangeRoom(true);
-                                                                    }}
-                                                                >
-                                                                    <MapPin className="size-4 mr-2" />
-                                                                    Change Room
-                                                                </Button>
-                                                            </>
-                                                        )}
-                                                    </div>
-                                                </div>
-                                            )}
-                                        </>
-                                    );
-                                })()}
-
-                                {!selectedEvent.is_cancelled && (
-                                    <div className="pt-6 border-t border-gray-200">
-                                        <Button
-                                            variant="outline"
-                                            className="w-full justify-start"
-                                            onClick={() => {
-                                                setShowSheet(false);
-                                                navigate(`/program-classes/${selectedEvent.class_id}/detail`);
-                                            }}
-                                        >
-                                            View Full Class Details →
-                                        </Button>
-                                    </div>
-                                )}
-
-                            </div>
-                            </>
-                        )}
-                    </SheetContent>
-                </Sheet>
-
-            {selectedEvent && (
-                <>
-                    <CancelEventModal
-                        open={showCancel}
-                        onOpenChange={setShowCancel}
-                        event={selectedEvent}
-                        onSuccess={handleModalSuccess}
-                    />
-                    <RescheduleEventModal
-                        open={showReschedule}
-                        onOpenChange={setShowReschedule}
-                        event={selectedEvent}
-                        onSingleSession={() => {
-                            setShowReschedule(false);
-                            setShowRescheduleSingle(true);
-                        }}
-                        onSeriesReschedule={() => {
-                            setShowReschedule(false);
-                            setShowRescheduleSeries(true);
-                        }}
-                    />
-                    <RescheduleSessionModal
-                        open={showRescheduleSingle}
-                        onOpenChange={setShowRescheduleSingle}
-                        event={selectedEvent}
-                        rooms={rooms}
-                        onSuccess={handleModalSuccess}
-                    />
-                    <RescheduleSeriesModal
-                        open={showRescheduleSeries}
-                        onOpenChange={setShowRescheduleSeries}
-                        event={selectedEvent}
-                        rooms={rooms}
-                        onSuccess={handleModalSuccess}
-                    />
-                    <RestoreEventModal
-                        open={showRestore}
-                        onOpenChange={setShowRestore}
-                        event={selectedEvent}
-                        onSuccess={handleModalSuccess}
-                    />
-                    <ChangeRoomModal
-                        open={showChangeRoom}
-                        onOpenChange={setShowChangeRoom}
-                        event={selectedEvent}
-                        rooms={rooms}
-                        onSuccess={handleModalSuccess}
-                    />
-                    <ChangeInstructorModal
-                        open={showChangeInstructor}
-                        onOpenChange={setShowChangeInstructor}
-                        event={selectedEvent}
+                {selectedEvent && (
+                    <SessionDetailSheet
+                        session={sessionView}
+                        onClose={() => setShowSheet(false)}
+                        className={selectedEvent.title}
+                        classTime={toClassTimeRange(selectedEvent.start, selectedEvent.end)}
+                        room={selectedEvent.room}
+                        originalRoom={selectedEvent.original_room}
+                        instructorName={selectedEvent.instructor_name}
+                        originalInstructorName={selectedEvent.original_instructor_name}
+                        classId={selectedEvent.class_id}
                         facilityId={activeFacilityId}
-                        onSuccess={handleModalSuccess}
+                        classEvents={[]}
+                        facilityEvent={selectedEvent}
+                        onMutate={() => void mutate()}
+                        onUndo={handleCancellationAction}
+                        programName={selectedEvent.program_name}
+                        showActiveBadge={showActiveBadge}
+                        hideRescheduledBadge
+                        cancellationActionLabel={cancellationActionLabel}
+                        disableModifyActions={disableModifyActions}
+                        onReschedule={handleRescheduleClick}
+                        onTakeAttendance={
+                            past &&
+                            !selectedEvent.is_cancelled &&
+                            selectedEvent.class_status !== SelectedClassStatus.Completed
+                                ? handleTakeAttendance
+                                : undefined
+                        }
+                        onViewClassDetails={handleViewClassDetails}
                     />
-                </>
-            )}
-        </div>
+                )}
+
+                {selectedEvent && (
+                    <>
+                        <RescheduleEventModal
+                            open={showReschedule}
+                            onOpenChange={setShowReschedule}
+                            event={selectedEvent}
+                            onSingleSession={() => {
+                                setShowReschedule(false);
+                                setShowRescheduleSingle(true);
+                            }}
+                            onSeriesReschedule={() => {
+                                setShowReschedule(false);
+                                setShowRescheduleSeries(true);
+                            }}
+                        />
+                        <RescheduleSessionModal
+                            open={showRescheduleSingle}
+                            onOpenChange={setShowRescheduleSingle}
+                            event={selectedEvent}
+                            rooms={rooms}
+                            onSuccess={handleModalSuccess}
+                        />
+                        <RescheduleSeriesModal
+                            open={showRescheduleSeries}
+                            onOpenChange={setShowRescheduleSeries}
+                            event={selectedEvent}
+                            rooms={rooms}
+                            onSuccess={handleModalSuccess}
+                        />
+                        <RestoreEventModal
+                            open={showRestore}
+                            onOpenChange={setShowRestore}
+                            event={selectedEvent}
+                            onSuccess={handleModalSuccess}
+                        />
+                    </>
+                )}
+            </div>
         </div>
     );
 }

--- a/frontend/src/pages/class-detail/ScheduleTab.tsx
+++ b/frontend/src/pages/class-detail/ScheduleTab.tsx
@@ -13,7 +13,7 @@ import {
     formatClassTimeRange
 } from '@/lib/formatters';
 import { cn } from '@/lib/utils';
-import { SessionDetailSheet } from './SessionDetailSheet';
+import { SessionDetailSheet } from '@/components/schedule/SessionDetailSheet';
 import {
     buildRescheduleMaps,
     buildRoomOverrideMap,

--- a/frontend/src/pages/class-detail/SessionsTab.tsx
+++ b/frontend/src/pages/class-detail/SessionsTab.tsx
@@ -33,7 +33,7 @@ import {
     ChangeInstructorSession
 } from './ChangeInstructorModal';
 import { ChangeRoomModal, ChangeRoomSession } from './ChangeRoomModal';
-import { SessionDetailSheet } from './SessionDetailSheet';
+import { SessionDetailSheet } from '@/components/schedule/SessionDetailSheet';
 import { formatClassTimeRange } from '@/lib/formatters';
 import {
     buildRescheduleMaps,


### PR DESCRIPTION
## Pre-Submission PR Checklist

- [x] No debug/console/fmt.Println statements
- [x] Unnecessary development comments removed
- [x] All acceptance criteria verified
- [x] Functions according to **ticket specifications**
- [x] Tested manually where applicable
- [x] Branch rebased with latest main
- [x] No business logic exists within the database layer

## Description of the change

Schedule popout logic was consolidated between the Schedule page and the Classes Detail page. Removes duplicated logic and now the code is shared between both pages.

NOTE: Didn't touch any modals here, left as is. 

- **Related issues**: N/A Refactor

## Screenshot(s)

Schedule Page:

<img width="1187" height="919" alt="image" src="https://github.com/user-attachments/assets/088b1633-5775-4840-a915-0434bf83a959" />

Class Details Page:
<img width="1034" height="928" alt="image" src="https://github.com/user-attachments/assets/cf20ad23-4015-4535-a79a-38d4827bb358" />