### PR TITLE
feat: add Show 10 more link to Sessions Tab per ticket ID 622

### DIFF
--- a/frontend/src/pages/class-detail/SessionsTab.tsx
+++ b/frontend/src/pages/class-detail/SessionsTab.tsx
@@ -62,6 +62,9 @@ export function SessionsTab({ cls, onClassMutate }: SessionsTabProps) {
         ChangeRoomSession[]
     >([]);
     const [showAllPast, setShowAllPast] = useState(false);
+    const [upcomingDisplayCount, setUpcomingDisplayCount] = useState(
+        UPCOMING_DISPLAY_LIMIT
+    );
     const [selectedSession, setSelectedSession] =
         useState<SessionDisplay | null>(null);
 
@@ -126,6 +129,7 @@ export function SessionsTab({ cls, onClassMutate }: SessionsTabProps) {
     const handleStatusChange = (newStatus: StatusFilter) => {
         setStatusFilter(newStatus);
         setSelectedDates(new Set());
+        setUpcomingDisplayCount(UPCOMING_DISPLAY_LIMIT);
         if (newStatus === 'upcoming') {
             setTimeFilter('all');
         }
@@ -134,6 +138,7 @@ export function SessionsTab({ cls, onClassMutate }: SessionsTabProps) {
     const handleTimeChange = (newTime: TimeFilter) => {
         setTimeFilter(newTime);
         setSelectedDates(new Set());
+        setUpcomingDisplayCount(UPCOMING_DISPLAY_LIMIT);
     };
 
     const toggleSession = (date: string) => {
@@ -177,7 +182,8 @@ export function SessionsTab({ cls, onClassMutate }: SessionsTabProps) {
         allSessions,
         statusFilter,
         timeFilter,
-        showAllPast
+        showAllPast,
+        upcomingDisplayCount
     });
 
     const refreshData = async () => {
@@ -228,7 +234,8 @@ export function SessionsTab({ cls, onClassMutate }: SessionsTabProps) {
     };
 
     const handleUndoCancel = async (session: SessionDisplay) => {
-        const overrideId = session.rescheduleOverrideId ?? session.instance.override_id;
+        const overrideId =
+            session.rescheduleOverrideId ?? session.instance.override_id;
         if (!overrideId) return;
         const resp = await API.post(
             `program-classes/${cls.id}/events/${overrideId}/uncancel`,
@@ -242,7 +249,11 @@ export function SessionsTab({ cls, onClassMutate }: SessionsTabProps) {
 
     const renderSessionRow = (session: SessionDisplay) => (
         <SessionRow
-            key={session.instance.date + '-' + (session.instance.event_id ?? session.instance.id)}
+            key={
+                session.instance.date +
+                '-' +
+                (session.instance.event_id ?? session.instance.id)
+            }
             session={session}
             selected={selectedDates.has(session.instance.date)}
             onToggle={() => toggleSession(session.instance.date)}
@@ -359,13 +370,9 @@ export function SessionsTab({ cls, onClassMutate }: SessionsTabProps) {
                                             Upcoming Sessions
                                         </h4>
                                         <p className="text-sm text-gray-600 mt-0.5">
-                                            Next{' '}
-                                            {Math.min(
-                                                upcomingSessions.length,
-                                                UPCOMING_DISPLAY_LIMIT
-                                            )}{' '}
+                                            Next {displayedUpcoming.length}{' '}
                                             scheduled{' '}
-                                            {upcomingSessions.length === 1
+                                            {displayedUpcoming.length === 1
                                                 ? 'session'
                                                 : 'sessions'}
                                         </p>
@@ -373,14 +380,32 @@ export function SessionsTab({ cls, onClassMutate }: SessionsTabProps) {
                                     {upcomingSessions.length >
                                         UPCOMING_DISPLAY_LIMIT && (
                                         <span className="text-xs text-gray-500">
-                                            Showing next {UPCOMING_DISPLAY_LIMIT}{' '}
-                                            of {upcomingSessions.length} total
+                                            Showing next{' '}
+                                            {displayedUpcoming.length} of{' '}
+                                            {upcomingSessions.length} total
                                         </span>
                                     )}
                                 </div>
                                 <div className="space-y-2">
                                     {displayedUpcoming.map(renderSessionRow)}
                                 </div>
+                                {upcomingSessions.length >
+                                    displayedUpcoming.length && (
+                                    <div className="text-sm text-gray-500 text-center mt-2">
+                                        <button
+                                            onClick={() =>
+                                                setUpcomingDisplayCount(
+                                                    (count) =>
+                                                        count +
+                                                        UPCOMING_DISPLAY_LIMIT
+                                                )
+                                            }
+                                            className="text-brand hover:text-brand-dark underline"
+                                        >
+                                            Show {UPCOMING_DISPLAY_LIMIT} more
+                                        </button>
+                                    </div>
+                                )}
                             </div>
                         )}
                     </div>
@@ -449,8 +474,7 @@ export function SessionsTab({ cls, onClassMutate }: SessionsTabProps) {
                             date: s.instance.date,
                             dateObj: s.dateObj,
                             dayName: s.dayName,
-                            eventId:
-                                s.instance.event_id ?? s.instance.id,
+                            eventId: s.instance.event_id ?? s.instance.id,
                             classTime: s.instance.class_time
                         }))
                     );
@@ -466,5 +490,3 @@ export function SessionsTab({ cls, onClassMutate }: SessionsTabProps) {
         </div>
     );
 }
-
-

--- a/frontend/src/pages/class-detail/SessionsTab.tsx
+++ b/frontend/src/pages/class-detail/SessionsTab.tsx
@@ -378,7 +378,7 @@ export function SessionsTab({ cls, onClassMutate }: SessionsTabProps) {
                                         </p>
                                     </div>
                                     {upcomingSessions.length >
-                                        UPCOMING_DISPLAY_LIMIT && (
+                                        displayedUpcoming.length && (
                                         <span className="text-xs text-gray-500">
                                             Showing next{' '}
                                             {displayedUpcoming.length} of{' '}

--- a/frontend/src/pages/class-detail/useSessionFilters.ts
+++ b/frontend/src/pages/class-detail/useSessionFilters.ts
@@ -1,7 +1,12 @@
 import { useMemo } from 'react';
 import type { SessionDisplay } from './session-utils';
 
-export type StatusFilter = 'all' | 'completed' | 'missing' | 'upcoming' | 'cancelled';
+export type StatusFilter =
+    | 'all'
+    | 'completed'
+    | 'missing'
+    | 'upcoming'
+    | 'cancelled';
 export type TimeFilter = 'week' | '2weeks' | 'month' | 'all';
 
 export const PAST_DISPLAY_LIMIT = 15;
@@ -26,6 +31,7 @@ interface UseSessionFiltersArgs {
     statusFilter: StatusFilter;
     timeFilter: TimeFilter;
     showAllPast: boolean;
+    upcomingDisplayCount: number;
 }
 
 interface UseSessionFiltersResult {
@@ -40,7 +46,8 @@ export function useSessionFilters({
     allSessions,
     statusFilter,
     timeFilter,
-    showAllPast
+    showAllPast,
+    upcomingDisplayCount
 }: UseSessionFiltersArgs): UseSessionFiltersResult {
     const filtered = useMemo(() => {
         let result = allSessions;
@@ -111,7 +118,7 @@ export function useSessionFilters({
         ? pastAndTodaySessions
         : pastAndTodaySessions.slice(0, PAST_DISPLAY_LIMIT);
 
-    const displayedUpcoming = upcomingSessions.slice(0, UPCOMING_DISPLAY_LIMIT);
+    const displayedUpcoming = upcomingSessions.slice(0, upcomingDisplayCount);
 
     return {
         filtered,


### PR DESCRIPTION
## Pre-Submission PR Checklist

- [X] No debug/console/fmt.Println statements
- [X] Unnecessary development comments removed
- [X] All acceptance criteria verified
- [X] Functions according to **ticket specifications**
- [X] Tested manually where applicable
- [X] Branch rebased with latest main
- [X] No business logic exists within the database layer

## Description of the change

Added a link to Show 10 more to the sessions tab per ticket 622. This required only frontend javascript/html/css development.

NOTE: For a future enhancement maybe add toggle ability to where we can show less? Didn't want to over complicate this so only worked on what this ticket called for. 

- **Related issues**: Link to related Asana ticket that this closes: [Add a "Show 10 more" sessions for upcoming sessions under the class details sessions tab](https://app.asana.com/1/1201607307149189/project/1209460078641109/task/1213823478161701?focus=true)

## Screenshot(s)

<img width="1405" height="842" alt="image" src="https://github.com/user-attachments/assets/9b219f38-1fef-4902-a4c0-ea4c9a205329" />