### PR TITLE
Ck 7vn/op insights 2

### DIFF
--- a/backend/src/database/DB.go
+++ b/backend/src/database/DB.go
@@ -139,6 +139,8 @@ func MigrateTesting(db *gorm.DB) {
 		&models.UserCourseActivityTotals{},
 		&models.ProgramClassesHistory{},
 		&models.UserAccountHistory{},
+		&models.Tag{},
+		&models.OpenContentTag{},
 	}
 	logrus.Println("Running up migrations...")
 	for _, table := range TableList {

--- a/backend/src/database/knowledge_center.go
+++ b/backend/src/database/knowledge_center.go
@@ -1,0 +1,130 @@
+package database
+
+import (
+	"UnlockEdv2/src/models"
+	"time"
+
+	"gorm.io/gorm"
+)
+
+func (db *DB) kcActivityScope(args *models.QueryContext, start, end *time.Time, facilityID *uint) *gorm.DB {
+	tx := db.WithContext(args.Ctx).Model(&models.OpenContentActivity{})
+	if facilityID != nil {
+		tx = tx.Where("facility_id = ?", *facilityID)
+	}
+	if start != nil && end != nil {
+		tx = tx.Where("request_ts >= ? AND request_ts < ?", *start, *end)
+	}
+	return tx
+}
+
+func (db *DB) GetKCInteractionStats(args *models.QueryContext, start, end *time.Time, facilityID *uint) (int64, int64, error) {
+	var total int64
+	if err := db.kcActivityScope(args, start, end, facilityID).Count(&total).Error; err != nil {
+		return 0, 0, newGetRecordsDBError(err, "open_content_activities")
+	}
+	var unique int64
+	if err := db.kcActivityScope(args, start, end, facilityID).
+		Distinct("user_id").Count(&unique).Error; err != nil {
+		return 0, 0, newGetRecordsDBError(err, "open_content_activities")
+	}
+	return total, unique, nil
+}
+
+func (db *DB) GetKCAvgSessionMinutes(args *models.QueryContext, start, end *time.Time, facilityID *uint) (float64, error) {
+	type sessionRow struct {
+		RequestTS time.Time
+		StopTS    time.Time
+	}
+	rows := make([]sessionRow, 0)
+	if err := db.kcActivityScope(args, start, end, facilityID).
+		Select("request_ts, stop_ts").
+		Where("stop_ts IS NOT NULL").
+		Find(&rows).Error; err != nil {
+		return 0, newGetRecordsDBError(err, "open_content_activities")
+	}
+	var totalMinutes float64
+	var counted int
+	for _, row := range rows {
+		if row.StopTS.After(row.RequestTS) {
+			totalMinutes += row.StopTS.Sub(row.RequestTS).Minutes()
+			counted++
+		}
+	}
+	if counted == 0 {
+		return 0, nil
+	}
+	return totalMinutes / float64(counted), nil
+}
+
+func (db *DB) GetKCRepeatEngagement(args *models.QueryContext, start, end *time.Time, facilityID *uint) (models.RepeatEngagement, error) {
+	type userCount struct {
+		UserID uint
+		Cnt    int64
+	}
+	counts := make([]userCount, 0)
+	if err := db.kcActivityScope(args, start, end, facilityID).
+		Select("user_id, count(*) as cnt").
+		Group("user_id").
+		Find(&counts).Error; err != nil {
+		return models.RepeatEngagement{}, newGetRecordsDBError(err, "open_content_activities")
+	}
+	var engagement models.RepeatEngagement
+	for _, row := range counts {
+		switch {
+		case row.Cnt >= 5:
+			engagement.FivePlus++
+		case row.Cnt >= 2:
+			engagement.TwoToFour++
+		default:
+			engagement.Once++
+		}
+	}
+	return engagement, nil
+}
+
+func (db *DB) GetKCLibraryViewsByCategory(args *models.QueryContext, start, end *time.Time, facilityID *uint) ([]models.CategoryViews, error) {
+	views := make([]models.CategoryViews, 0)
+	tx := db.WithContext(args.Ctx).Table("open_content_activities oca").
+		Select("t.name as category, count(oca.id) as views").
+		Joins("JOIN open_content_tags oct ON oct.content_id = oca.content_id AND oct.open_content_provider_id = oca.open_content_provider_id").
+		Joins("JOIN tags t ON t.id = oct.tag_id")
+	if facilityID != nil {
+		tx = tx.Where("oca.facility_id = ?", *facilityID)
+	}
+	if start != nil && end != nil {
+		tx = tx.Where("oca.request_ts >= ? AND oca.request_ts < ?", *start, *end)
+	}
+	if err := tx.Group("t.name").Order("views DESC, t.name ASC").Scan(&views).Error; err != nil {
+		return nil, newGetRecordsDBError(err, "open_content_tags")
+	}
+	return views, nil
+}
+
+func (db *DB) getKCTopContent(args *models.QueryContext, table, alias string, start, end *time.Time, facilityID *uint, limit int) ([]models.KCContentRow, error) {
+	rows := make([]models.KCContentRow, 0, limit)
+	tx := db.WithContext(args.Ctx).Table("open_content_activities oca").
+		Select(alias + ".title as title, count(oca.id) as visits").
+		Joins("JOIN " + table + " " + alias + " ON " + alias + ".id = oca.content_id AND " + alias + ".open_content_provider_id = oca.open_content_provider_id AND " + alias + ".deleted_at IS NULL")
+	if facilityID != nil {
+		tx = tx.Where("oca.facility_id = ?", *facilityID)
+	}
+	if start != nil && end != nil {
+		tx = tx.Where("oca.request_ts >= ? AND oca.request_ts < ?", *start, *end)
+	}
+	if err := tx.Group(alias + ".id, " + alias + ".title").
+		Order("visits DESC, " + alias + ".title ASC").
+		Limit(limit).
+		Scan(&rows).Error; err != nil {
+		return nil, newGetRecordsDBError(err, table)
+	}
+	return rows, nil
+}
+
+func (db *DB) GetKCTopLibraries(args *models.QueryContext, start, end *time.Time, facilityID *uint, limit int) ([]models.KCContentRow, error) {
+	return db.getKCTopContent(args, "libraries", "l", start, end, facilityID, limit)
+}
+
+func (db *DB) GetKCTopVideos(args *models.QueryContext, start, end *time.Time, facilityID *uint, limit int) ([]models.KCContentRow, error) {
+	return db.getKCTopContent(args, "videos", "v", start, end, facilityID, limit)
+}

--- a/backend/src/database/knowledge_center.go
+++ b/backend/src/database/knowledge_center.go
@@ -2,10 +2,28 @@ package database
 
 import (
 	"UnlockEdv2/src/models"
+	"math"
 	"time"
 
 	"gorm.io/gorm"
 )
+
+func kcPriorWindow(start, end *time.Time) (*time.Time, *time.Time) {
+	if start == nil || end == nil {
+		return nil, nil
+	}
+	duration := end.Sub(*start)
+	priorStart := start.Add(-duration)
+	priorEnd := *start
+	return &priorStart, &priorEnd
+}
+
+func kcPctChange(current, prior int64) int {
+	if prior <= 0 {
+		return 0
+	}
+	return int(math.Round(float64(current-prior) / float64(prior) * 100))
+}
 
 func (db *DB) kcActivityScope(args *models.QueryContext, start, end *time.Time, facilityID *uint) *gorm.DB {
 	tx := db.WithContext(args.Ctx).Model(&models.OpenContentActivity{})
@@ -18,17 +36,25 @@ func (db *DB) kcActivityScope(args *models.QueryContext, start, end *time.Time, 
 	return tx
 }
 
-func (db *DB) GetKCInteractionStats(args *models.QueryContext, start, end *time.Time, facilityID *uint) (int64, int64, error) {
+func (db *DB) GetKCInteractionStats(args *models.QueryContext, start, end *time.Time, facilityID *uint) (int64, int64, int, error) {
 	var total int64
 	if err := db.kcActivityScope(args, start, end, facilityID).Count(&total).Error; err != nil {
-		return 0, 0, newGetRecordsDBError(err, "open_content_activities")
+		return 0, 0, 0, newGetRecordsDBError(err, "open_content_activities")
 	}
 	var unique int64
 	if err := db.kcActivityScope(args, start, end, facilityID).
 		Distinct("user_id").Count(&unique).Error; err != nil {
-		return 0, 0, newGetRecordsDBError(err, "open_content_activities")
+		return 0, 0, 0, newGetRecordsDBError(err, "open_content_activities")
 	}
-	return total, unique, nil
+	change := 0
+	if priorStart, priorEnd := kcPriorWindow(start, end); priorStart != nil {
+		var priorTotal int64
+		if err := db.kcActivityScope(args, priorStart, priorEnd, facilityID).Count(&priorTotal).Error; err != nil {
+			return 0, 0, 0, newGetRecordsDBError(err, "open_content_activities")
+		}
+		change = kcPctChange(total, priorTotal)
+	}
+	return total, unique, change, nil
 }
 
 func (db *DB) GetKCAvgSessionMinutes(args *models.QueryContext, start, end *time.Time, facilityID *uint) (float64, error) {
@@ -102,9 +128,14 @@ func (db *DB) GetKCLibraryViewsByCategory(args *models.QueryContext, start, end 
 }
 
 func (db *DB) getKCTopContent(args *models.QueryContext, table, alias string, start, end *time.Time, facilityID *uint, limit int) ([]models.KCContentRow, error) {
-	rows := make([]models.KCContentRow, 0, limit)
+	type contentRow struct {
+		ContentID uint
+		Title     string
+		Visits    int64
+	}
+	current := make([]contentRow, 0, limit)
 	tx := db.WithContext(args.Ctx).Table("open_content_activities oca").
-		Select(alias + ".title as title, count(oca.id) as visits").
+		Select(alias + ".id as content_id, " + alias + ".title as title, count(oca.id) as visits").
 		Joins("JOIN " + table + " " + alias + " ON " + alias + ".id = oca.content_id AND " + alias + ".open_content_provider_id = oca.open_content_provider_id AND " + alias + ".deleted_at IS NULL")
 	if facilityID != nil {
 		tx = tx.Where("oca.facility_id = ?", *facilityID)
@@ -115,8 +146,43 @@ func (db *DB) getKCTopContent(args *models.QueryContext, table, alias string, st
 	if err := tx.Group(alias + ".id, " + alias + ".title").
 		Order("visits DESC, " + alias + ".title ASC").
 		Limit(limit).
-		Scan(&rows).Error; err != nil {
+		Scan(&current).Error; err != nil {
 		return nil, newGetRecordsDBError(err, table)
+	}
+	rows := make([]models.KCContentRow, 0, len(current))
+	if len(current) == 0 {
+		return rows, nil
+	}
+
+	priorVisits := make(map[uint]int64)
+	if priorStart, priorEnd := kcPriorWindow(start, end); priorStart != nil {
+		ids := make([]uint, 0, len(current))
+		for _, c := range current {
+			ids = append(ids, c.ContentID)
+		}
+		priors := make([]contentRow, 0, len(ids))
+		ptx := db.WithContext(args.Ctx).Table("open_content_activities oca").
+			Select(alias+".id as content_id, count(oca.id) as visits").
+			Joins("JOIN "+table+" "+alias+" ON "+alias+".id = oca.content_id AND "+alias+".open_content_provider_id = oca.open_content_provider_id AND "+alias+".deleted_at IS NULL").
+			Where(alias+".id IN ?", ids).
+			Where("oca.request_ts >= ? AND oca.request_ts < ?", *priorStart, *priorEnd)
+		if facilityID != nil {
+			ptx = ptx.Where("oca.facility_id = ?", *facilityID)
+		}
+		if err := ptx.Group(alias + ".id").Scan(&priors).Error; err != nil {
+			return nil, newGetRecordsDBError(err, table)
+		}
+		for _, p := range priors {
+			priorVisits[p.ContentID] = p.Visits
+		}
+	}
+
+	for _, c := range current {
+		rows = append(rows, models.KCContentRow{
+			Title:  c.Title,
+			Visits: c.Visits,
+			Change: kcPctChange(c.Visits, priorVisits[c.ContentID]),
+		})
 	}
 	return rows, nil
 }

--- a/backend/src/handlers/dashboard.go
+++ b/backend/src/handlers/dashboard.go
@@ -21,6 +21,7 @@ func (srv *Server) registerDashboardRoutes() []routeDef {
 		newAdminRoute("GET /api/department-metrics", srv.handleDepartmentMetrics),
 		newAdminRoute("GET /api/department-metrics/login-trend", srv.handleDepartmentLoginTrend),
 		newAdminRoute("GET /api/department-metrics/facility-comparison", srv.handleFacilityEngagementComparison),
+		newAdminRoute("GET /api/department-metrics/knowledge-center", srv.handleKnowledgeCenterMetrics),
 		newAdminRoute("GET /api/dashboard/class-metrics", srv.handleClassDashboardMetrics),
 		newAdminRoute("GET /api/dashboard/facility-health", srv.handleFacilityHealthSummary),
 		newAdminRoute("GET /api/users/{id}/admin-layer2", srv.handleAdminLayer2),
@@ -273,23 +274,28 @@ func (srv *Server) handleDepartmentMetrics(w http.ResponseWriter, r *http.Reques
 	return writeJsonResponse(w, http.StatusOK, cachedData)
 }
 
-func (srv *Server) handleDepartmentLoginTrend(w http.ResponseWriter, r *http.Request, log sLog) error {
-	args := srv.getQueryContext(r)
-	claims := r.Context().Value(ClaimsKey).(*Claims)
-	facility := r.URL.Query().Get("facility")
-	var facilityID *uint
+func resolveFacilityFilter(claims *Claims, facility string, ownFacilityID uint) (*uint, error) {
 	switch {
 	case facility == "all" && claims.canSwitchFacility():
-		facilityID = nil
+		return nil, nil
 	case facility != "" && facility != "all" && claims.canSwitchFacility():
 		facilityIdInt, err := strconv.Atoi(facility)
 		if err != nil {
-			return newInvalidIdServiceError(err, "facility")
+			return nil, newInvalidIdServiceError(err, "facility")
 		}
 		ref := uint(facilityIdInt)
-		facilityID = &ref
+		return &ref, nil
 	default:
-		facilityID = &args.FacilityID
+		return &ownFacilityID, nil
+	}
+}
+
+func (srv *Server) handleDepartmentLoginTrend(w http.ResponseWriter, r *http.Request, log sLog) error {
+	args := srv.getQueryContext(r)
+	claims := r.Context().Value(ClaimsKey).(*Claims)
+	facilityID, err := resolveFacilityFilter(claims, r.URL.Query().Get("facility"), args.FacilityID)
+	if err != nil {
+		return err
 	}
 	start, end, _, err := parseDateRangeRequest(r)
 	if err != nil {
@@ -300,6 +306,53 @@ func (srv *Server) handleDepartmentLoginTrend(w http.ResponseWriter, r *http.Req
 		return newDatabaseServiceError(err)
 	}
 	return writeJsonResponse(w, http.StatusOK, trend)
+}
+
+func (srv *Server) handleKnowledgeCenterMetrics(w http.ResponseWriter, r *http.Request, log sLog) error {
+	args := srv.getQueryContext(r)
+	claims := r.Context().Value(ClaimsKey).(*Claims)
+	facilityID, err := resolveFacilityFilter(claims, r.URL.Query().Get("facility"), args.FacilityID)
+	if err != nil {
+		return err
+	}
+	start, end, _, err := parseDateRangeRequest(r)
+	if err != nil {
+		return err
+	}
+	total, unique, err := srv.Db.GetKCInteractionStats(&args, start, end, facilityID)
+	if err != nil {
+		return newDatabaseServiceError(err)
+	}
+	avgSession, err := srv.Db.GetKCAvgSessionMinutes(&args, start, end, facilityID)
+	if err != nil {
+		return newDatabaseServiceError(err)
+	}
+	repeat, err := srv.Db.GetKCRepeatEngagement(&args, start, end, facilityID)
+	if err != nil {
+		return newDatabaseServiceError(err)
+	}
+	categories, err := srv.Db.GetKCLibraryViewsByCategory(&args, start, end, facilityID)
+	if err != nil {
+		return newDatabaseServiceError(err)
+	}
+	topLibraries, err := srv.Db.GetKCTopLibraries(&args, start, end, facilityID, 8)
+	if err != nil {
+		return newDatabaseServiceError(err)
+	}
+	topVideos, err := srv.Db.GetKCTopVideos(&args, start, end, facilityID, 8)
+	if err != nil {
+		return newDatabaseServiceError(err)
+	}
+	metrics := models.KnowledgeCenterMetrics{
+		TotalInteractions:      total,
+		UniqueResidents:        unique,
+		AvgSessionMinutes:      avgSession,
+		RepeatEngagement:       repeat,
+		LibraryViewsByCategory: categories,
+		TopLibraries:           topLibraries,
+		TopVideos:              topVideos,
+	}
+	return writeJsonResponse(w, http.StatusOK, metrics)
 }
 
 func (srv *Server) handleFacilityEngagementComparison(w http.ResponseWriter, r *http.Request, log sLog) error {

--- a/backend/src/handlers/dashboard.go
+++ b/backend/src/handlers/dashboard.go
@@ -319,7 +319,7 @@ func (srv *Server) handleKnowledgeCenterMetrics(w http.ResponseWriter, r *http.R
 	if err != nil {
 		return err
 	}
-	total, unique, err := srv.Db.GetKCInteractionStats(&args, start, end, facilityID)
+	total, unique, totalChange, err := srv.Db.GetKCInteractionStats(&args, start, end, facilityID)
 	if err != nil {
 		return newDatabaseServiceError(err)
 	}
@@ -344,13 +344,14 @@ func (srv *Server) handleKnowledgeCenterMetrics(w http.ResponseWriter, r *http.R
 		return newDatabaseServiceError(err)
 	}
 	metrics := models.KnowledgeCenterMetrics{
-		TotalInteractions:      total,
-		UniqueResidents:        unique,
-		AvgSessionMinutes:      avgSession,
-		RepeatEngagement:       repeat,
-		LibraryViewsByCategory: categories,
-		TopLibraries:           topLibraries,
-		TopVideos:              topVideos,
+		TotalInteractions:       total,
+		TotalInteractionsChange: totalChange,
+		UniqueResidents:         unique,
+		AvgSessionMinutes:       avgSession,
+		RepeatEngagement:        repeat,
+		LibraryViewsByCategory:  categories,
+		TopLibraries:            topLibraries,
+		TopVideos:               topVideos,
 	}
 	return writeJsonResponse(w, http.StatusOK, metrics)
 }

--- a/backend/src/models/open_content.go
+++ b/backend/src/models/open_content.go
@@ -57,13 +57,14 @@ type OpenContentParams struct {
 func (OpenContentActivity) TableName() string { return "open_content_activities" }
 
 type KnowledgeCenterMetrics struct {
-	TotalInteractions      int64            `json:"total_interactions"`
-	UniqueResidents        int64            `json:"unique_residents"`
-	AvgSessionMinutes      float64          `json:"avg_session_minutes"`
-	RepeatEngagement       RepeatEngagement `json:"repeat_engagement"`
-	LibraryViewsByCategory []CategoryViews  `json:"library_views_by_category"`
-	TopLibraries           []KCContentRow   `json:"top_libraries"`
-	TopVideos              []KCContentRow   `json:"top_videos"`
+	TotalInteractions       int64            `json:"total_interactions"`
+	TotalInteractionsChange int              `json:"total_interactions_change"`
+	UniqueResidents         int64            `json:"unique_residents"`
+	AvgSessionMinutes       float64          `json:"avg_session_minutes"`
+	RepeatEngagement        RepeatEngagement `json:"repeat_engagement"`
+	LibraryViewsByCategory  []CategoryViews  `json:"library_views_by_category"`
+	TopLibraries            []KCContentRow   `json:"top_libraries"`
+	TopVideos               []KCContentRow   `json:"top_videos"`
 }
 
 type RepeatEngagement struct {
@@ -80,6 +81,7 @@ type CategoryViews struct {
 type KCContentRow struct {
 	Title  string `json:"title"`
 	Visits int64  `json:"visits"`
+	Change int    `json:"change"`
 }
 
 type OpenContentUrl struct {

--- a/backend/src/models/open_content.go
+++ b/backend/src/models/open_content.go
@@ -56,6 +56,32 @@ type OpenContentParams struct {
 
 func (OpenContentActivity) TableName() string { return "open_content_activities" }
 
+type KnowledgeCenterMetrics struct {
+	TotalInteractions      int64            `json:"total_interactions"`
+	UniqueResidents        int64            `json:"unique_residents"`
+	AvgSessionMinutes      float64          `json:"avg_session_minutes"`
+	RepeatEngagement       RepeatEngagement `json:"repeat_engagement"`
+	LibraryViewsByCategory []CategoryViews  `json:"library_views_by_category"`
+	TopLibraries           []KCContentRow   `json:"top_libraries"`
+	TopVideos              []KCContentRow   `json:"top_videos"`
+}
+
+type RepeatEngagement struct {
+	Once      int64 `json:"once"`
+	TwoToFour int64 `json:"two_to_four"`
+	FivePlus  int64 `json:"five_plus"`
+}
+
+type CategoryViews struct {
+	Category string `json:"category"`
+	Views    int64  `json:"views"`
+}
+
+type KCContentRow struct {
+	Title  string `json:"title"`
+	Visits int64  `json:"visits"`
+}
+
 type OpenContentUrl struct {
 	ID         uint   `gorm:"primaryKey" json:"-"`
 	ContentURL string `gorm:"size:255" json:"content_url"`

--- a/backend/src/models/tags.go
+++ b/backend/src/models/tags.go
@@ -6,3 +6,11 @@ type Tag struct {
 }
 
 func (Tag) TableName() string { return "tags" }
+
+type OpenContentTag struct {
+	TagID                 uint `gorm:"primaryKey" json:"tag_id"`
+	ContentID             uint `gorm:"primaryKey" json:"content_id"`
+	OpenContentProviderID uint `gorm:"primaryKey" json:"open_content_provider_id"`
+}
+
+func (OpenContentTag) TableName() string { return "open_content_tags" }

--- a/backend/tests/integration/knowledge_center_test.go
+++ b/backend/tests/integration/knowledge_center_test.go
@@ -51,6 +51,10 @@ func TestKnowledgeCenterMetrics(t *testing.T) {
 	day := func(hour, min int) time.Time {
 		return time.Date(2026, 1, 15, hour, min, 0, 0, time.UTC)
 	}
+	// prior window for [01-15, 01-17) is [01-13, 01-15); seed on 01-14
+	priorDay := func(hour, min int) time.Time {
+		return time.Date(2026, 1, 14, hour, min, 0, 0, time.UTC)
+	}
 	activities := []models.OpenContentActivity{
 		// U1: career library twice + one video (3 interactions)
 		{FacilityID: facility.ID, UserID: u1.ID, OpenContentProviderID: kiwix.ID, ContentID: careerLib.ID, OpenContentUrlID: 1, RequestTS: day(9, 0), StopTS: day(9, 10)},
@@ -60,6 +64,11 @@ func TestKnowledgeCenterMetrics(t *testing.T) {
 		{FacilityID: facility.ID, UserID: u2.ID, OpenContentProviderID: kiwix.ID, ContentID: recoveryLib.ID, OpenContentUrlID: 1, RequestTS: day(10, 0), StopTS: day(10, 20)},
 		// U3: video once
 		{FacilityID: facility.ID, UserID: u3.ID, OpenContentProviderID: youtube.ID, ContentID: weldingVideo.ID, OpenContentUrlID: 1, RequestTS: day(11, 0), StopTS: day(11, 30)},
+		// PRIOR window (01-14): career x1, video x3 -> prior total 4 (recovery has none)
+		{FacilityID: facility.ID, UserID: u1.ID, OpenContentProviderID: kiwix.ID, ContentID: careerLib.ID, OpenContentUrlID: 1, RequestTS: priorDay(9, 0), StopTS: priorDay(9, 5)},
+		{FacilityID: facility.ID, UserID: u1.ID, OpenContentProviderID: youtube.ID, ContentID: weldingVideo.ID, OpenContentUrlID: 1, RequestTS: priorDay(9, 0), StopTS: priorDay(9, 5)},
+		{FacilityID: facility.ID, UserID: u2.ID, OpenContentProviderID: youtube.ID, ContentID: weldingVideo.ID, OpenContentUrlID: 1, RequestTS: priorDay(10, 0), StopTS: priorDay(10, 5)},
+		{FacilityID: facility.ID, UserID: u3.ID, OpenContentProviderID: youtube.ID, ContentID: weldingVideo.ID, OpenContentUrlID: 1, RequestTS: priorDay(11, 0), StopTS: priorDay(11, 5)},
 	}
 	for i := range activities {
 		require.NoError(t, env.DB.Create(&activities[i]).Error)
@@ -74,6 +83,8 @@ func TestKnowledgeCenterMetrics(t *testing.T) {
 		GetData()
 
 	require.Equal(t, int64(5), metrics.TotalInteractions)
+	// prior window total = 4 -> change = (5-4)/4 = 25%
+	require.Equal(t, 25, metrics.TotalInteractionsChange)
 	require.Equal(t, int64(3), metrics.UniqueResidents)
 	// durations (min): 10, 5, 10, 20, 30 -> avg 15
 	require.InDelta(t, 15.0, metrics.AvgSessionMinutes, 0.01)
@@ -83,11 +94,13 @@ func TestKnowledgeCenterMetrics(t *testing.T) {
 		{Category: "Vocational", Views: 2},
 		{Category: "Life Skills", Views: 1},
 	}, metrics.LibraryViewsByCategory)
+	// career prior 1 -> +100%; recovery prior 0 -> 0%
 	require.Equal(t, []models.KCContentRow{
-		{Title: "Career Library", Visits: 2},
-		{Title: "Recovery Library", Visits: 1},
+		{Title: "Career Library", Visits: 2, Change: 100},
+		{Title: "Recovery Library", Visits: 1, Change: 0},
 	}, metrics.TopLibraries)
+	// welding prior 3 -> (2-3)/3 = -33%
 	require.Equal(t, []models.KCContentRow{
-		{Title: "Welding Basics", Visits: 2},
+		{Title: "Welding Basics", Visits: 2, Change: -33},
 	}, metrics.TopVideos)
 }

--- a/backend/tests/integration/knowledge_center_test.go
+++ b/backend/tests/integration/knowledge_center_test.go
@@ -1,0 +1,93 @@
+package integration
+
+import (
+	"UnlockEdv2/src/handlers"
+	"UnlockEdv2/src/models"
+	"net/http"
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestKnowledgeCenterMetrics(t *testing.T) {
+	env := SetupTestEnv(t)
+	defer env.CleanupTestEnv()
+
+	facility, err := env.CreateTestFacility("KC Facility")
+	require.NoError(t, err)
+
+	kiwix := &models.OpenContentProvider{Title: "Kiwix", Url: "http://kiwix"}
+	require.NoError(t, env.DB.Create(kiwix).Error)
+	youtube := &models.OpenContentProvider{Title: "YouTube", Url: "http://youtube"}
+	require.NoError(t, env.DB.Create(youtube).Error)
+
+	careerLib := &models.Library{OpenContentProviderID: kiwix.ID, Title: "Career Library", Url: "/career"}
+	require.NoError(t, env.DB.Create(careerLib).Error)
+	recoveryLib := &models.Library{OpenContentProviderID: kiwix.ID, Title: "Recovery Library", Url: "/recovery"}
+	require.NoError(t, env.DB.Create(recoveryLib).Error)
+	weldingVideo := &models.Video{OpenContentProviderID: youtube.ID, Title: "Welding Basics", Url: "/welding", ExternalID: "vid1"}
+	require.NoError(t, env.DB.Create(weldingVideo).Error)
+
+	vocational := &models.Tag{Name: "Vocational"}
+	require.NoError(t, env.DB.Create(vocational).Error)
+	lifeSkills := &models.Tag{Name: "Life Skills"}
+	require.NoError(t, env.DB.Create(lifeSkills).Error)
+	require.NoError(t, env.DB.Create(&models.OpenContentTag{
+		TagID: vocational.ID, ContentID: careerLib.ID, OpenContentProviderID: kiwix.ID,
+	}).Error)
+	require.NoError(t, env.DB.Create(&models.OpenContentTag{
+		TagID: lifeSkills.ID, ContentID: recoveryLib.ID, OpenContentProviderID: kiwix.ID,
+	}).Error)
+
+	u1, err := env.CreateTestUser("userone", models.Student, facility.ID, "")
+	require.NoError(t, err)
+	u2, err := env.CreateTestUser("usertwo", models.Student, facility.ID, "")
+	require.NoError(t, err)
+	u3, err := env.CreateTestUser("userthree", models.Student, facility.ID, "")
+	require.NoError(t, err)
+
+	day := func(hour, min int) time.Time {
+		return time.Date(2026, 1, 15, hour, min, 0, 0, time.UTC)
+	}
+	activities := []models.OpenContentActivity{
+		// U1: career library twice + one video (3 interactions)
+		{FacilityID: facility.ID, UserID: u1.ID, OpenContentProviderID: kiwix.ID, ContentID: careerLib.ID, OpenContentUrlID: 1, RequestTS: day(9, 0), StopTS: day(9, 10)},
+		{FacilityID: facility.ID, UserID: u1.ID, OpenContentProviderID: kiwix.ID, ContentID: careerLib.ID, OpenContentUrlID: 1, RequestTS: day(14, 0), StopTS: day(14, 5)},
+		{FacilityID: facility.ID, UserID: u1.ID, OpenContentProviderID: youtube.ID, ContentID: weldingVideo.ID, OpenContentUrlID: 1, RequestTS: day(16, 0), StopTS: day(16, 10)},
+		// U2: recovery library once
+		{FacilityID: facility.ID, UserID: u2.ID, OpenContentProviderID: kiwix.ID, ContentID: recoveryLib.ID, OpenContentUrlID: 1, RequestTS: day(10, 0), StopTS: day(10, 20)},
+		// U3: video once
+		{FacilityID: facility.ID, UserID: u3.ID, OpenContentProviderID: youtube.ID, ContentID: weldingVideo.ID, OpenContentUrlID: 1, RequestTS: day(11, 0), StopTS: day(11, 30)},
+	}
+	for i := range activities {
+		require.NoError(t, env.DB.Create(&activities[i]).Error)
+	}
+
+	metrics := NewRequest[models.KnowledgeCenterMetrics](env.Client, t, http.MethodGet,
+		"/api/department-metrics/knowledge-center?facility="+strconv.Itoa(int(facility.ID))+
+			"&start_date=2026-01-15&end_date=2026-01-16", nil).
+		WithTestClaims(&handlers.Claims{Role: models.FacilityAdmin, FacilityID: facility.ID}).
+		Do().
+		ExpectStatus(http.StatusOK).
+		GetData()
+
+	require.Equal(t, int64(5), metrics.TotalInteractions)
+	require.Equal(t, int64(3), metrics.UniqueResidents)
+	// durations (min): 10, 5, 10, 20, 30 -> avg 15
+	require.InDelta(t, 15.0, metrics.AvgSessionMinutes, 0.01)
+	// interaction counts per resident: u1=3 (2-4), u2=1 (once), u3=1 (once)
+	require.Equal(t, models.RepeatEngagement{Once: 2, TwoToFour: 1, FivePlus: 0}, metrics.RepeatEngagement)
+	require.Equal(t, []models.CategoryViews{
+		{Category: "Vocational", Views: 2},
+		{Category: "Life Skills", Views: 1},
+	}, metrics.LibraryViewsByCategory)
+	require.Equal(t, []models.KCContentRow{
+		{Title: "Career Library", Visits: 2},
+		{Title: "Recovery Library", Visits: 1},
+	}, metrics.TopLibraries)
+	require.Equal(t, []models.KCContentRow{
+		{Title: "Welding Basics", Visits: 2},
+	}, metrics.TopVideos)
+}

--- a/frontend/src/pages/insights/KCContentTable.tsx
+++ b/frontend/src/pages/insights/KCContentTable.tsx
@@ -38,13 +38,14 @@ export function KCContentTable({
                         <TableHead className="text-right">
                             {valueLabel}
                         </TableHead>
+                        <TableHead className="text-right">Δ</TableHead>
                     </TableRow>
                 </TableHeader>
                 <TableBody>
                     {rows.length === 0 ? (
                         <TableRow>
                             <TableCell
-                                colSpan={2}
+                                colSpan={3}
                                 className="h-20 text-center text-muted-foreground"
                             >
                                 No activity in this range
@@ -58,6 +59,12 @@ export function KCContentTable({
                                 </TableCell>
                                 <TableCell className="text-right text-muted-foreground">
                                     {row.visits.toLocaleString()}
+                                </TableCell>
+                                <TableCell
+                                    className={`text-right ${row.change >= 0 ? 'text-brand' : 'text-red-500'}`}
+                                >
+                                    {row.change >= 0 ? '+' : ''}
+                                    {row.change}%
                                 </TableCell>
                             </TableRow>
                         ))

--- a/frontend/src/pages/insights/KCContentTable.tsx
+++ b/frontend/src/pages/insights/KCContentTable.tsx
@@ -1,0 +1,69 @@
+import { KCContentRow } from '@/types';
+import {
+    Table,
+    TableBody,
+    TableCell,
+    TableHead,
+    TableHeader,
+    TableRow
+} from '@/components/ui/table';
+
+interface KCContentTableProps {
+    title: string;
+    nameLabel: string;
+    valueLabel: string;
+    rows: KCContentRow[];
+}
+
+export function KCContentTable({
+    title,
+    nameLabel,
+    valueLabel,
+    rows
+}: KCContentTableProps) {
+    return (
+        <div className="bg-card rounded-lg border border-border overflow-hidden">
+            <div className="flex items-center justify-between px-6 pt-5 pb-4">
+                <h3 className="text-brand-dark dark:text-white font-medium">
+                    {title}
+                </h3>
+                <span className="text-sm text-muted-foreground">
+                    {valueLabel}
+                </span>
+            </div>
+            <Table>
+                <TableHeader>
+                    <TableRow>
+                        <TableHead>{nameLabel}</TableHead>
+                        <TableHead className="text-right">
+                            {valueLabel}
+                        </TableHead>
+                    </TableRow>
+                </TableHeader>
+                <TableBody>
+                    {rows.length === 0 ? (
+                        <TableRow>
+                            <TableCell
+                                colSpan={2}
+                                className="h-20 text-center text-muted-foreground"
+                            >
+                                No activity in this range
+                            </TableCell>
+                        </TableRow>
+                    ) : (
+                        rows.map((row) => (
+                            <TableRow key={row.title}>
+                                <TableCell className="text-muted-foreground">
+                                    {row.title}
+                                </TableCell>
+                                <TableCell className="text-right text-muted-foreground">
+                                    {row.visits.toLocaleString()}
+                                </TableCell>
+                            </TableRow>
+                        ))
+                    )}
+                </TableBody>
+            </Table>
+        </div>
+    );
+}

--- a/frontend/src/pages/insights/KnowledgeCenterTab.tsx
+++ b/frontend/src/pages/insights/KnowledgeCenterTab.tsx
@@ -22,6 +22,10 @@ function pct(part: number, whole: number): number {
     return whole > 0 ? Math.round((part / whole) * 100) : 0;
 }
 
+function deltaLabel(change: number): string {
+    return `${change >= 0 ? '+' : ''}${change}% vs prior period`;
+}
+
 function formatSessionLength(minutes: number): string {
     const totalSeconds = Math.round(minutes * 60);
     const mins = Math.floor(totalSeconds / 60);
@@ -72,7 +76,7 @@ export default function KnowledgeCenterTab({
     const segments = [
         { label: 'Once', count: once, className: 'bg-brand-dark' },
         { label: '2-4 visits', count: two_to_four, className: 'bg-brand' },
-        { label: '5+ visits', count: five_plus, className: 'bg-brand/60' }
+        { label: '5+ visits', count: five_plus, className: 'bg-brand-light' }
     ];
 
     return (
@@ -89,7 +93,7 @@ export default function KnowledgeCenterTab({
                         icon={BookOpenIcon}
                         value={metrics.total_interactions.toLocaleString()}
                         label="Total KC Interactions"
-                        sub="opens, plays & link clicks"
+                        sub={deltaLabel(metrics.total_interactions_change)}
                         tooltip="Total opens, video plays, and link clicks in the Knowledge Center in the selected range."
                     />
                     <MetricCard

--- a/frontend/src/pages/insights/KnowledgeCenterTab.tsx
+++ b/frontend/src/pages/insights/KnowledgeCenterTab.tsx
@@ -1,12 +1,234 @@
-import { BookOpenIcon } from '@heroicons/react/24/outline';
-import { EmptyState } from '@/components/shared';
+import useSWR from 'swr';
+import {
+    BookOpenIcon,
+    UsersIcon,
+    ClockIcon,
+    ArrowPathIcon
+} from '@heroicons/react/24/outline';
+import { KnowledgeCenterMetrics, ServerResponseOne } from '@/types';
+import { Skeleton } from '@/components/ui/skeleton';
+import { InfoTooltip } from '@/components/shared';
+import { MetricCard } from './MetricCard';
+import { KCContentTable } from './KCContentTable';
+import { InsightsDateParams } from './insightsRange';
 
-export default function KnowledgeCenterTab() {
+interface KnowledgeCenterTabProps {
+    dateParams: InsightsDateParams;
+    selectedFacility: string;
+    rangeLabel: string;
+}
+
+function pct(part: number, whole: number): number {
+    return whole > 0 ? Math.round((part / whole) * 100) : 0;
+}
+
+function formatSessionLength(minutes: number): string {
+    const totalSeconds = Math.round(minutes * 60);
+    const mins = Math.floor(totalSeconds / 60);
+    const secs = totalSeconds % 60;
+    return `${mins}m ${secs}s`;
+}
+
+export default function KnowledgeCenterTab({
+    dateParams,
+    selectedFacility,
+    rangeLabel
+}: KnowledgeCenterTabProps) {
+    const query = `facility=${selectedFacility}&start_date=${dateParams.start_date}&end_date=${dateParams.end_date}`;
+    const { data, isLoading } = useSWR<
+        ServerResponseOne<KnowledgeCenterMetrics>
+    >(`/api/department-metrics/knowledge-center?${query}`);
+
+    if (isLoading) {
+        return (
+            <div className="space-y-6">
+                <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
+                    {Array.from({ length: 4 }).map((_, i) => (
+                        <Skeleton key={i} className="h-28 w-full rounded-lg" />
+                    ))}
+                </div>
+                <Skeleton className="h-40 w-full rounded-lg" />
+                <Skeleton className="h-40 w-full rounded-lg" />
+            </div>
+        );
+    }
+
+    const metrics = data?.data;
+    if (!metrics) {
+        return (
+            <div className="bg-card rounded-lg border border-border p-8 text-center text-muted-foreground">
+                No Knowledge Center data available for this selection.
+            </div>
+        );
+    }
+
+    const { once, two_to_four, five_plus } = metrics.repeat_engagement;
+    const repeatTotal = once + two_to_four + five_plus;
+    const maxCategoryViews = Math.max(
+        1,
+        ...metrics.library_views_by_category.map((c) => c.views)
+    );
+
+    const segments = [
+        { label: 'Once', count: once, className: 'bg-brand-dark' },
+        { label: '2-4 visits', count: two_to_four, className: 'bg-brand' },
+        { label: '5+ visits', count: five_plus, className: 'bg-brand/60' }
+    ];
+
     return (
-        <EmptyState
-            icon={<BookOpenIcon className="size-6 text-muted-foreground" />}
-            title="Knowledge Center insights coming soon"
-            description="Library and video engagement metrics will appear here in an upcoming release."
-        />
+        <div className="space-y-6">
+            <div>
+                <h2 className="text-brand-dark dark:text-white mb-1 text-lg font-medium">
+                    At a glance
+                </h2>
+                <p className="text-sm text-muted-foreground mb-4">
+                    {rangeLabel}
+                </p>
+                <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
+                    <MetricCard
+                        icon={BookOpenIcon}
+                        value={metrics.total_interactions.toLocaleString()}
+                        label="Total KC Interactions"
+                        sub="opens, plays & link clicks"
+                        tooltip="Total opens, video plays, and link clicks in the Knowledge Center in the selected range."
+                    />
+                    <MetricCard
+                        icon={UsersIcon}
+                        value={metrics.unique_residents.toLocaleString()}
+                        label="Unique Residents"
+                        sub="distinct residents"
+                        tooltip="Distinct residents who accessed any Knowledge Center content in the selected range."
+                    />
+                    <MetricCard
+                        icon={ClockIcon}
+                        value={formatSessionLength(metrics.avg_session_minutes)}
+                        label="Avg Session Length"
+                        sub="per interaction"
+                        tooltip="Average duration of a Knowledge Center interaction (open to close) in the selected range."
+                    />
+                    <MetricCard
+                        icon={ArrowPathIcon}
+                        value={`${pct(five_plus, repeatTotal)}%`}
+                        label="Repeat Engagement"
+                        sub="5+ visits in range"
+                        tooltip="Share of Knowledge Center users who returned 5 or more times in the selected range."
+                    />
+                </div>
+            </div>
+
+            <div className="bg-card rounded-lg border border-border p-6">
+                <div className="flex items-center justify-between mb-1">
+                    <h3 className="text-brand-dark dark:text-white font-medium">
+                        Repeat Engagement
+                    </h3>
+                    <span className="text-sm text-muted-foreground">
+                        Unique users by visit count
+                    </span>
+                </div>
+                <p className="text-sm text-muted-foreground mb-4">
+                    How many times did residents return to the Knowledge Center?
+                </p>
+                {repeatTotal === 0 ? (
+                    <p className="text-sm text-muted-foreground">
+                        No Knowledge Center visits in this range.
+                    </p>
+                ) : (
+                    <>
+                        <div className="flex rounded-lg overflow-hidden h-9 mb-3">
+                            {segments.map(
+                                (segment) =>
+                                    segment.count > 0 && (
+                                        <div
+                                            key={segment.label}
+                                            className={`flex items-center justify-center text-white text-xs ${segment.className}`}
+                                            style={{
+                                                width: `${pct(segment.count, repeatTotal)}%`
+                                            }}
+                                        >
+                                            {segment.label} ·{' '}
+                                            {pct(segment.count, repeatTotal)}%
+                                        </div>
+                                    )
+                            )}
+                        </div>
+                        <div className="flex flex-wrap gap-x-6 gap-y-1 text-sm text-muted-foreground">
+                            {segments.map((segment) => (
+                                <span key={segment.label}>
+                                    {segment.label} (
+                                    {segment.count.toLocaleString()} users)
+                                </span>
+                            ))}
+                        </div>
+                    </>
+                )}
+            </div>
+
+            <div className="bg-card rounded-lg border border-border p-6">
+                <div className="flex items-center justify-between mb-1">
+                    <h3 className="text-brand-dark dark:text-white font-medium">
+                        Library Views by Category
+                    </h3>
+                    <span className="text-sm text-muted-foreground">
+                        Total views · libraries only
+                    </span>
+                </div>
+                <div className="flex items-start gap-2 mb-5">
+                    <InfoTooltip>
+                        Total library views across categories for the selected
+                        range. Video content is a separate resource type and is
+                        not counted here.
+                    </InfoTooltip>
+                    <p className="text-xs text-muted-foreground">
+                        Library views grouped by category tag.
+                    </p>
+                </div>
+                {metrics.library_views_by_category.length === 0 ? (
+                    <p className="text-sm text-muted-foreground">
+                        No categorized library views in this range.
+                    </p>
+                ) : (
+                    <div className="border border-border rounded-lg overflow-hidden">
+                        {metrics.library_views_by_category.map(
+                            (category, i) => (
+                                <div
+                                    key={category.category}
+                                    className={`flex items-center gap-4 px-4 py-3 ${i < metrics.library_views_by_category.length - 1 ? 'border-b border-border' : ''}`}
+                                >
+                                    <span className="text-sm text-muted-foreground w-44 shrink-0">
+                                        {category.category}
+                                    </span>
+                                    <div className="flex-1 bg-muted rounded-full h-2.5 overflow-hidden">
+                                        <div
+                                            className="h-full rounded-full bg-brand"
+                                            style={{
+                                                width: `${(category.views / maxCategoryViews) * 100}%`
+                                            }}
+                                        />
+                                    </div>
+                                    <span className="text-sm text-muted-foreground w-14 text-right shrink-0">
+                                        {category.views.toLocaleString()}
+                                    </span>
+                                </div>
+                            )
+                        )}
+                    </div>
+                )}
+            </div>
+
+            <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+                <KCContentTable
+                    title="Top Libraries Accessed"
+                    nameLabel="Library"
+                    valueLabel="Opens"
+                    rows={metrics.top_libraries}
+                />
+                <KCContentTable
+                    title="Top Videos Accessed"
+                    nameLabel="Video"
+                    valueLabel="Views"
+                    rows={metrics.top_videos}
+                />
+            </div>
+        </div>
     );
 }

--- a/frontend/src/pages/insights/OperationalInsights.tsx
+++ b/frontend/src/pages/insights/OperationalInsights.tsx
@@ -138,7 +138,7 @@ export default function OperationalInsightsPage() {
                 </div>
 
                 <Tabs defaultValue="overview" className="space-y-6">
-                    <TabsList className="bg-card border border-border p-1 h-auto gap-1">
+                    <TabsList className="bg-card border border-gray-200 dark:border-border p-1 h-auto gap-1">
                         <TabsTrigger
                             value="overview"
                             className={TAB_TRIGGER_CLASS}
@@ -161,7 +161,11 @@ export default function OperationalInsightsPage() {
                         />
                     </TabsContent>
                     <TabsContent value="knowledge-center" className="mt-0">
-                        <KnowledgeCenterTab />
+                        <KnowledgeCenterTab
+                            dateParams={dateParams}
+                            selectedFacility={selectedFacility}
+                            rangeLabel={rangeLabel}
+                        />
                     </TabsContent>
                 </Tabs>
             </div>

--- a/frontend/src/pages/insights/OverviewTab.tsx
+++ b/frontend/src/pages/insights/OverviewTab.tsx
@@ -24,7 +24,7 @@ import {
 } from '@/components/ui/table';
 import LoginTrendChart from '@/components/charts/LoginTrendChart';
 import { MetricCard } from './MetricCard';
-import { InsightsDateParams } from './insightsRange';
+import { InsightsDateParams, priorParams } from './insightsRange';
 
 interface OverviewTabProps {
     dateParams: InsightsDateParams;
@@ -54,6 +54,14 @@ function ratio(part: number, whole: number): number {
     return whole > 0 ? Math.round((part / whole) * 10) / 10 : 0;
 }
 
+function changePct(current: number, prior: number): number {
+    return prior > 0 ? Math.round(((current - prior) / prior) * 100) : 0;
+}
+
+function deltaLabel(change: number): string {
+    return `${change >= 0 ? '+' : ''}${change}% vs prior period`;
+}
+
 export default function OverviewTab({
     dateParams,
     selectedFacility,
@@ -71,6 +79,13 @@ export default function OverviewTab({
 
     const { data: trendResp } = useSWR<ServerResponseOne<DailyLoginCount[]>>(
         `/api/department-metrics/login-trend?${query}`
+    );
+
+    const prior = priorParams(dateParams);
+    const { data: priorMetricsResp } = useSWR<
+        ServerResponseOne<DepartmentMetrics>
+    >(
+        `/api/department-metrics?facility=${selectedFacility}&start_date=${prior.start_date}&end_date=${prior.end_date}`
     );
 
     const { data: comparisonResp } = useSWR<
@@ -129,6 +144,10 @@ export default function OverviewTab({
     }
 
     const avgPerActive = ratio(metrics.total_logins, metrics.active_users);
+    const newUsersChange = changePct(
+        metrics.new_residents_added,
+        priorMetricsResp?.data.data.new_residents_added ?? 0
+    );
 
     return (
         <div className="space-y-6">
@@ -158,7 +177,7 @@ export default function OverviewTab({
                         icon={UserPlusIcon}
                         value={metrics.new_residents_added.toLocaleString()}
                         label="New Users Added"
-                        sub="in selected range"
+                        sub={deltaLabel(newUsersChange)}
                         tooltip="New resident accounts created in the selected date range."
                     />
                     <MetricCard

--- a/frontend/src/pages/insights/insightsRange.ts
+++ b/frontend/src/pages/insights/insightsRange.ts
@@ -34,6 +34,21 @@ function daysAgo(end: Date, count: number): Date {
     return start;
 }
 
+export function priorParams(params: InsightsDateParams): InsightsDateParams {
+    const start = new Date(`${params.start_date}T00:00:00`);
+    const end = new Date(`${params.end_date}T00:00:00`);
+    const durationDays =
+        Math.round((end.getTime() - start.getTime()) / 86400000) + 1;
+    const priorEnd = new Date(start);
+    priorEnd.setDate(start.getDate() - 1);
+    const priorStart = new Date(start);
+    priorStart.setDate(start.getDate() - durationDays);
+    return {
+        start_date: formatDate(priorStart),
+        end_date: formatDate(priorEnd)
+    };
+}
+
 export function rangeToParams(
     range: InsightsRangeKey,
     customFrom: string,

--- a/frontend/src/styles/globals.css
+++ b/frontend/src/styles/globals.css
@@ -41,6 +41,7 @@
     --sidebar-ring: #b3b3b3;
     --brand: #556830;
     --brand-dark: #203622;
+    --brand-light: #8fb55e;
     --brand-gold: #f1b51c;
     --brand-gold-dark: #d9a419;
     --surface-hover: #e2e7ea;
@@ -121,6 +122,7 @@
     --color-sidebar-ring: var(--sidebar-ring);
     --color-brand: var(--brand);
     --color-brand-dark: var(--brand-dark);
+    --color-brand-light: var(--brand-light);
     --color-brand-gold: var(--brand-gold);
     --color-brand-gold-dark: var(--brand-gold-dark);
     --color-surface-hover: var(--surface-hover);

--- a/frontend/src/types/insights.ts
+++ b/frontend/src/types/insights.ts
@@ -212,3 +212,29 @@ export interface FacilityEngagement {
 }
 
 export type InsightsRangeKey = '7D' | '30D' | '90D' | 'YTD' | 'Custom';
+
+export interface RepeatEngagement {
+    once: number;
+    two_to_four: number;
+    five_plus: number;
+}
+
+export interface CategoryViews {
+    category: string;
+    views: number;
+}
+
+export interface KCContentRow {
+    title: string;
+    visits: number;
+}
+
+export interface KnowledgeCenterMetrics {
+    total_interactions: number;
+    unique_residents: number;
+    avg_session_minutes: number;
+    repeat_engagement: RepeatEngagement;
+    library_views_by_category: CategoryViews[];
+    top_libraries: KCContentRow[];
+    top_videos: KCContentRow[];
+}

--- a/frontend/src/types/insights.ts
+++ b/frontend/src/types/insights.ts
@@ -227,10 +227,12 @@ export interface CategoryViews {
 export interface KCContentRow {
     title: string;
     visits: number;
+    change: number;
 }
 
 export interface KnowledgeCenterMetrics {
     total_interactions: number;
+    total_interactions_change: number;
     unique_residents: number;
     avg_session_minutes: number;
     repeat_engagement: RepeatEngagement;


### PR DESCRIPTION
## Pre-Submission PR Checklist

- [x] No debug/console/fmt.Println statements
- [x] Unnecessary development comments removed
- [x] All acceptance criteria verified
- [x] Functions according to **ticket specifications**
- [x] Tested manually where applicable
- [x] Branch rebased with latest main
- [x] No business logic exists within the database layer

## Description of the change
This is the second PR for Operational Insights. This PR pulls more indepth charts and information to the knowledge center side of Operational Insights as well as adds prior-period deltas that compare each metric in the selected time range against the immediately preceeding window of equal length. 

- **Related issues**: Part 2 of [ID-701](https://app.asana.com/1/1201607307149189/project/1209460078641109/task/1215310633886761). Does **not** close the ticket the XLSX export is a separate, follow-up PR.

## Screenshot(s)
<img width="1853" height="922" alt="image" src="https://github.com/user-attachments/assets/2a8ef2c9-ce62-422f-8064-932751f214d0" />
<img width="1502" height="486" alt="image" src="https://github.com/user-attachments/assets/5266f7a3-4fbe-417a-a906-668ab2ef730b" />
<img width="1901" height="932" alt="image" src="https://github.com/user-attachments/assets/a44baeac-cf1b-4fc9-ab28-6d30e70cd36d" />

## Additional context


If any core features or components were removed with this PR, please note them here so that they can be added to the wiki (see [Deprecated features and Components](https://github.com/UnlockedLabs/UnlockEdv2/wiki/Deprecated-Features-and-Components)).
