### PR TITLE
fix: improve CannotArchive modal styling to match design intent

### DIFF
--- a/frontend/src/components/programs/ProgramDialogs.tsx
+++ b/frontend/src/components/programs/ProgramDialogs.tsx
@@ -137,7 +137,7 @@ export function CannotArchiveDialog({
                 <Button
                     variant="outline"
                     onClick={() => onOpenChange(false)}
-                    className="border-gray-300 bg-accent text-accent-foreground"
+                    className="border-gray-300"
                 >
                     Close
                 </Button>

--- a/frontend/src/components/programs/ProgramDialogs.tsx
+++ b/frontend/src/components/programs/ProgramDialogs.tsx
@@ -108,6 +108,8 @@ export function CannotArchiveDialog({
             open={open}
             onOpenChange={onOpenChange}
             title={`Cannot Archive ${programName}`}
+            titleClassName="text-3xl"
+            closeButtonClassName="opacity-100 text-gray-500"
         >
             <div className="flex flex-col gap-4 mt-2">
                 <p className="text-sm text-gray-600">
@@ -135,7 +137,7 @@ export function CannotArchiveDialog({
                 <Button
                     variant="outline"
                     onClick={() => onOpenChange(false)}
-                    className="border-gray-300"
+                    className="border-gray-300 bg-accent text-accent-foreground"
                 >
                     Close
                 </Button>

--- a/frontend/src/components/shared/FormModal.tsx
+++ b/frontend/src/components/shared/FormModal.tsx
@@ -21,6 +21,8 @@ interface FormModalProps {
     descriptionClassName?: string;
     /** Extra classes for the DialogHeader wrapper (use when overriding DialogContent padding). */
     headerClassName?: string;
+    /** Extra classes for the close (X) button. */
+    closeButtonClassName?: string;
     preventAutoFocus?: boolean;
     /** Prevent the dialog from closing when the user clicks outside. */
     preventOutsideClose?: boolean;
@@ -36,6 +38,7 @@ export function FormModal({
     titleClassName,
     descriptionClassName,
     headerClassName,
+    closeButtonClassName,
     preventAutoFocus,
     preventOutsideClose
 }: FormModalProps) {
@@ -43,6 +46,7 @@ export function FormModal({
         <Dialog open={open} onOpenChange={onOpenChange}>
             <DialogContent
                 className={className}
+                closeButtonClassName={closeButtonClassName}
                 onOpenAutoFocus={preventAutoFocus ? (e) => e.preventDefault() : undefined}
                 onPointerDownOutside={preventOutsideClose ? (e) => e.preventDefault() : undefined}
             >

--- a/frontend/src/components/ui/dialog.tsx
+++ b/frontend/src/components/ui/dialog.tsx
@@ -48,8 +48,8 @@ DialogOverlay.displayName = DialogPrimitive.Overlay.displayName;
 
 const DialogContent = React.forwardRef<
   React.ElementRef<typeof DialogPrimitive.Content>,
-  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Content>
->(({ className, children, ...props }, ref) => (
+  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Content> & { closeButtonClassName?: string }
+>(({ className, closeButtonClassName, children, ...props }, ref) => (
   <DialogPortal data-slot="dialog-portal">
     <DialogOverlay />
     <DialogPrimitive.Content
@@ -62,7 +62,7 @@ const DialogContent = React.forwardRef<
       {...props}
     >
       {children}
-      <DialogPrimitive.Close className="ring-offset-background focus-visible:ring-ring data-[state=open]:bg-accent data-[state=open]:text-muted-foreground absolute top-4 right-4 rounded-xs opacity-70 transition-opacity hover:opacity-100 focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none disabled:pointer-events-none [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4">
+      <DialogPrimitive.Close className={cn("ring-offset-background focus-visible:ring-ring data-[state=open]:bg-accent data-[state=open]:text-muted-foreground absolute top-4 right-4 rounded-xs opacity-70 transition-opacity hover:opacity-100 focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none disabled:pointer-events-none [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4", closeButtonClassName)}>
         <XIcon />
         <span className="sr-only">Close</span>
       </DialogPrimitive.Close>


### PR DESCRIPTION
## Pre-Submission PR Checklist

- [x] No debug/console/fmt.Println statements
- [x] Unnecessary development comments removed
- [x] All acceptance criteria verified
- [x] Functions according to **ticket specifications**
- [x] Tested manually where applicable
- [ ] Branch rebased with latest main
- [x] No business logic exists within the database layer

## Description of the change

Improves the styling of the `CannotArchiveDialog` modal to better match the intended design. The modal already had all the correct functionality (pre-check, facility list, messaging) — this PR only adjusts visual presentation.

- Increases modal title size (`text-3xl`)
- Makes the X close button (top-right) always visible (grey) rather than fading in on hover only
- Adds `closeButtonClassName` prop to `FormModal` and `DialogContent` to allow per-modal styling of the X close button without affecting all dialogs globally
- Bottom Close button styling kept consistent with Cancel buttons used in other modals (per review feedback)

- **Related issues**: https://app.asana.com/1/1201607307149189/project/1209460078641109/task/1213752572073392?focus=true

## Screenshot(s)

<img width="1431" height="752" alt="image" src="https://github.com/user-attachments/assets/8d9a7dfe-0de2-4fc3-8692-598db8200e45" />

## Additional context

The `closeButtonClassName` prop added to `FormModal` and `DialogContent` is opt-in and has no effect on any existing modals — defaults are unchanged.
