### PR TITLE
fix: CSS and a11y in class-detail components

### DIFF
--- a/frontend/src/pages/class-detail/ClassNotFoundCard.tsx
+++ b/frontend/src/pages/class-detail/ClassNotFoundCard.tsx
@@ -6,7 +6,7 @@ interface ClassNotFoundCardProps {
 
 export function ClassNotFoundCard({ onBack }: ClassNotFoundCardProps) {
     return (
-        <div className="bg-surface-hover flex items-center justify-center">
+        <div className="flex min-h-screen items-center justify-center bg-surface-hover">
             <div className="card-block p-8 text-center max-w-md">
                 <h2 className="text-xl font-semibold text-brand-dark mb-2">
                     Class Not Found

--- a/frontend/src/pages/class-detail/LoadingSkeleton.tsx
+++ b/frontend/src/pages/class-detail/LoadingSkeleton.tsx
@@ -8,7 +8,7 @@ export function LoadingSkeleton() {
                     <Skeleton className="h-8 w-32 mb-4" />
                     <Skeleton className="h-10 w-80 mb-3" />
                     <Skeleton className="h-5 w-48 mb-4" />
-                    <div className="grid grid-cols-5 gap-4">
+                    <div className="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-5 gap-4">
                         {Array.from({ length: 5 }).map((_, i) => (
                             <Skeleton key={i} className="h-20 rounded-lg" />
                         ))}
@@ -16,7 +16,7 @@ export function LoadingSkeleton() {
                 </div>
             </div>
             <div className="max-w-7xl mx-auto px-6 py-6">
-                <div className="grid grid-cols-3 gap-6 mb-6">
+                <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-6 mb-6">
                     {Array.from({ length: 3 }).map((_, i) => (
                         <Skeleton key={i} className="h-40 rounded-lg" />
                     ))}

--- a/frontend/src/pages/class-detail/SessionRow.tsx
+++ b/frontend/src/pages/class-detail/SessionRow.tsx
@@ -78,24 +78,16 @@ export function SessionRow({
 
     const getIcon = () => {
         if (treatAsFrom)
-            return (
-                <CalendarClock className="size-5 text-gray-400 flex-shrink-0" />
-            );
+            return <CalendarClock className="size-5 text-gray-400 shrink-0" />;
         if (treatAsTo)
-            return (
-                <CalendarClock className="size-5 text-blue-700 flex-shrink-0" />
-            );
+            return <CalendarClock className="size-5 text-blue-700 shrink-0" />;
         if (isCancelled)
-            return (
-                <CalendarOff className="size-5 text-gray-500 flex-shrink-0" />
-            );
+            return <CalendarOff className="size-5 text-gray-500 shrink-0" />;
         if (hasAttendance)
-            return <CheckCircle className="size-5 text-brand flex-shrink-0" />;
+            return <CheckCircle className="size-5 text-brand shrink-0" />;
         if (isPast)
-            return (
-                <AlertCircle className="size-5 text-brand-gold flex-shrink-0" />
-            );
-        return <Calendar className="size-5 text-gray-400 flex-shrink-0" />;
+            return <AlertCircle className="size-5 text-brand-gold shrink-0" />;
+        return <Calendar className="size-5 text-gray-400 shrink-0" />;
     };
 
     const showCheckbox =
@@ -105,6 +97,15 @@ export function SessionRow({
     return (
         <div
             onClick={onClick}
+            role="button"
+            tabIndex={0}
+            onKeyDown={(e) => {
+                if (e.target !== e.currentTarget) return;
+                if (e.key === 'Enter' || e.key === ' ') {
+                    e.preventDefault();
+                    onClick();
+                }
+            }}
             className={`flex items-center justify-between p-4 rounded-lg border transition-colors cursor-pointer ${getBorderClass()}`}
         >
             <div className="flex items-center gap-4 min-w-0">


### PR DESCRIPTION
## Summary

Three small UX/a11y fixes in `frontend/src/pages/class-detail/` surfaced by CodeRabbit on PR #1133. All were preexisting; extracted into named components by Split 3.

- **ClassNotFoundCard** — Added `min-h-screen` to the outer wrapper so `items-center` has a height to center against. Without it the "Class Not Found" card rendered flush to the top of the page. Also corrected Tailwind class order (`bg-surface-hover` moved after layout utilities).

- **LoadingSkeleton** — Replaced fixed `grid-cols-5` and `grid-cols-3` with responsive variants to prevent horizontal overflow on narrow screens:
  - Header: `grid-cols-2 sm:grid-cols-3 lg:grid-cols-5`
  - Cards: `grid-cols-1 sm:grid-cols-2 lg:grid-cols-3`

- **SessionRow** — Added `role="button"`, `tabIndex={0}`, and an `onKeyDown` handler (Enter/Space) to the clickable row div so it is reachable and activatable via keyboard. The handler guards with `e.target !== e.currentTarget` to prevent inner button keypresses (Reschedule, Cancel) from also firing the row's `onClick`. Also updated 6 `flex-shrink-0` → `shrink-0` (canonical Tailwind v3 alias).

## Test plan

- [x] ClassNotFoundCard renders vertically centered at `/program-classes/9999999/detail`
- [x] "Back to Classes" navigates to `/classes`
- [x] LoadingSkeleton header renders 2-col at 375px, 3-col at 768px, 5-col at 1280px
- [x] LoadingSkeleton cards render 1-col at 375px, 2-col at 768px, 3-col at 1280px
- [x] Session rows reachable via Tab with visible focus ring (`:focus-visible`)
- [x] Enter and Space activate the row action; Space does not scroll the page
- [x] Enter on inner Reschedule/Cancel buttons fires only that button's action, not the row's `onClick`
- [x] Past and cancelled session rows keyboard accessible
- [x] No console errors during keyboard navigation

Closes #ID-666


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1214913938577599