### PR TITLE
fix: restore agenda scroll and cap to one week per ticket ID-643

### DIFF
--- a/frontend/src/pages/Schedule.tsx
+++ b/frontend/src/pages/Schedule.tsx
@@ -347,7 +347,7 @@ export default function Schedule() {
         return (
             <div className="space-y-6">
                 <Skeleton className="h-8 w-64" />
-                <Skeleton className="h-[600px]" />
+                <Skeleton className="h-150" />
             </div>
         );
     }
@@ -364,7 +364,7 @@ export default function Schedule() {
 
     return (
         <div className="bg-[#E7EAED] dark:bg-[#0a0a0a] min-h-screen overflow-x-hidden">
-            <div className="max-w-[1400px] mx-auto px-8 py-8 space-y-6">
+            <div className="max-w-350 mx-auto px-8 py-8 space-y-6">
                 {/* Page Header */}
                 <div className="flex items-center justify-between">
                     <div>
@@ -489,6 +489,7 @@ export default function Schedule() {
                         onSelectEvent={handleSelectEvent}
                         eventPropGetter={eventStyleGetter}
                         views={['month', 'week', 'day', 'agenda']}
+                        length={6}
                         style={{ height: '100%' }}
                         min={new Date(0, 0, 0, 0, 0, 0, 0)}
                         max={new Date(0, 0, 0, 23, 59, 59, 999)}

--- a/frontend/src/styles/globals.css
+++ b/frontend/src/styles/globals.css
@@ -465,11 +465,16 @@ input[type='checkbox']:focus {
 }
 
 .unlocked-calendar .rbc-month-view,
-.unlocked-calendar .rbc-time-view,
-.unlocked-calendar .rbc-agenda-view {
+.unlocked-calendar .rbc-time-view {
     border: 1px solid #e5e7eb;
     border-radius: 8px;
     overflow: hidden;
+}
+
+.unlocked-calendar .rbc-agenda-view {
+    border: 1px solid #e5e7eb;
+    border-radius: 8px;
+    overflow: auto;
 }
 
 .unlocked-calendar .rbc-time-slot {


### PR DESCRIPTION
## Summary
- Restored react-big-calendar agenda scrolling — our own `globals.css` rule was forcing
  `overflow: hidden` on `.rbc-agenda-view`, overriding RBC's built-in scroll container.
  Fixed by splitting the rule so month/week/day views keep `overflow: hidden` and the
  agenda gets `overflow: auto`.
- Capped the agenda to one week (7 days rolling from focused date) by adding `length={6}`
  to `<Calendar>`. RBC's range is inclusive so `length + 1 = 7` day-rows are shown.
  Per team decision (Carolina: "if we can scroll → max the agenda to one week").
- Replaced two arbitrary Tailwind bracket values in touched file with Tailwind v4 canonical
  equivalents (`h-[600px]` → `h-150`, `max-w-[1400px]` → `max-w-350`). These are now
  flagged by IntelliSense because Tailwind v4 expanded the default spacing scale to cover
  all 4px-grid multiples natively — see the [v4 upgrade guide](https://tailwindcss.com/docs/upgrade-guide)
  for details. Follows the same cleanup pattern as commit `0cf8e2fd`.

## Test plan
- [ ] Open Schedule page → switch to Agenda view
- [ ] Confirm agenda shows ~7 days (not 30) from the focused date
- [ ] Confirm agenda scrolls when events exceed the 700px container height
- [ ] Confirm Back/Next moves the window forward/back correctly
- [ ] Confirm Month, Week, and Day views are unregressed
- [ ] Confirm loading skeleton and page max-width are visually unchanged

```

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1214434555944306