### PR TITLE
fix: room scoping issue and restore session wording

### DIFF
--- a/backend/src/handlers/classes_handler.go
+++ b/backend/src/handlers/classes_handler.go
@@ -205,7 +205,7 @@ func (srv *Server) handleUpdateClass(w http.ResponseWriter, r *http.Request, log
 		if class.InstructorID == nil || *class.InstructorID == 0 {
 			class.InstructorID = nil
 		} else {
-			instructorName, err := srv.Db.GetInstructorNameByID(*class.InstructorID, claims.FacilityID)
+			instructorName, err := srv.Db.GetInstructorNameByID(*class.InstructorID, existing.FacilityID)
 			if err != nil || instructorName == "" {
 				return newBadRequestServiceError(err, "invalid instructor selected")
 			}
@@ -219,16 +219,11 @@ func (srv *Server) handleUpdateClass(w http.ResponseWriter, r *http.Request, log
 	if enrolled > class.Capacity {
 		return writeJsonResponse(w, http.StatusBadRequest, "Cannot update class until unenrolling residents")
 	}
-	claims = r.Context().Value(ClaimsKey).(*Claims)
 	class.UpdateUserID = models.UintPtr(claims.UserID)
 
 	var conflictReq *models.ConflictCheckRequest
 	if len(class.Events) > 0 && class.Events[0].RoomID != nil {
-		if _, err := srv.Db.GetRoomByIDForFacility(*class.Events[0].RoomID, claims.FacilityID); err != nil {
-			return newDatabaseServiceError(err)
-		}
-		existing, err := srv.Db.GetClassByID(id)
-		if err != nil {
+		if _, err := srv.Db.GetRoomByIDForFacility(*class.Events[0].RoomID, existing.FacilityID); err != nil {
 			return newDatabaseServiceError(err)
 		}
 		existingRoomID := uint(0)
@@ -237,7 +232,7 @@ func (srv *Server) handleUpdateClass(w http.ResponseWriter, r *http.Request, log
 		}
 		if *class.Events[0].RoomID != existingRoomID {
 			conflictReq = &models.ConflictCheckRequest{
-				FacilityID:     claims.FacilityID,
+				FacilityID:     existing.FacilityID,
 				RoomID:         *class.Events[0].RoomID,
 				RecurrenceRule: existing.Events[0].RecurrenceRule,
 				Duration:       existing.Events[0].Duration,

--- a/backend/src/handlers/facilities_handler.go
+++ b/backend/src/handlers/facilities_handler.go
@@ -137,6 +137,11 @@ func (srv *Server) handleGetRooms(w http.ResponseWriter, r *http.Request, log sL
 
 func (srv *Server) handleCreateRoom(w http.ResponseWriter, r *http.Request, log sLog) error {
 	facilityID := srv.getFacilityID(r)
+	if queryParam := r.URL.Query().Get("facility_id"); queryParam != "" {
+		if parsed, err := strconv.Atoi(queryParam); err == nil {
+			facilityID = uint(parsed)
+		}
+	}
 	var room models.Room
 	if err := json.NewDecoder(r.Body).Decode(&room); err != nil {
 		return newJSONReqBodyServiceError(err)

--- a/frontend/src/components/schedule/RestoreEventModal.tsx
+++ b/frontend/src/components/schedule/RestoreEventModal.tsx
@@ -62,7 +62,11 @@ export function RestoreEventModal({
         <ConfirmDialog
             open={open}
             onOpenChange={onOpenChange}
-            title={isSeries ? 'Restore Future Sessions' : 'Restore Event'}
+            title={
+                isSeries
+                    ? 'Restore This & All Future Sessions'
+                    : 'Restore Event'
+            }
             description={
                 isSeries
                     ? `This will restore all cancelled sessions from ${dateStr} onwards.`

--- a/frontend/src/components/schedule/SessionDetailSheet.tsx
+++ b/frontend/src/components/schedule/SessionDetailSheet.tsx
@@ -270,6 +270,7 @@ export function SessionDetailSheet({
                     open={showRescheduleModal}
                     onClose={() => setShowRescheduleModal(false)}
                     classId={classId}
+                    facilityId={facilityId}
                     eventId={eventId}
                     originalDate={instance.date}
                     dateLabel={shortDateLabel}

--- a/frontend/src/loaders/routeLoaders.ts
+++ b/frontend/src/loaders/routeLoaders.ts
@@ -190,10 +190,6 @@ export const getProgramTitle: LoaderFunction = async ({
     let rooms: Room[] = [];
     let breadcrumbs: BreadcrumbItem[] | undefined;
 
-    const roomsResp = await API.get('rooms');
-    if (roomsResp.success) {
-        rooms = roomsResp.data as Room[];
-    }
     if (id) {
         const resp = await API.get(`programs/${id}`);
         if (resp.success) {
@@ -211,6 +207,12 @@ export const getProgramTitle: LoaderFunction = async ({
         } else {
             return redirectOnError(classResp);
         }
+    }
+
+    const roomsUrl = cls ? `rooms?facility_id=${cls.facility_id}` : 'rooms';
+    const roomsResp = await API.get(roomsUrl);
+    if (roomsResp.success) {
+        rooms = roomsResp.data as Room[];
     }
 
     const url = new URL(request.url);

--- a/frontend/src/pages/Schedule.tsx
+++ b/frontend/src/pages/Schedule.tsx
@@ -355,7 +355,7 @@ export default function Schedule() {
     const past = isPastEvent(selectedEvent);
     const cancellationActionLabel = selectedEvent?.is_override
         ? 'Undo Cancellation'
-        : 'Restore Future Sessions';
+        : 'Restore This & All Future Sessions';
     const disableModifyActions = past || !canUpdateEvent();
     const showActiveBadge =
         !!selectedEvent &&

--- a/frontend/src/pages/class-detail/ChangeRoomModal.tsx
+++ b/frontend/src/pages/class-detail/ChangeRoomModal.tsx
@@ -11,6 +11,7 @@ interface ChangeRoomModalProps {
     open: boolean;
     onClose: () => void;
     classId: number;
+    facilityId: string;
     sessions: ChangeRoomSession[];
     onChanged: () => void;
     applyToFuture?: boolean;
@@ -29,7 +30,7 @@ const ROOM_REASON_OPTIONS = [
 
 export function ChangeRoomModal(props: ChangeRoomModalProps) {
     const { data: roomsResp } = useSWR<ServerResponseMany<Room>>(
-        props.open ? '/api/rooms' : null
+        props.open ? `/api/rooms?facility_id=${props.facilityId}` : null
     );
     const options = (roomsResp?.data ?? []).map((room) => ({
         id: room.id,

--- a/frontend/src/pages/class-detail/EditClassModal.tsx
+++ b/frontend/src/pages/class-detail/EditClassModal.tsx
@@ -248,8 +248,9 @@ export function EditClassModal({
     >(user ? `/api/users?role=${user.role}&per_page=100` : null);
     const instructors = instructorsResp?.data ?? [];
 
-    const { data: roomsResp, mutate: mutateRooms } =
-        useSWR<ServerResponseMany<Room>>('/api/rooms');
+    const { data: roomsResp, mutate: mutateRooms } = useSWR<
+        ServerResponseMany<Room>
+    >(`/api/rooms?facility_id=${cls.facility_id}`);
     const rooms = roomsResp?.data ?? [];
 
     const {
@@ -313,9 +314,12 @@ export function EditClassModal({
 
     async function handleAddRoom() {
         if (!newRoomName.trim()) return;
-        const resp = await API.post<Room, object>('rooms', {
-            name: newRoomName.trim()
-        });
+        const resp = await API.post<Room, object>(
+            `rooms?facility_id=${cls.facility_id}`,
+            {
+                name: newRoomName.trim()
+            }
+        );
         if (resp.success) {
             const created = resp.data as unknown as Room;
             await mutateRooms();

--- a/frontend/src/pages/class-detail/RescheduleSessionModal.tsx
+++ b/frontend/src/pages/class-detail/RescheduleSessionModal.tsx
@@ -26,6 +26,7 @@ interface RescheduleSessionModalProps {
     open: boolean;
     onClose: () => void;
     classId: number;
+    facilityId: string;
     eventId: number;
     originalDate: string;
     dateLabel: string;
@@ -41,6 +42,7 @@ export function RescheduleSessionModal({
     open,
     onClose,
     classId,
+    facilityId,
     eventId,
     originalDate,
     dateLabel,
@@ -60,7 +62,7 @@ export function RescheduleSessionModal({
     const [isSubmitting, setIsSubmitting] = useState(false);
 
     const { data: roomsResp } = useSWR<ServerResponseMany<Room>>(
-        open ? '/api/rooms' : null
+        open ? `/api/rooms?facility_id=${facilityId}` : null
     );
     const rooms = roomsResp?.data ?? [];
 

--- a/frontend/src/pages/class-detail/SessionsTabModals.tsx
+++ b/frontend/src/pages/class-detail/SessionsTabModals.tsx
@@ -103,6 +103,7 @@ export function SessionsTabModals({
                     open={!!rescheduleTarget}
                     onClose={onCloseReschedule}
                     classId={cls.id}
+                    facilityId={String(cls.facility_id)}
                     eventId={
                         rescheduleTarget.instance.event_id ??
                         rescheduleTarget.instance.id
@@ -161,6 +162,7 @@ export function SessionsTabModals({
                     open={showChangeRoom}
                     onClose={onCloseChangeRoom}
                     classId={cls.id}
+                    facilityId={String(cls.facility_id)}
                     sessions={changeRoomSessions}
                     onChanged={onRoomChanged}
                     showSessionsList

--- a/frontend/src/pages/programs/ClassManagementForm.tsx
+++ b/frontend/src/pages/programs/ClassManagementForm.tsx
@@ -179,7 +179,9 @@ export function ClassManagementFormInner({
     }, [resolvedFacilityId]);
 
     const { data: roomsResp } = useSWR<ServerResponseMany<Room>>(
-        rooms.length === 0 ? '/api/rooms' : null
+        rooms.length === 0 && resolvedFacilityId
+            ? `/api/rooms?facility_id=${resolvedFacilityId}`
+            : null
     );
 
     const {
@@ -377,9 +379,12 @@ export function ClassManagementFormInner({
 
     async function handleAddRoom() {
         if (!newRoomName.trim()) return;
-        const resp = await API.post<Room, object>('rooms', {
-            name: newRoomName.trim()
-        });
+        const resp = await API.post<Room, object>(
+            `rooms?facility_id=${resolvedFacilityId}`,
+            {
+                name: newRoomName.trim()
+            }
+        );
         if (resp.success) {
             const created = resp.data as unknown as Room;
             setRooms((prev) => [...prev, created]);


### PR DESCRIPTION
## Pre-Submission PR Checklist

- [x] No debug/console/fmt.Println statements
- [x] Unnecessary development comments removed
- [x] All acceptance criteria verified
- [x] Functions according to **ticket spexifications**
- [x] Tested manually where applicable
- [x] Branch rebased with latest main
- [x] No business logic exists within the database layer

## Description of the change
Scopes room selection to the class's facility rather than the acting admin's session facility, so a dept/super-admin working cross-facility no longer see's or saves rooms from the wrong facility. Also fixes a backend validation that rejected valid saves due to class facility id vs session facility ID and renames the restore action (original ticket) 

- Frontend: room dropdowns now pass ?facility_id=<class facility> in edit-class, change-room, reschedule, create-class flows, the route loader,
  and the "+ Add Room" create call.
  - Backend: handleUpdateClass validates room and instructor against existing.FacilityID (the class), not claims.FacilityID; handleCreateRoom
  honors an optional facility_id query param.
  - Wording: "Restore Future Sessions" → "Restore This & All Future Sessions".

- **Related issues**: https://app.asana.com/1/1201607307149189/project/1209460078641109/task/1214430813078155?focus=true

## Screenshot(s)
<img width="960" height="999" alt="image" src="https://github.com/user-attachments/assets/991bba37-1e18-420c-8b54-bb256d128144" />



## Additional context

Since this originally would have been a super small change, I just added the room scoping fix into this PR because it was causing issues when I was trying to test things. 
