### PR TITLE
Truncate Classes page program filter dropdown (ID-700)

### DIFF
--- a/frontend/src/pages/ClassesPage.tsx
+++ b/frontend/src/pages/ClassesPage.tsx
@@ -340,12 +340,16 @@ export default function ClassesPage() {
                                 <Filter className="size-4 mr-2" />
                                 <SelectValue placeholder="All Programs" />
                             </SelectTrigger>
-                            <SelectContent>
+                            <SelectContent className="max-w-55">
                                 <SelectItem value="all">
                                     All Programs
                                 </SelectItem>
                                 {programOptions.map(([id, name]) => (
-                                    <SelectItem key={id} value={String(id)}>
+                                    <SelectItem
+                                        key={id}
+                                        value={String(id)}
+                                        className="truncate"
+                                    >
                                         {name}
                                     </SelectItem>
                                 ))}


### PR DESCRIPTION
a single targeted fix to the program filter dropdown on the Classes page. When a program has a very long name, the open dropdown menu grew to fit the full text — blowing far past the 220px trigger width. The fix adds max-w-55 to SelectContent and truncate to each mapped SelectItem so the menu is capped and long names clip with an ellipsis.

<img width="943" height="879" alt="before_fix_dropdown_open" src="https://github.com/user-attachments/assets/4f0c0280-d2be-4b34-8d29-f4a1f4eb4dad" />


<img width="943" height="879" alt="after_fix_dropdown_open" src="https://github.com/user-attachments/assets/9c68d7f8-18dc-4908-950c-b9a01b3c1554" />


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1215338392202908