### PR TITLE
fix: destructive modal close behavior

### DIFF
--- a/frontend/src/components/residents/BulkActionDialogs.tsx
+++ b/frontend/src/components/residents/BulkActionDialogs.tsx
@@ -150,6 +150,7 @@ export function BulkResetPasswordDialog({
             description={`Generate new temporary passwords for ${users.length} selected ${cfg.singular}${users.length > 1 ? 's' : ''}`}
             className="max-w-2xl"
             titleClassName="text-foreground"
+            preventOutsideClose
         >
             {!completed ? (
                 <>
@@ -327,6 +328,7 @@ export function BulkDeactivateDialog({
             title="Deactivate Residents"
             description={`Deactivate ${residents.length} selected resident${residents.length > 1 ? 's' : ''}`}
             titleClassName="text-foreground"
+            preventOutsideClose
         >
             <TonedPanel tone="orange">
                 <div className="flex items-start gap-3">
@@ -472,6 +474,7 @@ export function BulkDeleteDialog({
             title={cfg.title}
             description={`Permanently delete ${users.length} selected ${cfg.singular}${users.length > 1 ? 's' : ''}`}
             titleClassName="text-foreground"
+            preventOutsideClose
         >
             <TonedPanel tone="red">
                 <div className="flex items-start gap-3">

--- a/frontend/src/components/residents/ResidentDialogs.tsx
+++ b/frontend/src/components/residents/ResidentDialogs.tsx
@@ -341,6 +341,7 @@ export function DeactivateDialog({
             title="Deactivate Account"
             description={`You are about to deactivate ${resident.name_first} ${resident.name_last}'s account.`}
             titleClassName="text-foreground"
+            preventOutsideClose
         >
             <div className="py-4 space-y-4">
                 <ul className="space-y-2 text-sm text-gray-700">
@@ -466,6 +467,7 @@ export function DeleteDialog({
             title="Delete Resident"
             description={`Are you sure you want to delete ${resident.name_first} ${resident.name_last}?`}
             titleClassName="text-foreground"
+            preventOutsideClose
         >
             <div className="py-4 space-y-4">
                 <p className="text-sm text-red-600 font-medium">
@@ -583,6 +585,7 @@ export function TransferDialog({
             description={`Move ${resident.name_last}, ${resident.name_first} to a different facility`}
             className="max-w-2xl"
             titleClassName="text-foreground"
+            preventOutsideClose
         >
             <div className="space-y-6 py-4">
                 <div className="space-y-3">

--- a/frontend/src/pages/class-detail/DeleteClassModal.tsx
+++ b/frontend/src/pages/class-detail/DeleteClassModal.tsx
@@ -50,6 +50,7 @@ export function DeleteClassModal({
                     This action cannot be undone.
                 </>
             }
+            preventOutsideClose
         >
             <TonedPanel tone="red" className="my-4">
                 <div className="flex gap-3">


### PR DESCRIPTION
## Pre-Submission PR Checklist

- [x] No debug/console/fmt.Println statements
- [x] Unnecessary development comments removed
- [x] All acceptance criteria verified
- [x] Functions according to **ticket specifications**
- [x] Tested manually where applicable
- [x] Branch rebased with latest main
- [x] No business logic exists within the database layer

## Description of the change
Fixes modal escape behavior on destructive actions like bulk user actions, and user transfers. Users can now only exit the modal through the x button, cancel, and escape key. 

 - BulkActionDialogs.tsx — BulkResetPassword (L150), BulkDeactivate (L328), BulkDelete (L474)
 - ResidentDialogs.tsx — Deactivate (L344), Delete (L470), Transfer (L589)
 - DeleteClassModal.tsx (L50)



- **Related issues**: https://app.asana.com/1/1201607307149189/project/1209460078641109/task/1215131538607872?focus=true
