### PR TITLE
fix: remove facility toggle adjust lingering facility toggle 

### DIFF
--- a/backend/src/database/programs.go
+++ b/backend/src/database/programs.go
@@ -626,7 +626,7 @@ func (db *DB) GetProgramsOverviewTable(args *models.QueryContext, timeFilter int
 
 	baseQuery := db.WithContext(args.Ctx).Model(&models.Program{})
 
-	facilityScoped := adminRole == models.FacilityAdmin || adminRole == models.SystemAdmin
+	facilityScoped := adminRole == models.FacilityAdmin
 	var selectFields string
 	if facilityScoped {
 		selectFields = `

--- a/backend/src/database/users.go
+++ b/backend/src/database/users.go
@@ -47,7 +47,9 @@ func (db *DB) GetCurrentUsers(args *models.QueryContext, role string) ([]models.
 			tx = tx.Where("facility_id = ?", args.FacilityID)
 		}
 	default:
-		tx = tx.Where("facility_id = ?", args.FacilityID)
+		if args.FacilityID > 0 {
+			tx = tx.Where("facility_id = ?", args.FacilityID)
+		}
 	}
 	if args.Search != "" {
 		tx = fuzzySearchUsers(tx, args)

--- a/backend/src/handlers/auth.go
+++ b/backend/src/handlers/auth.go
@@ -286,46 +286,23 @@ func (srv *Server) validateOrySession(r *http.Request) (*Claims, bool, error) {
 				}
 				fields["user"] = user
 				log.WithFields(fields).Trace("found user from ory session")
-				facilityId, ok := traits["facility_id"].(float64)
-				if !ok {
-					facilityId = float64(user.FacilityID)
-				}
-				if uint(facilityId) != user.FacilityID && !slices.Contains([]models.UserRole{models.DepartmentAdmin, models.SystemAdmin}, user.Role) {
-					return nil, hasCookie, errors.New("user is not allowed to switch facilities")
-				}
 
 				passReset, ok := traits["password_reset"].(bool)
 				if !ok {
 					passReset = true
 				}
-				facilityName := user.Facility.Name
-				tz := user.Facility.Timezone
-				if user.FacilityID != uint(facilityId) && slices.Contains([]models.UserRole{models.DepartmentAdmin, models.SystemAdmin}, user.Role) {
-					var nameTz struct {
-						Name     string `json:"name"`
-						Timezone string `json:"timezone"`
-					}
-					if err := srv.Db.Model(&models.Facility{}).
-						Select("name, timezone").
-						Where("id = ?", facilityId).
-						Find(&nameTz).Error; err != nil {
-						return nil, hasCookie, err
-					}
-					facilityName = nameTz.Name
-					tz = nameTz.Timezone
-				}
 				claims := &Claims{
 					Username:      user.Username,
 					Email:         user.Email,
 					UserID:        user.ID,
-					FacilityID:    uint(facilityId),
-					FacilityName:  facilityName,
+					FacilityID:    user.FacilityID,
+					FacilityName:  user.Facility.Name,
 					PasswordReset: passReset,
 					KratosID:      kratosID,
 					Role:          user.Role,
 					FeatureAccess: srv.features,
 					SessionID:     sessionID,
-					TimeZone:      tz,
+					TimeZone:      user.Facility.Timezone,
 				}
 				traitsRole, ok := traits["role"].(string)
 				if !ok || string(user.Role) != traitsRole {

--- a/backend/src/handlers/class_events.go
+++ b/backend/src/handlers/class_events.go
@@ -37,7 +37,7 @@ func (srv *Server) handleGetAdminCalendar(w http.ResponseWriter, r *http.Request
 	if err != nil {
 		return newInvalidQueryParamServiceError(err, "start_dt")
 	}
-	args := srv.getQueryContext(r)
+	args := srv.facilityScopedQueryContext(r)
 
 	id := r.URL.Query().Get("class_id")
 	var classID int

--- a/backend/src/handlers/classes_handler.go
+++ b/backend/src/handlers/classes_handler.go
@@ -16,17 +16,19 @@ func (srv *Server) registerClassesRoutes() []routeDef {
 	resolver := FacilityAdminResolver("program_classes", "class_id")
 	validateFacility := func(check string) RouteResolver {
 		return func(tx *database.DB, r *http.Request) bool {
-			claims := r.Context().Value(ClaimsKey).(*Claims)
-			if claims.canSwitchFacility() {
-				if check == "" {
-					return true
-				}
+			// Facility comes from getQueryContext: the ?facility_id= param for
+			// switch-capable admins, else their home facility. A statewide admin
+			// (facilityID == 0) is allowed for facility-agnostic reads but must
+			// target a specific facility for facility-scoped operations.
+			facilityID := srv.getQueryContext(r).FacilityID
+			if facilityID == 0 {
+				return check == ""
 			}
 			var count int64
 			return tx.WithContext(r.Context()).
 				Table("programs").
 				Where(fmt.Sprintf("id = ? AND %s id IN (SELECT program_id FROM facilities_programs WHERE facility_id = ?)", check),
-					r.PathValue("program_id"), claims.FacilityID).
+					r.PathValue("program_id"), facilityID).
 				Count(&count).Error == nil && count > 0
 		}
 	}
@@ -125,15 +127,18 @@ func (srv *Server) handleCreateClass(w http.ResponseWriter, r *http.Request, log
 		return newJSONReqBodyServiceError(err)
 	}
 
-	claims := r.Context().Value(ClaimsKey).(*Claims)
-	class.FacilityID = claims.FacilityID
+	facilityID, err := srv.requireFacilityID(r)
+	if err != nil {
+		return err
+	}
+	class.FacilityID = facilityID
 	class.ProgramID = uint(id)
 
 	if class.InstructorID == nil || *class.InstructorID == 0 {
 		return newBadRequestServiceError(nil, "instructor selection is required")
 	}
 
-	instructorName, err := srv.Db.GetInstructorNameByID(*class.InstructorID, claims.FacilityID)
+	instructorName, err := srv.Db.GetInstructorNameByID(*class.InstructorID, class.FacilityID)
 	if err != nil || instructorName == "" {
 		return newBadRequestServiceError(err, "invalid instructor selected")
 	}
@@ -143,11 +148,11 @@ func (srv *Server) handleCreateClass(w http.ResponseWriter, r *http.Request, log
 
 	var conflictReq *models.ConflictCheckRequest
 	if len(class.Events) > 0 && class.Events[0].RoomID != nil {
-		if _, err := srv.Db.GetRoomByIDForFacility(*class.Events[0].RoomID, claims.FacilityID); err != nil {
+		if _, err := srv.Db.GetRoomByIDForFacility(*class.Events[0].RoomID, class.FacilityID); err != nil {
 			return newDatabaseServiceError(err)
 		}
 		conflictReq = &models.ConflictCheckRequest{
-			FacilityID:     claims.FacilityID,
+			FacilityID:     class.FacilityID,
 			RoomID:         *class.Events[0].RoomID,
 			RecurrenceRule: class.Events[0].RecurrenceRule,
 			Duration:       class.Events[0].Duration,

--- a/backend/src/handlers/facilities_handler.go
+++ b/backend/src/handlers/facilities_handler.go
@@ -15,7 +15,6 @@ func (srv *Server) registerFacilitiesRoutes() []routeDef {
 		newDeptAdminRoute("POST /api/facilities", srv.handleCreateFacility),
 		newSystemAdminRoute("DELETE /api/facilities/{id}", srv.handleDeleteFacility),
 		newDeptAdminRoute("PATCH /api/facilities/{id}", srv.handleUpdateFacility),
-		newDeptAdminRoute("PUT /api/admin/facility-context/{id}", srv.handleChangeAdminFacility),
 		adminFeatureRoute("GET /api/rooms", srv.handleGetRooms, axx),
 		adminFeatureRoute("POST /api/rooms", srv.handleCreateRoom, axx),
 		adminValidatedFeatureRoute("GET /api/facilities/{facilityId}/instructors",
@@ -50,23 +49,6 @@ func (srv *Server) handleShowFacility(w http.ResponseWriter, r *http.Request, lo
 	}
 
 	return writeJsonResponse(w, http.StatusOK, facility)
-}
-
-func (srv *Server) handleChangeAdminFacility(w http.ResponseWriter, r *http.Request, log sLog) error {
-	id, err := strconv.Atoi(r.PathValue("id"))
-	if err != nil {
-		return newInvalidIdServiceError(err, "facility ID")
-	}
-	claims := r.Context().Value(ClaimsKey).(*Claims)
-	if !claims.canSwitchFacility() {
-		return newUnauthorizedServiceError()
-	}
-	claims.FacilityID = uint(id)
-	if err := srv.updateUserTraitsInKratos(claims); err != nil {
-		log.add("facility_id", id)
-		return newInternalServerServiceError(err, "error updating user traits in kratos")
-	}
-	return writeJsonResponse(w, http.StatusOK, "facility updated successfully")
 }
 
 func (srv *Server) handleCreateFacility(w http.ResponseWriter, r *http.Request, log sLog) error {
@@ -121,12 +103,7 @@ func (srv *Server) handleDeleteFacility(w http.ResponseWriter, r *http.Request, 
 }
 
 func (srv *Server) handleGetRooms(w http.ResponseWriter, r *http.Request, log sLog) error {
-	facilityID := srv.getFacilityID(r)
-	if queryParam := r.URL.Query().Get("facility_id"); queryParam != "" {
-		if parsed, err := strconv.Atoi(queryParam); err == nil {
-			facilityID = uint(parsed)
-		}
-	}
+	facilityID := srv.facilityScopedQueryContext(r).FacilityID
 	log.add("facility_id", facilityID)
 	rooms, err := srv.Db.GetRoomsForFacility(facilityID)
 	if err != nil {
@@ -136,11 +113,9 @@ func (srv *Server) handleGetRooms(w http.ResponseWriter, r *http.Request, log sL
 }
 
 func (srv *Server) handleCreateRoom(w http.ResponseWriter, r *http.Request, log sLog) error {
-	facilityID := srv.getFacilityID(r)
-	if queryParam := r.URL.Query().Get("facility_id"); queryParam != "" {
-		if parsed, err := strconv.Atoi(queryParam); err == nil {
-			facilityID = uint(parsed)
-		}
+	facilityID, err := srv.requireFacilityID(r)
+	if err != nil {
+		return err
 	}
 	var room models.Room
 	if err := json.NewDecoder(r.Body).Decode(&room); err != nil {

--- a/backend/src/handlers/helpful_links_handler.go
+++ b/backend/src/handlers/helpful_links_handler.go
@@ -42,7 +42,7 @@ func (srv *Server) changeSortOrder(w http.ResponseWriter, r *http.Request, log s
 }
 
 func (srv *Server) handleGetHelpfulLinks(w http.ResponseWriter, r *http.Request, log sLog) error {
-	args := srv.getQueryContext(r)
+	args := srv.facilityScopedQueryContext(r)
 	onlyVisible := r.URL.Query().Get("visibility") == "true"
 	if !userIsAdmin(r) {
 		onlyVisible = true

--- a/backend/src/handlers/libraries_handler.go
+++ b/backend/src/handlers/libraries_handler.go
@@ -38,7 +38,7 @@ func (srv *Server) registerLibraryRoutes() []routeDef {
 // all - true or false on whether or not to return all libraries without pagination
 // categories - the tag ids to filter the libraries by
 func (srv *Server) handleIndexLibraries(w http.ResponseWriter, r *http.Request, log sLog) error {
-	args := srv.getQueryContext(r)
+	args := srv.facilityScopedQueryContext(r)
 	showHidden := "visible"
 	if !userIsAdmin(r) && r.URL.Query().Get("visibility") == "hidden" {
 		return newUnauthorizedServiceError()
@@ -119,7 +119,7 @@ func (srv *Server) handleSearchOpenContent(w http.ResponseWriter, r *http.Reques
 	}
 	// if we are on a library viewer page, we want to search
 	// only the included library, so we omit title search
-	queryCtx := srv.getQueryContext(r)
+	queryCtx := srv.facilityScopedQueryContext(r)
 	if page == 1 && len(libraryIDs) == 0 {
 		titleSearch, err = srv.Db.OpenContentTitleSearch(&queryCtx)
 		if err != nil {
@@ -212,7 +212,7 @@ func (srv *Server) handleSearchOpenContent(w http.ResponseWriter, r *http.Reques
 }
 
 func (srv *Server) handleToggleLibraryVisibility(w http.ResponseWriter, r *http.Request, log sLog) error {
-	args := srv.getQueryContext(r)
+	args := srv.facilityScopedQueryContext(r)
 	id, err := strconv.Atoi(r.PathValue("id"))
 	if err != nil {
 		return newInvalidIdServiceError(err, "library id")

--- a/backend/src/handlers/open_content_activity_handler.go
+++ b/backend/src/handlers/open_content_activity_handler.go
@@ -25,7 +25,7 @@ func (srv *Server) handleGetTopFacilityOpenContent(w http.ResponseWriter, r *htt
 }
 
 func (srv *Server) handleGetTopUserOpenContent(w http.ResponseWriter, r *http.Request, log sLog) error {
-	args := srv.getQueryContext(r)
+	args := srv.facilityScopedQueryContext(r)
 	id, err := strconv.Atoi(r.PathValue("id"))
 	if err != nil {
 		return newInvalidIdServiceError(err, "user ID")

--- a/backend/src/handlers/open_content_handler.go
+++ b/backend/src/handlers/open_content_handler.go
@@ -35,7 +35,7 @@ func (srv *Server) handleIndexOpenContent(w http.ResponseWriter, r *http.Request
 }
 
 func (srv *Server) handleGetUserFavoriteOpenContent(w http.ResponseWriter, r *http.Request, log sLog) error {
-	args := srv.getQueryContext(r)
+	args := srv.facilityScopedQueryContext(r)
 	favorites, err := srv.Db.GetUserFavorites(&args)
 	if err != nil {
 		return newDatabaseServiceError(err)
@@ -44,7 +44,7 @@ func (srv *Server) handleGetUserFavoriteOpenContent(w http.ResponseWriter, r *ht
 }
 
 func (srv *Server) handleGetUserFavoriteOpenContentGroupings(w http.ResponseWriter, r *http.Request, log sLog) error {
-	args := srv.getQueryContext(r)
+	args := srv.facilityScopedQueryContext(r)
 	favorites, err := srv.Db.GetUserFavoriteGroupings(&args)
 	if err != nil {
 		return newDatabaseServiceError(err)

--- a/backend/src/handlers/provider_user_management.go
+++ b/backend/src/handlers/provider_user_management.go
@@ -86,7 +86,10 @@ func stripNonAlphaChars(str string, keepCharacter func(char rune) bool) string {
 // already in the correct format) and creates a new user in the database for each of them, as well as
 // creating a mapping for each user, and creating a login for each user in the provider
 func (srv *Server) handleImportProviderUsers(w http.ResponseWriter, r *http.Request, log sLog) error {
-	facilityId := srv.getFacilityID(r)
+	facilityId, err := srv.requireFacilityID(r)
+	if err != nil {
+		return err
+	}
 	providerId, err := strconv.Atoi(r.PathValue("id"))
 	if err != nil {
 		return newInvalidIdServiceError(err, "provider platform ID")

--- a/backend/src/handlers/user_handler.go
+++ b/backend/src/handlers/user_handler.go
@@ -53,7 +53,9 @@ func (srv *Server) registerUserRoutes() []routeDef {
 
 func (srv *Server) handleIndexUsers(w http.ResponseWriter, r *http.Request, log sLog) error {
 	role := r.URL.Query().Get("role")
-	args := srv.getQueryContext(r)
+	// Eligible/unmapped resident branches need a concrete facility, so default to
+	// home here; the statewide list branch resets to 0 below.
+	args := srv.facilityScopedQueryContext(r)
 	include := r.URL.Query()["include"]
 	var users []models.User
 	var err error
@@ -121,7 +123,7 @@ func (srv *Server) handleGetUserStats(w http.ResponseWriter, r *http.Request, lo
 
 func (srv *Server) handleGetUnmappedUsers(w http.ResponseWriter, r *http.Request, providerId string, log sLog) error {
 	log.add("subhandlerCall", "HandleGetUnmappedUsers")
-	args := srv.getQueryContext(r)
+	args := srv.facilityScopedQueryContext(r)
 	provID, err := strconv.Atoi(providerId)
 	if err != nil {
 		return newInvalidIdServiceError(err, "provider ID")
@@ -196,8 +198,11 @@ func (srv *Server) handleCreateUser(w http.ResponseWriter, r *http.Request, log 
 	if err != nil {
 		return newJSONReqBodyServiceError(err)
 	}
-	if reqForm.User.FacilityID == 0 {
+	if !claims.canSwitchFacility() {
+		// A facility admin can only create users in their own facility.
 		reqForm.User.FacilityID = claims.FacilityID
+	} else if reqForm.User.FacilityID == 0 {
+		return newBadRequestServiceError(nil, "facility selection is required")
 	}
 	invalidUser := validateUser(&reqForm.User)
 	if invalidUser != "" {
@@ -246,7 +251,7 @@ func (srv *Server) handleCreateUser(w http.ResponseWriter, r *http.Request, log 
 		if err := srv.Db.InsertUserAccountHistoryAction(r.Context(), accountCreation); err != nil {
 			return newCreateRequestServiceError(err)
 		}
-		facilityTransfer := models.NewUserAccountHistory(reqForm.User.ID, models.FacilityTransfer, &claims.UserID, nil, &claims.FacilityID)
+		facilityTransfer := models.NewUserAccountHistory(reqForm.User.ID, models.FacilityTransfer, &claims.UserID, nil, &reqForm.User.FacilityID)
 		if err := srv.Db.InsertUserAccountHistoryAction(r.Context(), facilityTransfer); err != nil {
 			return newCreateRequestServiceError(err)
 		}
@@ -716,8 +721,13 @@ func (srv *Server) handleBulkCreate(w http.ResponseWriter, r *http.Request, log 
 		return newBadRequestServiceError(errors.New("no valid rows"), "no valid rows provided for user creation")
 	}
 
+	facilityID, err := srv.requireFacilityID(r)
+	if err != nil {
+		return err
+	}
+
 	log.add("admin_id", claims.UserID)
-	log.add("facility_id", claims.FacilityID)
+	log.add("facility_id", facilityID)
 	log.add("users_to_create", len(validRows))
 
 	usersToCreate := make([]models.User, 0, len(validRows))
@@ -730,12 +740,12 @@ func (srv *Server) handleBulkCreate(w http.ResponseWriter, r *http.Request, log 
 			NameLast:   validRow.LastName,
 			DocID:      validRow.ResidentID,
 			Role:       models.Student,
-			FacilityID: claims.FacilityID,
+			FacilityID: facilityID,
 		}
 		usersToCreate = append(usersToCreate, user)
 	}
 
-	err := srv.Db.CreateUsersBulk(usersToCreate, claims.UserID)
+	err = srv.Db.CreateUsersBulk(usersToCreate, claims.UserID)
 	if err != nil {
 		log.add("transaction_error", err.Error())
 		log.error("Bulk user creation transaction failed")

--- a/backend/src/handlers/utils.go
+++ b/backend/src/handlers/utils.go
@@ -66,15 +66,23 @@ func (slog *sLog) add(key string, value any) {
 	slog.f[key] = value
 }
 
+// getQueryContext resolves the facility scope for a request: a switch-capable
+// admin (sysadmin/dept admin) gets the ?facility_id they're viewing, or 0
+// (statewide) when none is selected; a facility admin is always pinned to their
+// own facility. See facilityScopedQueryContext for reads that must fall back to
+// the home facility instead of going statewide.
 func (srv *Server) getQueryContext(r *http.Request) models.QueryContext {
 	var facilityID, userID uint
 	claims := r.Context().Value(ClaimsKey).(*Claims)
 	ctxWithUser := context.WithValue(r.Context(), models.UserIDKey, claims.UserID)
 	f, err := strconv.Atoi(r.URL.Query().Get("facility_id"))
-	if err != nil || !claims.canSwitchFacility() {
-		facilityID = claims.FacilityID
-	} else {
+	switch {
+	case err == nil && claims.canSwitchFacility():
 		facilityID = uint(f)
+	case claims.canSwitchFacility():
+		facilityID = 0
+	default:
+		facilityID = claims.FacilityID
 	}
 	u, err := strconv.Atoi(r.URL.Query().Get("user_id"))
 	if err != nil {
@@ -114,6 +122,30 @@ func (srv *Server) getQueryContext(r *http.Request) models.QueryContext {
 		Timezone:           tz,
 		IncludeDeactivated: includeDeactivated,
 	}
+}
+
+// facilityScopedQueryContext is for reads whose results are inherently
+// per-facility (libraries, videos, favorites, helpful links, resident/user
+// listings tied to a facility). A statewide admin has no single facility
+// (FacilityID == 0), so these fall back to the admin's home facility rather than
+// matching no facility at all.
+func (srv *Server) facilityScopedQueryContext(r *http.Request) models.QueryContext {
+	args := srv.getQueryContext(r)
+	if args.FacilityID == 0 {
+		args.FacilityID = r.Context().Value(ClaimsKey).(*Claims).FacilityID
+	}
+	return args
+}
+
+// requireFacilityID resolves the request's target facility for a facility-scoped
+// write. A statewide admin (FacilityID == 0) has not selected one, which is an
+// error for a write that must land in a concrete facility.
+func (srv *Server) requireFacilityID(r *http.Request) (uint, error) {
+	facilityID := srv.getQueryContext(r).FacilityID
+	if facilityID == 0 {
+		return 0, newBadRequestServiceError(nil, "facility selection is required")
+	}
+	return facilityID, nil
 }
 
 func getDateRange(r *http.Request) (*models.DateRange, error) {

--- a/backend/src/handlers/video_handler.go
+++ b/backend/src/handlers/video_handler.go
@@ -55,7 +55,7 @@ func (srv *Server) handleGetVideos(w http.ResponseWriter, r *http.Request, log s
 	if !user.isAdmin() {
 		visibility = "visible"
 	}
-	args := srv.getQueryContext(r)
+	args := srv.facilityScopedQueryContext(r)
 	videos, err := srv.Db.GetAllVideos(&args, visibility)
 	if err != nil {
 		return newInternalServerServiceError(err, "error fetching videos")

--- a/backend/tests/integration/classes_test.go
+++ b/backend/tests/integration/classes_test.go
@@ -134,6 +134,55 @@ func runCreateClassNotOfferedFacilityTest(t *testing.T, env *TestEnv, facility *
 		ExpectStatus(http.StatusUnauthorized)
 }
 
+// A department admin (statewide) must create a class at the facility named by
+// the ?facility_id= query param, not at their home facility or whatever the body
+// carries. This guards the toggle-removal re-scoping.
+func TestCreateClassFacilityScopingForDeptAdmin(t *testing.T) {
+	env := SetupTestEnv(t)
+	defer env.CleanupTestEnv()
+
+	homeFacility, err := env.CreateTestFacility("Home Facility")
+	require.NoError(t, err)
+	targetFacility, err := env.CreateTestFacility("Target Facility")
+	require.NoError(t, err)
+
+	deptAdmin, err := env.CreateTestUser("deptadmin", models.DepartmentAdmin, homeFacility.ID, "")
+	require.NoError(t, err)
+
+	program, err := env.CreateTestProgram("Scoped Program", models.FundingType(models.FederalGrants), []models.ProgramType{}, []models.ProgramCreditType{}, true, nil)
+	require.NoError(t, err)
+	// Offered only at the target facility, not the admin's home facility.
+	err = env.SetFacilitiesToProgram(program.ID, []uint{targetFacility.ID})
+	require.NoError(t, err)
+
+	instructor, err := env.CreateTestInstructor(targetFacility.ID, "target")
+	require.NoError(t, err)
+
+	t.Run("class is created at the query-param facility, not the admin's home", func(t *testing.T) {
+		// Body intentionally carries the home facility to prove it is ignored.
+		class := newClassWithInstructor(program, homeFacility, &instructor.ID)
+
+		resp := NewRequest[*models.ProgramClass](env.Client, t, http.MethodPost,
+			fmt.Sprintf("/api/programs/%d/classes?facility_id=%d", program.ID, targetFacility.ID), class).
+			WithTestClaims(&handlers.Claims{Role: models.DepartmentAdmin, UserID: deptAdmin.ID, FacilityID: homeFacility.ID}).
+			Do().
+			ExpectStatus(http.StatusCreated)
+
+		got := resp.GetData()
+		require.Equal(t, targetFacility.ID, got.FacilityID)
+	})
+
+	t.Run("missing facility_id is rejected for a statewide admin", func(t *testing.T) {
+		class := newClassWithInstructor(program, targetFacility, &instructor.ID)
+
+		NewRequest[*models.ProgramClass](env.Client, t, http.MethodPost,
+			fmt.Sprintf("/api/programs/%d/classes", program.ID), class).
+			WithTestClaims(&handlers.Claims{Role: models.DepartmentAdmin, UserID: deptAdmin.ID, FacilityID: homeFacility.ID}).
+			Do().
+			ExpectStatus(http.StatusUnauthorized)
+	})
+}
+
 // creates a boilerplate class with required instructor
 func newClassWithInstructor(program *models.Program, facility *models.Facility, instructorID *uint) models.ProgramClass {
 	endDt := time.Now().Add(time.Hour * 24)

--- a/backend/tests/integration/users_test.go
+++ b/backend/tests/integration/users_test.go
@@ -50,4 +50,29 @@ func TestCreateUserHandler(t *testing.T) {
 		require.Equal(t, form.User.DocID, got.DocID)
 		require.Equal(t, form.User.FacilityID, got.FacilityID)
 	})
+
+	t.Run("switch-capable admin must specify a facility", func(t *testing.T) {
+		var form struct {
+			User      models.User `json:"user"`
+			Providers []int       `json:"provider_platforms"`
+		}
+
+		form.User = models.User{
+			Username:  "nofacuser",
+			NameFirst: "No",
+			NameLast:  "Facility",
+			Role:      models.Student,
+			Email:     "nofacuser@example.com",
+			DocID:     "987654321",
+			// FacilityID intentionally omitted: a statewide admin has no ambient
+			// facility, so creation must be rejected rather than defaulting.
+		}
+
+		NewRequest[struct {
+			User models.User `json:"user"`
+		}](env.Client, t, http.MethodPost, "/api/users", form).
+			WithTestClaims(&handlers.Claims{Role: models.DepartmentAdmin}).
+			Do().
+			ExpectStatus(http.StatusBadRequest)
+	})
 }

--- a/frontend/src/components/navigation/TopNav.tsx
+++ b/frontend/src/components/navigation/TopNav.tsx
@@ -1,10 +1,4 @@
-import {
-    useAuth,
-    canSwitchFacility,
-    handleLogout,
-    isFacilityAdmin
-} from '@/auth/useAuth';
-import { Facility } from '@/types';
+import { useAuth, handleLogout, isFacilityAdmin } from '@/auth/useAuth';
 import {
     DropdownMenu,
     DropdownMenuContent,
@@ -12,30 +6,14 @@ import {
     DropdownMenuTrigger
 } from '@/components/ui/dropdown-menu';
 import { Button } from '@/components/ui/button';
-import { Building2, LogOut } from 'lucide-react';
+import { LogOut } from 'lucide-react';
 import { usePageTitle } from '@/contexts/usePageTitle';
 
-export default function TopNav({ facilities }: { facilities?: Facility[] }) {
+export default function TopNav() {
     const { user } = useAuth();
     const { pageTitle } = usePageTitle();
 
     if (!user) return null;
-
-    const handleSwitchFacility = async (facility: Facility) => {
-        const API = (await import('@/api/api')).default;
-        const resp = await API.put<null, object>(
-            `admin/facility-context/${facility.id}`,
-            {}
-        );
-        if (resp.success) {
-            const params = new URLSearchParams(window.location.search);
-            if (params.get('page') !== null) {
-                params.set('page', '1');
-            }
-            const paramsString = params.size > 0 ? '?' + params.toString() : '';
-            window.location.href = window.location.pathname + paramsString;
-        }
-    };
 
     return (
         <header className="h-16 bg-background border-b border-border flex items-center justify-between px-6 shrink-0">
@@ -51,33 +29,6 @@ export default function TopNav({ facilities }: { facilities?: Facility[] }) {
             </div>
 
             <div className="flex items-center gap-2 flex-shrink-0">
-                {canSwitchFacility(user) &&
-                facilities &&
-                facilities.length > 0 ? (
-                    <DropdownMenu>
-                        <DropdownMenuTrigger asChild>
-                            <Button variant="ghost" size="sm" className="gap-2">
-                                <Building2 className="h-4 w-4" />
-                                <span className="hidden sm:inline truncate max-w-[8rem]">
-                                    {user.facility.name}
-                                </span>
-                            </Button>
-                        </DropdownMenuTrigger>
-                        <DropdownMenuContent align="end">
-                            {facilities.map((facility) => (
-                                <DropdownMenuItem
-                                    key={facility.id}
-                                    onClick={() => {
-                                        void handleSwitchFacility(facility);
-                                    }}
-                                >
-                                    {facility.name}
-                                </DropdownMenuItem>
-                            ))}
-                        </DropdownMenuContent>
-                    </DropdownMenu>
-                ) : null}
-
                 <DropdownMenu>
                     <DropdownMenuTrigger asChild>
                         <Button variant="ghost" size="sm" className="gap-2">

--- a/frontend/src/components/residents/BulkImportDialog.tsx
+++ b/frontend/src/components/residents/BulkImportDialog.tsx
@@ -4,13 +4,21 @@ import {
     BulkUploadResponse,
     InvalidUserRow,
     ValidatedUserRow,
-    ServerResponseOne
+    ServerResponseOne,
+    Facility
 } from '@/types';
 import { toast } from 'sonner';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import { DialogFooter } from '@/components/ui/dialog';
+import {
+    Select,
+    SelectContent,
+    SelectItem,
+    SelectTrigger,
+    SelectValue
+} from '@/components/ui/select';
 import { FormModal, TonedPanel } from '@/components/shared';
 import { Upload, Download, AlertCircle, CheckCircle } from 'lucide-react';
 
@@ -18,12 +26,18 @@ interface BulkImportDialogProps {
     open: boolean;
     onOpenChange: (open: boolean) => void;
     onSuccess: () => void;
+    facilities?: Facility[];
+    showFacilitySelect?: boolean;
+    defaultFacilityId?: number;
 }
 
 export function BulkImportDialog({
     open,
     onOpenChange,
-    onSuccess
+    onSuccess,
+    facilities = [],
+    showFacilitySelect = false,
+    defaultFacilityId
 }: BulkImportDialogProps) {
     const [step, setStep] = useState<'upload' | 'validation'>('upload');
     const [uploadedFile, setUploadedFile] = useState<File | null>(null);
@@ -32,6 +46,9 @@ export function BulkImportDialog({
     const [errorCsvData, setErrorCsvData] = useState<string | undefined>();
     const [validating, setValidating] = useState(false);
     const [creating, setCreating] = useState(false);
+    const [selectedFacilityId, setSelectedFacilityId] = useState<
+        number | undefined
+    >(defaultFacilityId);
 
     const reset = () => {
         setStep('upload');
@@ -39,6 +56,7 @@ export function BulkImportDialog({
         setValidRows([]);
         setInvalidRows([]);
         setErrorCsvData(undefined);
+        setSelectedFacilityId(defaultFacilityId);
     };
 
     const handleOpenChange = (value: boolean) => {
@@ -100,9 +118,16 @@ export function BulkImportDialog({
 
     const handleCreateAccounts = async () => {
         if (validRows.length === 0) return;
+        if (showFacilitySelect && !selectedFacilityId) {
+            toast.error('Please select a facility');
+            return;
+        }
         setCreating(true);
+        const createUrl = selectedFacilityId
+            ? `users/bulk/create?facility_id=${selectedFacilityId}`
+            : 'users/bulk/create';
         const response = await API.post<string, ValidatedUserRow[]>(
-            'users/bulk/create',
+            createUrl,
             validRows
         );
         setCreating(false);
@@ -130,6 +155,40 @@ export function BulkImportDialog({
             <div className="space-y-6 py-4">
                 {step === 'upload' ? (
                     <>
+                        {showFacilitySelect && (
+                            <div>
+                                <Label htmlFor="bulk-import-facility">
+                                    Facility
+                                </Label>
+                                <Select
+                                    value={
+                                        selectedFacilityId
+                                            ? String(selectedFacilityId)
+                                            : undefined
+                                    }
+                                    onValueChange={(v) =>
+                                        setSelectedFacilityId(Number(v))
+                                    }
+                                >
+                                    <SelectTrigger
+                                        id="bulk-import-facility"
+                                        className="mt-2"
+                                    >
+                                        <SelectValue placeholder="Select facility" />
+                                    </SelectTrigger>
+                                    <SelectContent>
+                                        {facilities.map((f) => (
+                                            <SelectItem
+                                                key={f.id}
+                                                value={String(f.id)}
+                                            >
+                                                {f.name}
+                                            </SelectItem>
+                                        ))}
+                                    </SelectContent>
+                                </Select>
+                            </div>
+                        )}
                         <Label
                             htmlFor="csv-upload"
                             className="block cursor-pointer"
@@ -361,7 +420,11 @@ export function BulkImportDialog({
                         </Button>
                         <Button
                             onClick={() => void handleCreateAccounts()}
-                            disabled={validRows.length === 0 || creating}
+                            disabled={
+                                validRows.length === 0 ||
+                                creating ||
+                                (showFacilitySelect && !selectedFacilityId)
+                            }
                             variant="brand"
                         >
                             {creating

--- a/frontend/src/components/schedule/SessionDetailSheet.tsx
+++ b/frontend/src/components/schedule/SessionDetailSheet.tsx
@@ -270,7 +270,9 @@ export function SessionDetailSheet({
                     open={showRescheduleModal}
                     onClose={() => setShowRescheduleModal(false)}
                     classId={classId}
-                    facilityId={facilityId}
+                    classFacilityId={
+                        facilityId ? Number(facilityId) : undefined
+                    }
                     eventId={eventId}
                     originalDate={instance.date}
                     dateLabel={shortDateLabel}

--- a/frontend/src/layouts/AuthenticatedLayout.tsx
+++ b/frontend/src/layouts/AuthenticatedLayout.tsx
@@ -1,8 +1,7 @@
 import { Outlet, useLocation, useMatches } from 'react-router-dom';
 import { useState, useEffect } from 'react';
-import { Facility, RouteTitleHandler, TitleHandler } from '@/types';
+import { RouteTitleHandler, TitleHandler } from '@/types';
 import { useAuth, isAdministrator, canSwitchFacility } from '@/auth/useAuth';
-import API from '@/api/api';
 import TopNav from '@/components/navigation/TopNav';
 import Sidebar from '@/components/navigation/Sidebar';
 import MobileNav from '@/components/navigation/MobileNav';
@@ -19,7 +18,6 @@ import WebsocketSession from '@/session/websocket';
 
 export default function AuthenticatedLayout() {
     const { user } = useAuth();
-    const [facilities, setFacilities] = useState<Facility[]>([]);
     const [helpCenterOpen, setHelpCenterOpen] = useState(false);
     const [sidebarCollapsed, setSidebarCollapsed] = useState(false);
     const matches = useMatches();
@@ -126,17 +124,6 @@ export default function AuthenticatedLayout() {
     ]);
 
     useEffect(() => {
-        if (user && canSwitchFacility(user)) {
-            void (async () => {
-                const resp = await API.get<Facility>('facilities');
-                if (resp.success && Array.isArray(resp.data)) {
-                    setFacilities(resp.data);
-                }
-            })();
-        }
-    }, [user]);
-
-    useEffect(() => {
         if (user && !isAdministrator(user)) {
             const ws = new WebsocketSession(user);
             ws.connect();
@@ -181,7 +168,7 @@ export default function AuthenticatedLayout() {
                         <MobileNav />
                     </div>
                     <div className="flex-1">
-                        <TopNav facilities={facilities} />
+                        <TopNav />
                     </div>
                 </div>
 

--- a/frontend/src/pages/Schedule.tsx
+++ b/frontend/src/pages/Schedule.tsx
@@ -11,7 +11,7 @@ import {
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 const Calendar = BigCalendar as unknown as React.ComponentType<any>;
 import moment from 'moment';
-import { useAuth, isDeptAdmin } from '@/auth/useAuth';
+import { useAuth, canSwitchFacility } from '@/auth/useAuth';
 import {
     FacilityProgramClassEvent,
     ServerResponseMany,
@@ -143,13 +143,13 @@ export default function Schedule() {
     const [showRescheduleSeries, setShowRescheduleSeries] = useState(false);
     const [showRestore, setShowRestore] = useState(false);
 
-    const isDepAdmin = user ? isDeptAdmin(user) : false;
+    const canSwitchFac = user ? canSwitchFacility(user) : false;
     const activeFacilityId =
         selectedFacilityId || (user ? String(user.facility.id) : '');
     const timezone = user?.timezone ?? 'UTC';
 
     const { data: facilitiesResp } = useSWR<ServerResponseMany<Facility>>(
-        isDepAdmin ? '/api/facilities' : null
+        canSwitchFac ? '/api/facilities' : null
     );
     const facilities = useMemo(
         () => facilitiesResp?.data ?? [],
@@ -166,7 +166,7 @@ export default function Schedule() {
         if (!user) return null;
         let url = `/api/admin-calendar?start_dt=${startDate.toISOString()}&end_dt=${endDate.toISOString()}`;
         if (class_id && !showAllClasses) url += `&class_id=${class_id}`;
-        if (isDepAdmin && activeFacilityId)
+        if (canSwitchFac && activeFacilityId)
             url += `&facility_id=${activeFacilityId}`;
         return url;
     }, [
@@ -175,7 +175,7 @@ export default function Schedule() {
         endDate,
         class_id,
         showAllClasses,
-        isDepAdmin,
+        canSwitchFac,
         activeFacilityId
     ]);
 
@@ -246,12 +246,12 @@ export default function Schedule() {
 
     const selectedFacilityName = useMemo(() => {
         if (!user) return '';
-        if (!isDepAdmin) return user.facility.name;
+        if (!canSwitchFac) return user.facility.name;
         return (
             facilities.find((f) => String(f.id) === activeFacilityId)?.name ??
             user.facility.name
         );
-    }, [isDepAdmin, facilities, activeFacilityId, user]);
+    }, [canSwitchFac, facilities, activeFacilityId, user]);
 
     const sessionView = useMemo(
         () =>
@@ -339,7 +339,7 @@ export default function Schedule() {
         setShowRestore(true);
     };
 
-    const subtitle = isDepAdmin
+    const subtitle = canSwitchFac
         ? `Viewing: ${selectedFacilityName}`
         : 'Manage class schedules';
 
@@ -392,7 +392,7 @@ export default function Schedule() {
                 {!class_id && (
                     <div className="bg-white border border-gray-200 rounded-lg p-4">
                         <div className="grid grid-cols-1 gap-4 md:grid-cols-3">
-                            {isDepAdmin && (
+                            {canSwitchFac && (
                                 <div>
                                     <label className="form-label">
                                         Facility

--- a/frontend/src/pages/admin/AdminManagement.tsx
+++ b/frontend/src/pages/admin/AdminManagement.tsx
@@ -333,6 +333,10 @@ export default function AdminManagement() {
             toast.error('First name, last name, and username are required');
             return;
         }
+        if (!formData.facility_id) {
+            toast.error('Please select a facility');
+            return;
+        }
         const payload = {
             user: {
                 name_first: formData.name_first,
@@ -868,44 +872,42 @@ export default function AdminManagement() {
                             </SelectContent>
                         </Select>
                     </div>
-                    {formData.role === UserRole.FacilityAdmin && (
-                        <div className="space-y-2">
-                            <Label htmlFor="facility">Facility</Label>
-                            {canSwitchFac ? (
-                                <Select
-                                    value={
-                                        formData.facility_id
-                                            ? String(formData.facility_id)
-                                            : ''
-                                    }
-                                    onValueChange={(value) =>
-                                        setFormData({
-                                            ...formData,
-                                            facility_id: Number(value)
-                                        })
-                                    }
-                                >
-                                    <SelectTrigger id="facility">
-                                        <SelectValue placeholder="Select facility" />
-                                    </SelectTrigger>
-                                    <SelectContent>
-                                        {facilities.map((facility) => (
-                                            <SelectItem
-                                                key={facility.id}
-                                                value={String(facility.id)}
-                                            >
-                                                {facility.name}
-                                            </SelectItem>
-                                        ))}
-                                    </SelectContent>
-                                </Select>
-                            ) : (
-                                <div className="field-readonly">
-                                    {user?.facility?.name ?? '—'}
-                                </div>
-                            )}
-                        </div>
-                    )}
+                    <div className="space-y-2">
+                        <Label htmlFor="facility">Facility</Label>
+                        {canSwitchFac ? (
+                            <Select
+                                value={
+                                    formData.facility_id
+                                        ? String(formData.facility_id)
+                                        : ''
+                                }
+                                onValueChange={(value) =>
+                                    setFormData({
+                                        ...formData,
+                                        facility_id: Number(value)
+                                    })
+                                }
+                            >
+                                <SelectTrigger id="facility">
+                                    <SelectValue placeholder="Select facility" />
+                                </SelectTrigger>
+                                <SelectContent>
+                                    {facilities.map((facility) => (
+                                        <SelectItem
+                                            key={facility.id}
+                                            value={String(facility.id)}
+                                        >
+                                            {facility.name}
+                                        </SelectItem>
+                                    ))}
+                                </SelectContent>
+                            </Select>
+                        ) : (
+                            <div className="field-readonly">
+                                {user?.facility?.name ?? '—'}
+                            </div>
+                        )}
+                    </div>
                 </div>
                 <DialogFooter>
                     <Button

--- a/frontend/src/pages/admin/StudentManagement.tsx
+++ b/frontend/src/pages/admin/StudentManagement.tsx
@@ -665,6 +665,11 @@ export default function StudentManagement() {
                 open={bulkImportOpen}
                 onOpenChange={setBulkImportOpen}
                 onSuccess={() => void mutate()}
+                facilities={facilities}
+                showFacilitySelect={showFacilityColumn}
+                defaultFacilityId={
+                    showFacilityColumn && user ? user.facility_id : undefined
+                }
             />
 
             {/* Bulk Action Bar */}

--- a/frontend/src/pages/class-detail/ChangeRoomModal.tsx
+++ b/frontend/src/pages/class-detail/ChangeRoomModal.tsx
@@ -11,7 +11,7 @@ interface ChangeRoomModalProps {
     open: boolean;
     onClose: () => void;
     classId: number;
-    facilityId: string;
+    classFacilityId: number;
     sessions: ChangeRoomSession[];
     onChanged: () => void;
     applyToFuture?: boolean;
@@ -30,7 +30,11 @@ const ROOM_REASON_OPTIONS = [
 
 export function ChangeRoomModal(props: ChangeRoomModalProps) {
     const { data: roomsResp } = useSWR<ServerResponseMany<Room>>(
-        props.open ? `/api/rooms?facility_id=${props.facilityId}` : null
+        props.open
+            ? props.classFacilityId
+                ? `/api/rooms?facility_id=${props.classFacilityId}`
+                : '/api/rooms'
+            : null
     );
     const options = (roomsResp?.data ?? []).map((room) => ({
         id: room.id,

--- a/frontend/src/pages/class-detail/EditClassModal.tsx
+++ b/frontend/src/pages/class-detail/EditClassModal.tsx
@@ -250,7 +250,11 @@ export function EditClassModal({
 
     const { data: roomsResp, mutate: mutateRooms } = useSWR<
         ServerResponseMany<Room>
-    >(`/api/rooms?facility_id=${cls.facility_id}`);
+    >(
+        cls.facility_id
+            ? `/api/rooms?facility_id=${cls.facility_id}`
+            : '/api/rooms'
+    );
     const rooms = roomsResp?.data ?? [];
 
     const {

--- a/frontend/src/pages/class-detail/RescheduleSessionModal.tsx
+++ b/frontend/src/pages/class-detail/RescheduleSessionModal.tsx
@@ -26,7 +26,7 @@ interface RescheduleSessionModalProps {
     open: boolean;
     onClose: () => void;
     classId: number;
-    facilityId: string;
+    classFacilityId?: number;
     eventId: number;
     originalDate: string;
     dateLabel: string;
@@ -42,7 +42,7 @@ export function RescheduleSessionModal({
     open,
     onClose,
     classId,
-    facilityId,
+    classFacilityId,
     eventId,
     originalDate,
     dateLabel,
@@ -62,7 +62,11 @@ export function RescheduleSessionModal({
     const [isSubmitting, setIsSubmitting] = useState(false);
 
     const { data: roomsResp } = useSWR<ServerResponseMany<Room>>(
-        open ? `/api/rooms?facility_id=${facilityId}` : null
+        open
+            ? classFacilityId
+                ? `/api/rooms?facility_id=${classFacilityId}`
+                : '/api/rooms'
+            : null
     );
     const rooms = roomsResp?.data ?? [];
 

--- a/frontend/src/pages/class-detail/RosterTab.tsx
+++ b/frontend/src/pages/class-detail/RosterTab.tsx
@@ -101,7 +101,10 @@ export function RosterTab({
         `/api/program-classes/${classId}/events?all=true`
     );
 
-    const enrolledRows = enrollmentResp?.data ?? [];
+    const enrolledRows = useMemo(
+        () => enrollmentResp?.data ?? [],
+        [enrollmentResp]
+    );
 
     const attendanceMap = useMemo(() => {
         return computeAttendanceByUser(eventsResp?.data ?? []);

--- a/frontend/src/pages/class-detail/SessionsTabModals.tsx
+++ b/frontend/src/pages/class-detail/SessionsTabModals.tsx
@@ -103,7 +103,7 @@ export function SessionsTabModals({
                     open={!!rescheduleTarget}
                     onClose={onCloseReschedule}
                     classId={cls.id}
-                    facilityId={String(cls.facility_id)}
+                    classFacilityId={cls.facility_id}
                     eventId={
                         rescheduleTarget.instance.event_id ??
                         rescheduleTarget.instance.id
@@ -162,7 +162,7 @@ export function SessionsTabModals({
                     open={showChangeRoom}
                     onClose={onCloseChangeRoom}
                     classId={cls.id}
-                    facilityId={String(cls.facility_id)}
+                    classFacilityId={cls.facility_id}
                     sessions={changeRoomSessions}
                     onChanged={onRoomChanged}
                     showSessionsList

--- a/frontend/src/pages/programs/ClassManagementForm.tsx
+++ b/frontend/src/pages/programs/ClassManagementForm.tsx
@@ -179,8 +179,10 @@ export function ClassManagementFormInner({
     }, [resolvedFacilityId]);
 
     const { data: roomsResp } = useSWR<ServerResponseMany<Room>>(
-        rooms.length === 0 && resolvedFacilityId
-            ? `/api/rooms?facility_id=${resolvedFacilityId}`
+        rooms.length === 0
+            ? resolvedFacilityId
+                ? `/api/rooms?facility_id=${resolvedFacilityId}`
+                : '/api/rooms'
             : null
     );
 

--- a/frontend/src/pages/programs/ClassManagementForm.tsx
+++ b/frontend/src/pages/programs/ClassManagementForm.tsx
@@ -379,12 +379,12 @@ export function ClassManagementFormInner({
 
     async function handleAddRoom() {
         if (!newRoomName.trim()) return;
-        const resp = await API.post<Room, object>(
-            `rooms?facility_id=${resolvedFacilityId}`,
-            {
-                name: newRoomName.trim()
-            }
-        );
+        const roomUrl = resolvedFacilityId
+            ? `rooms?facility_id=${resolvedFacilityId}`
+            : 'rooms';
+        const resp = await API.post<Room, object>(roomUrl, {
+            name: newRoomName.trim()
+        });
         if (resp.success) {
             const created = resp.data as unknown as Room;
             setRooms((prev) => [...prev, created]);
@@ -517,8 +517,11 @@ export function ClassManagementFormInner({
                   ]
         };
 
+        const createUrl = resolvedFacilityId
+            ? `programs/${programId}/classes?facility_id=${resolvedFacilityId}`
+            : `programs/${programId}/classes`;
         const resp = isNewClass
-            ? await API.post(`programs/${programId}/classes`, payload)
+            ? await API.post(createUrl, payload)
             : await API.patch(
                   `programs/${programId}/classes/${classId}`,
                   payload

--- a/frontend/src/pages/programs/ProgramOverviewStatewide.tsx
+++ b/frontend/src/pages/programs/ProgramOverviewStatewide.tsx
@@ -453,17 +453,9 @@ export default function ProgramOverviewStatewide() {
         }));
     };
 
-    const handleViewAtFacility = async (facilityId: number) => {
+    const handleViewAtFacility = (facilityId: number) => {
         if (!program) return;
-        const resp = await API.put<null, object>(
-            `admin/facility-context/${facilityId}`,
-            {}
-        );
-        if (resp.success) {
-            navigate(`/programs/${program.id}?facility_id=${facilityId}`);
-        } else {
-            toast.error(resp.message || 'Failed to switch facility context');
-        }
+        navigate(`/programs/${program.id}?facility_id=${facilityId}`);
     };
 
     if (!program) {
@@ -941,7 +933,7 @@ export default function ProgramOverviewStatewide() {
                                                     size="sm"
                                                     onClick={(event) => {
                                                         event.stopPropagation();
-                                                        void handleViewAtFacility(
+                                                        handleViewAtFacility(
                                                             stat.facilityId
                                                         );
                                                     }}


### PR DESCRIPTION


## Pre-Submission PR Checklist

- [x] No debug/console/fmt.Println statements
- [x] Unnecessary development comments removed
- [x] All acceptance criteria verified
- [x] Functions according to **ticket specifications**
- [x] Tested manually where applicable
- [x] Branch rebased with latest main
- [x] No business logic exists within the database layer

## Description of the change
Removes the top facility-switcher toggle and re-scopes how facility context is resolved so that data is no longer silently filtered by an ambient session facility. 

  - **Frontend**
    - Removed the top facility toggle from `TopNav` and the now-dead facilities fetch in `AuthenticatedLayout`.
    - "View at Facility" drill-in is now **stateless** — it navigates with `?facility_id=N` instead of mutating session state.
    - Department/Super admins default to **statewide** views; facility selection is explicit where a write needs it (class/room creation send
  `?facility_id`; bulk-import and Add-Admin now require a facility selection for all roles).
  - **Backend**
    - `getQueryContext` returns statewide (`FacilityID = 0`) for switch-capable admins with no `facility_id`; facility admins stay pinned to
  their own facility.
    - Removed the `PUT /api/admin/facility-context/{id}` session-switch endpoint; `auth.go` no longer honors an alternate Kratos facility
  trait (claims are pinned to the user's home facility).
    - Write handlers (class, room, single/bulk user, provider import) derive the target facility from the request and reject (`400`) when a
  switch-capable admin omits it (`requireFacilityID` helper).
    - Reads whose visibility is inherently per-facility (open content, calendar, helpful links, resident-for-class lists) fall back to the
  home facility via `facilityScopedQueryContext`.



- **Related issues**: Link to related Asana ticket that this closes.

## Screenshot(s)
<img width="1894" height="407" alt="image" src="https://github.com/user-attachments/assets/73769d63-32b1-4e36-9a5b-d6fbeeb8b4b4" />


## Additional context

A lot of these lines are actually from prettier, so if this gets reviewed before we end up merging a prettier PR, then you can append `?w=1` to the "Files changed" URL and it will remove the formatting lines and leave just the logic for review. 


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1215131303729099