### PR TITLE
fix: take attendance/ edit attendance

### DIFF
--- a/backend/src/models/program_classes.go
+++ b/backend/src/models/program_classes.go
@@ -59,6 +59,7 @@ type TodaysScheduleItem struct {
 	Date           string `json:"date"`
 	StartTime      string `json:"start_time"`
 	Room           string `json:"room"`
+	HasAttendance  bool   `json:"has_attendance"`
 }
 
 func (c *ProgramClass) BeforeCreate(tx *gorm.DB) error {

--- a/backend/src/services/classes.go
+++ b/backend/src/services/classes.go
@@ -336,6 +336,25 @@ func (svc *ClassesService) GetTodaysSchedule(args *models.QueryContext, facility
 		}
 	}
 
+	if len(items) > 0 {
+		eventIDs := make([]uint, 0, len(items))
+		dates := make([]string, 0, len(items))
+		for _, item := range items {
+			eventIDs = append(eventIDs, item.EventID)
+			dates = append(dates, item.Date)
+		}
+		attendanceCounts, err := svc.db.GetAttendanceCountsForEvents(args, eventIDs, dates)
+		if err == nil {
+			taken := make(map[string]bool)
+			for _, ac := range attendanceCounts {
+				taken[fmt.Sprintf("%d|%s", ac.EventID, ac.Date)] = true
+			}
+			for i, item := range items {
+				items[i].HasAttendance = taken[fmt.Sprintf("%d|%s", item.EventID, item.Date)]
+			}
+		}
+	}
+
 	sort.Slice(items, func(i, j int) bool {
 		if items[i].Date == items[j].Date { //sorting by date, time, then by name
 			if items[i].StartTime == items[j].StartTime {

--- a/frontend/src/pages/Dashboard.tsx
+++ b/frontend/src/pages/Dashboard.tsx
@@ -377,13 +377,23 @@ function TodaysSchedule({
                                     </div>
                                     <Button
                                         size="sm"
+                                        variant={
+                                            item.has_attendance
+                                                ? 'outline'
+                                                : 'default'
+                                        }
                                         onClick={(e) => {
                                             e.stopPropagation();
                                             onNavigate(item);
                                         }}
-                                        className="bg-brand hover:bg-brand-dark text-white w-full sm:w-auto"
+                                        className={
+                                            item.has_attendance
+                                                ? 'border-gray-300 w-full sm:w-auto'
+                                                : 'bg-brand hover:bg-brand-dark text-white w-full sm:w-auto'
+                                        }
                                     >
-                                        Take Attendance
+                                        {item.has_attendance ? 'Edit' : 'Take'}{' '}
+                                        Attendance
                                     </Button>
                                 </div>
                             );

--- a/frontend/src/types/program.ts
+++ b/frontend/src/types/program.ts
@@ -178,6 +178,7 @@ export interface TodaysScheduleItem {
     date: string;
     start_time: string;
     room: string;
+    has_attendance?: boolean;
 }
 
 export interface ClassMetrics {


### PR DESCRIPTION
## Pre-Submission PR Checklist

- [x] No debug/console/fmt.Println statements
- [x] Unnecessary development comments removed
- [x] All acceptance criteria verified
- [x] Functions according to **ticket specifications**
- [x] Tested manually where applicable
- [x] Branch rebased with latest main
- [x] No business logic exists within the database layer

## Description of the change

After taking attendance for a class session on the Facility Dashboard, the "Take Attendance" button gave no visual indication that action had already been taken. This change makes the button dynamically reflect the real attendance state for each session in Today's Schedule.

- Sessions with no attendance recorded show a green **"Take Attendance"** button (existing style, unchanged)
- Sessions where attendance has already been taken show a gray outline **"Edit Attendance"** button, matching the style used in the Sessions Tab within Class Detail

**Implementation:** `GetTodaysSchedule()` now calls the existing `GetAttendanceCountsForEvents()` DB function (already used by the missing-attendance flow) after building the schedule item list, and sets a new `has_attendance` field on each item. The frontend button renders conditionally based on that field. No new DB queries, no migration needed.


- **Related issues**: Link to related Asana ticket that this closes.
[Asana Task](https://app.asana.com/1/1201607307149189/project/1209460078641109/task/1215507139034429?focus=true)
## Screenshot(s)
<img width="1891" height="1054" alt="image" src="https://github.com/user-attachments/assets/8e5498ae-bf50-4af8-adde-4d8bf21fac81" />
