### PR TITLE
fix: apply to future intended behavior

### DIFF
--- a/backend/src/database/calendar_test.go
+++ b/backend/src/database/calendar_test.go
@@ -365,11 +365,14 @@ func TestDedupeEventDates_PrefersNewestRowOnCollision(t *testing.T) {
 	result := dedupeEventDates(dates)
 
 	assert.Len(t, result, 2, "duplicate date+classTime should collapse to one entry")
+	foundCollisionDate := false
 	for _, d := range result {
 		if d.Date == "2026-01-05" {
+			foundCollisionDate = true
 			assert.Equal(t, uint(2), d.EventID, "newest row should win on collision")
 		}
 	}
+	assert.True(t, foundCollisionDate, "expected deduped result to include 2026-01-05")
 }
 
 func TestDedupeEventDates_KeepsDistinctTimesSameDate(t *testing.T) {

--- a/backend/src/database/calendar_test.go
+++ b/backend/src/database/calendar_test.go
@@ -300,3 +300,85 @@ func TestGenerateEventInstances_InvalidRRULE(t *testing.T) {
 	instances := generateEventInstances(event, startDate, endDate)
 	assert.Len(t, instances, 0, "Instances should be nil when an error occurs")
 }
+
+// dedupeClassEventInstances merges instances expanded from multiple event rows (the
+// state left behind by "Apply to all future sessions"). It must keep distinct
+// sessions, collapse true duplicates, and let the newest row win on a collision.
+func TestDedupeClassEventInstances_PrefersNewestRowOnCollision(t *testing.T) {
+	// EventID 1 is the older capped row, EventID 2 is the newer row. Both produce the
+	// same date and start time — the newest row should win.
+	instances := []models.ClassEventInstance{
+		{EventID: 1, Date: "2026-01-05", ClassTime: "10:00-11:00"},
+		{EventID: 2, Date: "2026-01-05", ClassTime: "10:00-11:00"},
+		{EventID: 1, Date: "2026-01-12", ClassTime: "10:00-11:00"},
+	}
+
+	result := dedupeClassEventInstances(instances)
+
+	assert.Len(t, result, 2, "duplicate date+time should collapse to one instance")
+	// Sorted by date descending.
+	assert.Equal(t, "2026-01-12", result[0].Date)
+	assert.Equal(t, "2026-01-05", result[1].Date)
+	assert.Equal(t, uint(2), result[1].EventID, "newest row should win on collision")
+}
+
+func TestDedupeClassEventInstances_KeepsDistinctTimesSameDate(t *testing.T) {
+	instances := []models.ClassEventInstance{
+		{EventID: 1, Date: "2026-01-05", ClassTime: "09:00-10:00"},
+		{EventID: 1, Date: "2026-01-05", ClassTime: "13:00-14:00"},
+	}
+
+	result := dedupeClassEventInstances(instances)
+
+	assert.Len(t, result, 2, "different start times on the same date are distinct sessions")
+}
+
+func TestDedupeClassEventInstances_MergesAcrossRowsWithoutGap(t *testing.T) {
+	// Simulates the bug: an older capped row's past sessions plus a newer row's
+	// future sessions must all survive the merge.
+	pastFromOldRow := []models.ClassEventInstance{
+		{EventID: 1, Date: "2026-01-05", ClassTime: "10:00-11:00"},
+		{EventID: 1, Date: "2026-01-12", ClassTime: "10:00-11:00"},
+	}
+	futureFromNewRow := []models.ClassEventInstance{
+		{EventID: 2, Date: "2026-01-19", ClassTime: "14:00-15:00"},
+		{EventID: 2, Date: "2026-01-26", ClassTime: "14:00-15:00"},
+	}
+
+	result := dedupeClassEventInstances(append(pastFromOldRow, futureFromNewRow...))
+
+	dates := make([]string, len(result))
+	for i, inst := range result {
+		dates[i] = inst.Date
+	}
+	assert.Equal(t, []string{"2026-01-26", "2026-01-19", "2026-01-12", "2026-01-05"}, dates,
+		"all sessions from both rows should be present, sorted by date descending")
+}
+
+func TestDedupeEventDates_PrefersNewestRowOnCollision(t *testing.T) {
+	dates := []models.EventDates{
+		{EventID: 1, Date: "2026-01-05", ClassTime: "10:00-11:00"},
+		{EventID: 2, Date: "2026-01-05", ClassTime: "10:00-11:00"},
+		{EventID: 1, Date: "2026-01-12", ClassTime: "10:00-11:00"},
+	}
+
+	result := dedupeEventDates(dates)
+
+	assert.Len(t, result, 2, "duplicate date+classTime should collapse to one entry")
+	for _, d := range result {
+		if d.Date == "2026-01-05" {
+			assert.Equal(t, uint(2), d.EventID, "newest row should win on collision")
+		}
+	}
+}
+
+func TestDedupeEventDates_KeepsDistinctTimesSameDate(t *testing.T) {
+	dates := []models.EventDates{
+		{EventID: 1, Date: "2026-01-05", ClassTime: "09:00-10:00"},
+		{EventID: 1, Date: "2026-01-05", ClassTime: "13:00-14:00"},
+	}
+
+	result := dedupeEventDates(dates)
+
+	assert.Len(t, result, 2, "different class times on the same date are distinct entries")
+}

--- a/backend/src/database/class_events.go
+++ b/backend/src/database/class_events.go
@@ -5,6 +5,7 @@ import (
 	"UnlockEdv2/src/models"
 	"cmp"
 	"errors"
+	"regexp"
 	"slices"
 	"sort"
 	"strconv"
@@ -55,38 +56,91 @@ func (db *DB) GetEventById(eventId int) (*models.ProgramClassEvent, error) {
 	return &event, nil
 }
 
-func (db *DB) CreateRescheduleEventSeries(ctx *models.QueryContext, events []models.ProgramClassEvent) error {
+var dtStartDateRegex = regexp.MustCompile(`DTSTART[^\n:]*:(\d{8})`)
+
+func getRuleDTStartDate(rule string) string {
+	m := dtStartDateRegex.FindStringSubmatch(rule)
+	if len(m) < 2 {
+		return ""
+	}
+	return m[1]
+}
+
+// ruleStartsAfterUntil reports whether DTSTART falls after UNTIL (a dead, zero-occurrence row).
+func ruleStartsAfterUntil(rule string) bool {
+	start := getRuleDTStartDate(rule)
+	until := src.GetUntilDateFromRule(rule)
+	if start == "" || len(until) < 8 {
+		return false
+	}
+	return start > until[:8]
+}
+
+// CreateRescheduleEventSeries applies a series-level reschedule or cancel from a cut
+// date (closedSeries' UNTIL, = cut - 1). It reconciles every existing row so the new
+// series owns all sessions on/after the cut: rows starting before the cut are capped to
+// it, rows starting on/after it are soft-deleted. This stays correct when a class has
+// multiple recurrence rows, not just the one being edited.
+func (db *DB) CreateRescheduleEventSeries(ctx *models.QueryContext, classID uint, newSeries, closedSeries models.ProgramClassEvent) error {
+	untilDate := src.GetUntilDateFromRule(closedSeries.RecurrenceRule)
+	if len(untilDate) < 8 {
+		return NewDBError(errors.New("closed_event_series is missing a valid UNTIL date"), "invalid event series request")
+	}
+	cutMinusOne := untilDate[:8] // YYYYMMDD of (cut date - 1)
+
 	tx := db.WithContext(ctx.Ctx).Begin()
 	if tx.Error != nil {
 		return NewDBError(tx.Error, "unable to start the database transaction")
 	}
 
-	var changeLogEntry *models.ChangeLogEntry
-	for _, event := range events {
-		if event.ID == 0 {
-			logField := "event_rescheduled_series"
-			if event.IsCancelled {
-				logField = "event_cancelled_series"
-			}
-			changeLogEntry = models.NewChangeLogEntry("program_classes", logField, models.StringPtr(""), &event.RecurrenceRule, event.ClassID, ctx.UserID)
-			if err := tx.Create(&event).Error; err != nil {
-				tx.Rollback()
-				return newCreateDBError(err, "program_class_events")
-			}
-		} else {
-			if err := tx.Model(&models.ProgramClassEvent{}).Where("id = ?", event.ID).Update("recurrence_rule", event.RecurrenceRule).Error; err != nil {
+	var existing []models.ProgramClassEvent
+	if err := tx.Where("class_id = ?", classID).Find(&existing).Error; err != nil {
+		tx.Rollback()
+		return newGetRecordsDBError(err, "program_class_events")
+	}
+
+	for i := range existing {
+		row := existing[i]
+		if dtStart := getRuleDTStartDate(row.RecurrenceRule); dtStart != "" && dtStart > cutMinusOne {
+			if err := tx.Delete(&models.ProgramClassEvent{}, row.ID).Error; err != nil {
 				tx.Rollback()
 				return newUpdateDBError(err, "program_class_events")
 			}
+			continue
+		}
+		// Skip rows that already end on/before the cut; only ever shorten, never extend.
+		if existingUntil := src.GetUntilDateFromRule(row.RecurrenceRule); len(existingUntil) >= 8 && existingUntil[:8] <= cutMinusOne {
+			continue
+		}
+		cappedRule := src.ReplaceOrAddUntilDate(row.RecurrenceRule, untilDate)
+		if cappedRule == row.RecurrenceRule {
+			continue
+		}
+		if err := tx.Model(&models.ProgramClassEvent{}).Where("id = ?", row.ID).Update("recurrence_rule", cappedRule).Error; err != nil {
+			tx.Rollback()
+			return newUpdateDBError(err, "program_class_events")
 		}
 	}
 
-	if changeLogEntry != nil {
+	// Create the new series from the cut, unless it would be empty (DTSTART after UNTIL).
+	if newSeries.RecurrenceRule != "" && !ruleStartsAfterUntil(newSeries.RecurrenceRule) {
+		newSeries.ID = 0
+		newSeries.ClassID = classID
+		logField := "event_rescheduled_series"
+		if newSeries.IsCancelled {
+			logField = "event_cancelled_series"
+		}
+		changeLogEntry := models.NewChangeLogEntry("program_classes", logField, models.StringPtr(""), &newSeries.RecurrenceRule, classID, ctx.UserID)
+		if err := tx.Create(&newSeries).Error; err != nil {
+			tx.Rollback()
+			return newCreateDBError(err, "program_class_events")
+		}
 		if err := tx.Create(&changeLogEntry).Error; err != nil {
 			tx.Rollback()
 			return newCreateDBError(err, "change_log_entries")
 		}
 	}
+
 	if err := tx.Commit().Error; err != nil {
 		return NewDBError(err, "unable to commit the database transaction")
 	}
@@ -445,28 +499,18 @@ func (db *DB) CreateOverrideEvents(ctx *models.QueryContext, overrideEvents []*m
 }
 
 func (db *DB) syncClassDateBoundaries(trans *gorm.DB, classID uint) error {
-	var event models.ProgramClassEvent
-	if err := trans.Preload("Overrides").Where("class_id = ?", classID).First(&event).Error; err != nil {
+	// Boundaries must be derived from all rows, since a class can have multiple.
+	var events []models.ProgramClassEvent
+	if err := trans.Preload("Overrides").Where("class_id = ?", classID).Order("created_at ASC").Find(&events).Error; err != nil {
 		return newGetRecordsDBError(err, "program_class_events")
+	}
+	if len(events) == 0 {
+		return newGetRecordsDBError(gorm.ErrRecordNotFound, "program_class_events")
 	}
 
 	var class models.ProgramClass
 	if err := trans.First(&class, "id = ?", classID).Error; err != nil {
 		return newGetRecordsDBError(err, "program_classes")
-	}
-
-	rRule, err := event.GetRRule()
-	if err != nil {
-		return err
-	}
-
-	originalBaseStart := rRule.OrigOptions.Dtstart.In(time.UTC)
-	// rrule-go's GetUntil() returns a far-future date (~year 2318) instead of zero
-	// when no UNTIL is present, so check the raw string for an explicit UNTIL clause
-	hasExplicitUntil := strings.Contains(event.RecurrenceRule, "UNTIL=")
-	var ruleUntil time.Time
-	if hasExplicitUntil {
-		ruleUntil = rRule.GetUntil()
 	}
 
 	startBoundary := class.StartDt
@@ -475,45 +519,66 @@ func (db *DB) syncClassDateBoundaries(trans *gorm.DB, classID uint) error {
 		endBoundary = class.EndDt.AddDate(0, 3, 0)
 	}
 
-	baseOccurrences := rRule.Between(startBoundary, endBoundary, true)
-	if len(baseOccurrences) == 0 {
-		return nil
-	}
+	var originalBaseStart, ruleUntil, earliestReschedule time.Time
+	allDates := make([]time.Time, 0)
+	hasOverrides := false
 
-	cancelledDates := make(map[string]bool)
-	rescheduledDates := make([]time.Time, 0)
-	var earliestReschedule time.Time
-
-	for _, override := range event.Overrides {
-		overrideRule, err := rrule.StrToRRule(override.OverrideRrule)
+	for i := range events {
+		event := events[i]
+		rRule, err := event.GetRRule()
 		if err != nil {
-			logrus.Warnf("unable to parse override rule: %s", override.OverrideRrule)
-			continue
-		}
-		occurrences := overrideRule.All()
-		if len(occurrences) == 0 {
-			continue
+			return err
 		}
 
-		overrideDate := occurrences[0].In(time.UTC)
-		if override.IsCancelled {
-			cancelledDates[overrideDate.Format("2006-01-02")] = true
-			continue
+		baseStart := rRule.OrigOptions.Dtstart.In(time.UTC)
+		if originalBaseStart.IsZero() || baseStart.Before(originalBaseStart) {
+			originalBaseStart = baseStart
+		}
+		// rrule-go's GetUntil() returns a far-future date (~year 2318) instead of zero
+		// when no UNTIL is present, so check the raw string for an explicit UNTIL clause
+		if strings.Contains(event.RecurrenceRule, "UNTIL=") {
+			if u := rRule.GetUntil(); u.After(ruleUntil) {
+				ruleUntil = u
+			}
 		}
 
-		rescheduledDates = append(rescheduledDates, overrideDate)
-		if earliestReschedule.IsZero() || overrideDate.Before(earliestReschedule) {
-			earliestReschedule = overrideDate
+		baseOccurrences := rRule.Between(startBoundary, endBoundary, true)
+
+		if len(event.Overrides) > 0 {
+			hasOverrides = true
 		}
+		cancelledDates := make(map[string]bool)
+		rescheduledDates := make([]time.Time, 0)
+		for _, override := range event.Overrides {
+			overrideRule, err := rrule.StrToRRule(override.OverrideRrule)
+			if err != nil {
+				logrus.Warnf("unable to parse override rule: %s", override.OverrideRrule)
+				continue
+			}
+			occurrences := overrideRule.All()
+			if len(occurrences) == 0 {
+				continue
+			}
+
+			overrideDate := occurrences[0].In(time.UTC)
+			if override.IsCancelled {
+				cancelledDates[overrideDate.Format("2006-01-02")] = true
+				continue
+			}
+
+			rescheduledDates = append(rescheduledDates, overrideDate)
+			if earliestReschedule.IsZero() || overrideDate.Before(earliestReschedule) {
+				earliestReschedule = overrideDate
+			}
+		}
+
+		for _, occurrence := range baseOccurrences {
+			if !cancelledDates[occurrence.Format("2006-01-02")] {
+				allDates = append(allDates, occurrence)
+			}
+		}
+		allDates = append(allDates, rescheduledDates...)
 	}
-
-	allDates := make([]time.Time, 0, len(baseOccurrences)+len(rescheduledDates))
-	for _, occurrence := range baseOccurrences {
-		if !cancelledDates[occurrence.Format("2006-01-02")] {
-			allDates = append(allDates, occurrence)
-		}
-	}
-	allDates = append(allDates, rescheduledDates...)
 
 	if len(allDates) == 0 {
 		return nil
@@ -534,8 +599,6 @@ func (db *DB) syncClassDateBoundaries(trans *gorm.DB, classID uint) error {
 	if !targetStart.Equal(class.StartDt) {
 		updates["start_dt"] = targetStart
 	}
-
-	hasOverrides := len(event.Overrides) > 0
 
 	if class.EndDt == nil || !computedEnd.Equal(*class.EndDt) {
 		if (!hasOverrides && !ruleUntil.IsZero()) || (!ruleUntil.IsZero() && ruleUntil.After(computedEnd)) {
@@ -1125,19 +1188,41 @@ func (db *DB) GetClassEventInstancesWithAttendanceForRecurrence(classId int, qry
 		return nil, NewDBError(err, "failed to load timezone")
 	}
 
-	var event models.ProgramClassEvent
+	// Load all rows, not just the newest: "apply to all future sessions" leaves a class
+	// with multiple rows whose RRULEs together describe the full schedule.
+	var events []models.ProgramClassEvent
 	if err := db.WithContext(qryCtx.Ctx).
 		Model(&models.ProgramClassEvent{}).
 		Preload("Overrides").
 		Where("class_id = ?", classId).
-		Order("created_at DESC").
-		First(&event).Error; err != nil {
+		Order("created_at ASC").
+		Find(&events).Error; err != nil {
 		return nil, newGetRecordsDBError(err, "program_class_events")
 	}
+	if len(events) == 0 {
+		return nil, newGetRecordsDBError(gorm.ErrRecordNotFound, "program_class_events")
+	}
 
-	rRule, err := event.GetRRuleWithTimezone(qryCtx.Timezone)
-	if err != nil {
-		logrus.Errorf("event has invalid rule, event: %v", event)
+	type parsedEvent struct {
+		event models.ProgramClassEvent
+		rule  *rrule.RRule
+	}
+	parsed := make([]parsedEvent, 0, len(events))
+	var earliestStart time.Time
+	for i := range events {
+		rule, err := events[i].GetRRuleWithTimezone(qryCtx.Timezone)
+		if err != nil {
+			logrus.Errorf("event has invalid rule, event: %v", events[i])
+			continue
+		}
+		parsed = append(parsed, parsedEvent{event: events[i], rule: rule})
+		dtStart := rule.GetDTStart()
+		if earliestStart.IsZero() || dtStart.Before(earliestStart) {
+			earliestStart = dtStart
+		}
+	}
+	if len(parsed) == 0 {
+		return []models.ClassEventInstance{}, nil
 	}
 
 	var startTime, untilTime time.Time
@@ -1152,7 +1237,7 @@ func (db *DB) GetClassEventInstancesWithAttendanceForRecurrence(classId int, qry
 			if err != nil {
 				return nil, newGetRecordsDBError(err, "program_class_enrollments")
 			}
-			startTime = rRule.GetDTStart()
+			startTime = earliestStart
 			if enrollment.CreatedAt.After(startTime) {
 				startTime = enrollment.CreatedAt.Truncate(24 * time.Hour)
 			}
@@ -1161,15 +1246,21 @@ func (db *DB) GetClassEventInstancesWithAttendanceForRecurrence(classId int, qry
 				untilTime = enrollment.UpdatedAt.AddDate(0, 0, 1).Truncate(24 * time.Hour)
 			}
 		} else {
-			startTime = rRule.GetDTStart()
+			startTime = earliestStart
 			if allInstances {
 				// rrule-go's GetUntil() returns a far-future date (~year 2318) instead of zero
-				// when no UNTIL is present, so check the raw string for an explicit UNTIL clause
-				hasExplicitUntil := strings.Contains(event.RecurrenceRule, "UNTIL=")
-				if hasExplicitUntil {
-					untilTime = rRule.GetUntil().AddDate(0, 0, 1)
-				} else {
-					untilTime = time.Now().AddDate(1, 0, 0).Truncate(24 * time.Hour)
+				// when no UNTIL is present, so check the raw string for an explicit UNTIL clause.
+				untilTime = time.Now().AddDate(1, 0, 0).Truncate(24 * time.Hour)
+				var latestUntil time.Time
+				for _, pe := range parsed {
+					if strings.Contains(pe.event.RecurrenceRule, "UNTIL=") {
+						if u := pe.rule.GetUntil().AddDate(0, 0, 1); u.After(latestUntil) {
+							latestUntil = u
+						}
+					}
+				}
+				if !latestUntil.IsZero() {
+					untilTime = latestUntil
 				}
 				maxFuture := time.Now().AddDate(0, 6, 0).Truncate(24 * time.Hour)
 				if untilTime.After(maxFuture) {
@@ -1192,54 +1283,14 @@ func (db *DB) GetClassEventInstancesWithAttendanceForRecurrence(classId int, qry
 		untilTime = startTime.AddDate(0, 1, 0)
 	}
 
-	occurrences := rRule.Between(startTime, untilTime, true)
-
-	// occurrences can be empty if there are no base rule occurrences in the window
-	// but we still need to check for overrides and fetch attendance
-	var classTime string
-	var canonicalHour, canonicalMinute int
-	if len(occurrences) > 0 {
-		duration, err := time.ParseDuration(event.Duration)
-		if err != nil {
-			logrus.Errorf("error parsing duration for event: %v", err)
-		}
-
-		startTime = rRule.GetDTStart()
-		// Use the DTSTART's own timezone to extract the canonical wall-clock time,
-		// not the user's timezone. The DTSTART time represents the class's local
-		// wall-clock time at the facility, so converting to a different timezone
-		// would shift the displayed time incorrectly.
-		canonicalHour = startTime.Hour()
-		canonicalMinute = startTime.Minute()
-
-		firstOcc := occurrences[0]
-		//day light savings time issue
-		consistentOccurrence := time.Date(
-			firstOcc.Year(),
-			firstOcc.Month(),
-			firstOcc.Day(),
-			canonicalHour,
-			canonicalMinute,
-			0,
-			0,
-			loc,
-		)
-
-		startTimeStr := consistentOccurrence.Format("15:04")
-		endTimeStr := consistentOccurrence.Add(duration).Format("15:04")
-		classTime = startTimeStr + "-" + endTimeStr
+	// Fetch attendance across all event IDs so records on older (capped) rows still surface.
+	classEventIDs := make([]uint, 0, len(events))
+	for i := range events {
+		classEventIDs = append(classEventIDs, events[i].ID)
 	}
 	var attendances []models.ProgramClassEventAttendance
-
 	startDateStr := startTime.Format("2006-01-02")
 	endDateStr := untilTime.Format("2006-01-02")
-
-	// Fetch all event IDs for this class to ensure we get attendance even if it's linked to an older event rule
-	var classEventIDs []uint
-	if err := db.WithContext(qryCtx.Ctx).Model(&models.ProgramClassEvent{}).Where("class_id = ?", classId).Pluck("id", &classEventIDs).Error; err != nil {
-		return nil, newGetRecordsDBError(err, "program_class_events")
-	}
-
 	tx := db.WithContext(qryCtx.Ctx).
 		Model(&models.ProgramClassEventAttendance{}).
 		Where("event_id IN (?) AND date >= ? AND date < ?", classEventIDs, startDateStr, endDateStr)
@@ -1252,7 +1303,13 @@ func (db *DB) GetClassEventInstancesWithAttendanceForRecurrence(classId int, qry
 		return nil, newGetRecordsDBError(err, "program_class_event_attendances")
 	}
 
-	eventInstances := createEventInstances(event, occurrences, loc, classTime, attendances, canonicalHour, canonicalMinute)
+	var eventInstances []models.ClassEventInstance
+	for _, pe := range parsed {
+		occurrences := pe.rule.Between(startTime, untilTime, true)
+		classTime, canonicalHour, canonicalMinute := eventClassTime(pe.event, pe.rule, occurrences, loc)
+		eventInstances = append(eventInstances, createEventInstances(pe.event, occurrences, loc, classTime, attendances, canonicalHour, canonicalMinute)...)
+	}
+	eventInstances = dedupeClassEventInstances(eventInstances)
 
 	qryCtx.Total = int64(len(eventInstances))
 	if !qryCtx.All {
@@ -1298,8 +1355,9 @@ func createEventInstances(event models.ProgramClassEvent, occurrences []time.Tim
 			ClassTime:         classTime,
 			Date:              occDateStr,
 			AttendanceRecords: attendanceByDate[occDateStr],
-			IsCancelled:       isCancelled,
-			IsRescheduled:     isRescheduled,
+			// event.IsCancelled is a series-level cancellation: every occurrence is cancelled.
+			IsCancelled:   isCancelled || event.IsCancelled,
+			IsRescheduled: isRescheduled,
 		}
 		if isCancelled {
 			eventInstance.OverrideID = overrideID
@@ -1463,6 +1521,55 @@ func createEventInstances(event models.ProgramClassEvent, occurrences []time.Tim
 	return eventInstances
 }
 
+// eventClassTime returns the displayed "HH:MM-HH:MM" class time and canonical
+// hour/minute, locked to the DTSTART's wall-clock time to avoid DST shifts.
+func eventClassTime(event models.ProgramClassEvent, rRule *rrule.RRule, occurrences []time.Time, loc *time.Location) (string, int, int) {
+	if len(occurrences) == 0 {
+		return "", 0, 0
+	}
+	duration, err := time.ParseDuration(event.Duration)
+	if err != nil {
+		logrus.Errorf("error parsing duration for event: %v", err)
+	}
+	dtStart := rRule.GetDTStart()
+	canonicalHour := dtStart.Hour()
+	canonicalMinute := dtStart.Minute()
+
+	firstOcc := occurrences[0]
+	consistentOccurrence := time.Date(
+		firstOcc.Year(), firstOcc.Month(), firstOcc.Day(),
+		canonicalHour, canonicalMinute, 0, 0, loc,
+	)
+	startTimeStr := consistentOccurrence.Format("15:04")
+	endTimeStr := consistentOccurrence.Add(duration).Format("15:04")
+	return startTimeStr + "-" + endTimeStr, canonicalHour, canonicalMinute
+}
+
+// dedupeClassEventInstances merges instances from multiple rows. On a date+start-time
+// collision the newest row wins (rows arrive oldest-first); sorted by date descending.
+func dedupeClassEventInstances(instances []models.ClassEventInstance) []models.ClassEventInstance {
+	type instanceKey struct{ date, start string }
+	indexByKey := make(map[instanceKey]int, len(instances))
+	result := make([]models.ClassEventInstance, 0, len(instances))
+	for _, inst := range instances {
+		start := inst.ClassTime
+		if dash := strings.Index(start, "-"); dash != -1 {
+			start = start[:dash]
+		}
+		key := instanceKey{date: inst.Date, start: start}
+		if idx, ok := indexByKey[key]; ok {
+			result[idx] = inst
+			continue
+		}
+		indexByKey[key] = len(result)
+		result = append(result, inst)
+	}
+	slices.SortFunc(result, func(a, b models.ClassEventInstance) int {
+		return cmp.Compare(b.Date, a.Date)
+	})
+	return result
+}
+
 func (db *DB) GetCancelledOverrideEvents(qryCtx *models.QueryContext, eventId int) ([]models.ProgramClassEventOverride, error) {
 	overrides := make([]models.ProgramClassEventOverride, 0)
 	if err := db.WithContext(qryCtx.Ctx).Model(&models.ProgramClassEventOverride{}).Where("event_id = ? and is_cancelled = true", eventId).Find(&overrides).Error; err != nil {
@@ -1472,31 +1579,43 @@ func (db *DB) GetCancelledOverrideEvents(qryCtx *models.QueryContext, eventId in
 }
 
 func (db *DB) GetClassEventDatesForRecurrence(classID int, timezone string, month, year string, eventId *int) ([]models.EventDates, error) {
-	var event models.ProgramClassEvent
+	// Load all rows so a multi-row class shows every date; honor a specific event_id if given.
+	var events []models.ProgramClassEvent
 	query := db.Preload("Overrides").Where("class_id = ?", classID)
-
-	// if specific event_id is provided, use it, otherwise get the latest event
 	if eventId != nil {
 		query = query.Where("id = ?", *eventId)
-	} else {
-		query = query.Order("created_at DESC")
 	}
-
-	if err := query.First(&event).Error; err != nil {
+	if err := query.Order("created_at ASC").Find(&events).Error; err != nil {
 		return nil, newGetRecordsDBError(err, "program_class_events")
+	}
+	if len(events) == 0 {
+		return nil, newGetRecordsDBError(gorm.ErrRecordNotFound, "program_class_events")
 	}
 
 	loc, _ := time.LoadLocation(timezone)
-	rule, err := event.GetRRuleWithTimezone(timezone)
-	if err != nil {
-		return nil, err
-	}
-
 	y, _ := strconv.Atoi(year)
 	m, _ := strconv.Atoi(month)
 	start := time.Date(y, time.Month(m), 1, 0, 0, 0, 0, loc)
 	until := start.AddDate(0, 1, 0)
 
+	out := make([]models.EventDates, 0)
+	for i := range events {
+		rule, err := events[i].GetRRuleWithTimezone(timezone)
+		if err != nil {
+			logrus.Errorf("event has invalid rule, event: %v", events[i])
+			continue
+		}
+		out = append(out, eventDatesForRow(events[i], rule, start, until, loc)...)
+	}
+
+	return dedupeEventDates(out), nil
+}
+
+func eventDatesForRow(event models.ProgramClassEvent, rule *rrule.RRule, start, until time.Time, loc *time.Location) []models.EventDates {
+	// A fully cancelled series contributes no scheduled dates.
+	if event.IsCancelled {
+		return nil
+	}
 	occs := rule.Between(start, until, true)
 
 	duration, err := time.ParseDuration(event.Duration)
@@ -1514,7 +1633,7 @@ func (db *DB) GetClassEventDatesForRecurrence(classID int, timezone string, mont
 
 	out := make([]models.EventDates, 0, len(occs))
 	for _, occ := range occs {
-		isCancelled, _, _, _, _ := checkEventCancelledAndRescheduled(occ, event.Overrides, timezone)
+		isCancelled, _, _, _, _ := checkEventCancelledAndRescheduled(occ, event.Overrides, loc.String())
 		if isCancelled {
 			continue
 		}
@@ -1565,7 +1684,24 @@ func (db *DB) GetClassEventDatesForRecurrence(classID int, timezone string, mont
 		})
 	}
 
-	return out, nil
+	return out
+}
+
+// dedupeEventDates drops entries sharing a date and class time; newest row wins on a tie.
+func dedupeEventDates(dates []models.EventDates) []models.EventDates {
+	type dateKey struct{ date, classTime string }
+	indexByKey := make(map[dateKey]int, len(dates))
+	result := make([]models.EventDates, 0, len(dates))
+	for _, d := range dates {
+		key := dateKey{date: d.Date, classTime: d.ClassTime}
+		if idx, ok := indexByKey[key]; ok {
+			result[idx] = d
+			continue
+		}
+		indexByKey[key] = len(result)
+		result = append(result, d)
+	}
+	return result
 }
 
 func (db *DB) GetProgramClassEventOverrides(qryCtx *models.QueryContext, eventIDs ...uint) ([]models.ProgramClassEventOverride, error) {

--- a/backend/src/handlers/class_events.go
+++ b/backend/src/handlers/class_events.go
@@ -1,7 +1,6 @@
 package handlers
 
 import (
-	"UnlockEdv2/src"
 	"UnlockEdv2/src/models"
 	"UnlockEdv2/src/services"
 	"encoding/json"
@@ -472,7 +471,8 @@ func (srv *Server) handleRescheduleEventSeries(w http.ResponseWriter, r *http.Re
 	if err := json.NewDecoder(r.Body).Decode(&eventSeriesRequest); err != nil {
 		return newJSONReqBodyServiceError(err)
 	}
-	if eventSeriesRequest.EventSeries.RoomID != nil {
+	// A cancelled series frees the room, so skip the conflict check for cancellations.
+	if eventSeriesRequest.EventSeries.RoomID != nil && !eventSeriesRequest.EventSeries.IsCancelled {
 		class, err := srv.Db.GetClassByID(classID)
 		if err != nil {
 			return newDatabaseServiceError(err)
@@ -502,32 +502,9 @@ func (srv *Server) handleRescheduleEventSeries(w http.ResponseWriter, r *http.Re
 		}
 	}
 	args := srv.getQueryContext(r)
-	args.All = true
-	allEvents, err := srv.Db.GetClassEvents(&args, classID)
-	if err != nil {
-		return newDatabaseServiceError(err)
-	}
 	eventSeriesRequest.EventSeries.ClassID = uint(classID)
 	eventSeriesRequest.ClosedEventSeries.ClassID = uint(classID)
-	var events []models.ProgramClassEvent
-	if eventSeriesRequest.EventSeries.RecurrenceRule != "" {
-		events = append(events, eventSeriesRequest.EventSeries)
-	}
-	events = append(events, eventSeriesRequest.ClosedEventSeries)
-	var maxEvent *models.ProgramClassEvent
-	for i := range allEvents {
-		if maxEvent == nil || allEvents[i].ID > maxEvent.ID {
-			maxEvent = &allEvents[i]
-		}
-	}
-	if maxEvent != nil && maxEvent.ID != eventSeriesRequest.ClosedEventSeries.ID { //making sure of only one active rrule
-		untilDate := src.GetUntilDateFromRule(eventSeriesRequest.ClosedEventSeries.RecurrenceRule)
-		if untilDate != "" {
-			maxEvent.RecurrenceRule = src.ReplaceOrAddUntilDate(maxEvent.RecurrenceRule, untilDate)
-			events = append(events, *maxEvent)
-		}
-	}
-	err = srv.WithUserContext(r).CreateRescheduleEventSeries(&args, events)
+	err = srv.WithUserContext(r).CreateRescheduleEventSeries(&args, uint(classID), eventSeriesRequest.EventSeries, eventSeriesRequest.ClosedEventSeries)
 	if err != nil {
 		return newDatabaseServiceError(err)
 	}

--- a/backend/src/handlers/class_events.go
+++ b/backend/src/handlers/class_events.go
@@ -472,7 +472,7 @@ func (srv *Server) handleRescheduleEventSeries(w http.ResponseWriter, r *http.Re
 		return newJSONReqBodyServiceError(err)
 	}
 	// A cancelled series frees the room, so skip the conflict check for cancellations.
-	if eventSeriesRequest.EventSeries.RoomID != nil && !eventSeriesRequest.EventSeries.IsCancelled {
+	if eventSeriesRequest.EventSeries.RoomID != nil {
 		class, err := srv.Db.GetClassByID(classID)
 		if err != nil {
 			return newDatabaseServiceError(err)
@@ -480,25 +480,27 @@ func (srv *Server) handleRescheduleEventSeries(w http.ResponseWriter, r *http.Re
 		if _, err := srv.Db.GetRoomByIDForFacility(*eventSeriesRequest.EventSeries.RoomID, class.FacilityID); err != nil {
 			return newDatabaseServiceError(err)
 		}
-		var excludeEventID *uint
-		if eventSeriesRequest.ClosedEventSeries.ID > 0 {
-			closedID := eventSeriesRequest.ClosedEventSeries.ID
-			excludeEventID = &closedID
-		} else if eventSeriesRequest.EventSeries.ID > 0 {
-			excludeEventID = &eventSeriesRequest.EventSeries.ID
-		}
-		conflicts, err := srv.Db.CheckRRuleConflicts(&models.ConflictCheckRequest{
-			FacilityID:     class.FacilityID,
-			RoomID:         *eventSeriesRequest.EventSeries.RoomID,
-			RecurrenceRule: eventSeriesRequest.EventSeries.RecurrenceRule,
-			Duration:       eventSeriesRequest.EventSeries.Duration,
-			ExcludeEventID: excludeEventID,
-		})
-		if err != nil {
-			return newDatabaseServiceError(err)
-		}
-		if len(conflicts) > 0 {
-			return writeConflictResponse(w, conflicts)
+		if !eventSeriesRequest.EventSeries.IsCancelled {
+			var excludeEventID *uint
+			if eventSeriesRequest.ClosedEventSeries.ID > 0 {
+				closedID := eventSeriesRequest.ClosedEventSeries.ID
+				excludeEventID = &closedID
+			} else if eventSeriesRequest.EventSeries.ID > 0 {
+				excludeEventID = &eventSeriesRequest.EventSeries.ID
+			}
+			conflicts, err := srv.Db.CheckRRuleConflicts(&models.ConflictCheckRequest{
+				FacilityID:     class.FacilityID,
+				RoomID:         *eventSeriesRequest.EventSeries.RoomID,
+				RecurrenceRule: eventSeriesRequest.EventSeries.RecurrenceRule,
+				Duration:       eventSeriesRequest.EventSeries.Duration,
+				ExcludeEventID: excludeEventID,
+			})
+			if err != nil {
+				return newDatabaseServiceError(err)
+			}
+			if len(conflicts) > 0 {
+				return writeConflictResponse(w, conflicts)
+			}
 		}
 	}
 	args := srv.getQueryContext(r)

--- a/backend/tests/integration/class_events_multirow_test.go
+++ b/backend/tests/integration/class_events_multirow_test.go
@@ -1,0 +1,228 @@
+package integration
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"UnlockEdv2/src/models"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestMultiRowEventSessionsAllSurface reproduces ID-692: after "Apply to all future
+// sessions" a class ends up with two ProgramClassEvent rows (an UNTIL-capped original
+// plus a new row). The sessions tab must show sessions from BOTH rows, not just the
+// newest one.
+func TestMultiRowEventSessionsAllSurface(t *testing.T) {
+	env := SetupTestEnv(t)
+	defer env.CleanupTestEnv()
+
+	facility, err := env.CreateTestFacility("Multi-Row Facility")
+	require.NoError(t, err)
+
+	admin, err := env.CreateTestUser("multirowadmin", models.FacilityAdmin, facility.ID, "")
+	require.NoError(t, err)
+
+	program, err := env.CreateTestProgram("Multi-Row Program", models.FundingType(models.FederalGrants), []models.ProgramType{}, []models.ProgramCreditType{}, true, nil)
+	require.NoError(t, err)
+	require.NoError(t, env.SetFacilitiesToProgram(program.ID, []uint{facility.ID}))
+
+	class, err := env.CreateTestClass(program, facility, models.Active, &admin.ID)
+	require.NoError(t, err)
+
+	now := time.Now().UTC()
+	fmtTS := func(t time.Time) string { return t.Format("20060102T150405Z") }
+
+	// Original row: weekly, started 8 weeks ago, capped (UNTIL) 4 weeks ago.
+	oldStart := now.AddDate(0, 0, -56)
+	oldUntil := now.AddDate(0, 0, -28)
+	oldRule := fmt.Sprintf("DTSTART:%s\nRRULE:FREQ=WEEKLY;UNTIL=%s", fmtTS(oldStart), fmtTS(oldUntil))
+	_, err = env.CreateTestEventWithRRule(class.ID, oldRule, admin.ID)
+	require.NoError(t, err)
+
+	// New row created by "Apply to all future sessions": weekly from 3 weeks ago at a
+	// different time, running 4 weeks into the future.
+	newStart := now.AddDate(0, 0, -21).Truncate(time.Hour).Add(13 * time.Hour)
+	newUntil := now.AddDate(0, 0, 28)
+	newRule := fmt.Sprintf("DTSTART:%s\nRRULE:FREQ=WEEKLY;UNTIL=%s", fmtTS(newStart), fmtTS(newUntil))
+	_, err = env.CreateTestEventWithRRule(class.ID, newRule, admin.ID)
+	require.NoError(t, err)
+
+	qryCtx := &models.QueryContext{
+		Ctx:      env.Context,
+		Timezone: "UTC",
+		All:      true,
+	}
+
+	instances, err := env.DB.GetClassEventInstancesWithAttendanceForRecurrence(int(class.ID), qryCtx, "", "", nil, true)
+	require.NoError(t, err)
+	require.NotEmpty(t, instances, "expected sessions from both event rows")
+
+	var earliest, latest string
+	for _, inst := range instances {
+		if earliest == "" || inst.Date < earliest {
+			earliest = inst.Date
+		}
+		if inst.Date > latest {
+			latest = inst.Date
+		}
+	}
+
+	// Past sessions from the capped original row must still be present (the bug dropped
+	// these). The earliest session should be near the original 8-weeks-ago DTSTART.
+	pastThreshold := now.AddDate(0, 0, -50).Format("2006-01-02")
+	require.LessOrEqual(t, earliest, pastThreshold,
+		"past sessions from the original capped row should still surface (earliest=%s)", earliest)
+
+	// Future sessions from the new row must also be present.
+	futureThreshold := now.AddDate(0, 0, 20).Format("2006-01-02")
+	require.GreaterOrEqual(t, latest, futureThreshold,
+		"future sessions from the new row should surface (latest=%s)", latest)
+}
+
+// TestCancelAllFutureSessionsAcrossMultipleRows reproduces the write-side twin of
+// ID-692: when a class has multiple active recurrence rows, "cancel all future
+// sessions" must cap/cancel every row, not just the clicked one. Previously stray
+// rows kept generating active future sessions.
+func TestCancelAllFutureSessionsAcrossMultipleRows(t *testing.T) {
+	env := SetupTestEnv(t)
+	defer env.CleanupTestEnv()
+
+	facility, err := env.CreateTestFacility("Cancel-Future Facility")
+	require.NoError(t, err)
+
+	admin, err := env.CreateTestUser("cancelfutureadmin", models.FacilityAdmin, facility.ID, "")
+	require.NoError(t, err)
+
+	program, err := env.CreateTestProgram("Cancel-Future Program", models.FundingType(models.FederalGrants), []models.ProgramType{}, []models.ProgramCreditType{}, true, nil)
+	require.NoError(t, err)
+	require.NoError(t, env.SetFacilitiesToProgram(program.ID, []uint{facility.ID}))
+
+	class, err := env.CreateTestClass(program, facility, models.Active, &admin.ID)
+	require.NoError(t, err)
+
+	now := time.Now().UTC()
+	today := time.Date(now.Year(), now.Month(), now.Day(), 0, 0, 0, 0, time.UTC)
+	dstart := func(t time.Time) string { return t.Format("20060102") + "T090000Z" }
+	until := func(t time.Time) string { return t.Format("20060102") + "T235959Z" }
+
+	// Row A: the original series spanning past through future.
+	ruleA := fmt.Sprintf("DTSTART:%s\nRRULE:FREQ=WEEKLY;UNTIL=%s", dstart(today.AddDate(0, 0, -28)), until(today.AddDate(0, 0, 28)))
+	rowA, err := env.CreateTestEventWithRRule(class.ID, ruleA, admin.ID)
+	require.NoError(t, err)
+
+	// Row B: a stray future-only row left behind by a prior reschedule. The old code
+	// never touched this on a cancel, so its future sessions leaked through.
+	ruleB := fmt.Sprintf("DTSTART:%s\nRRULE:FREQ=WEEKLY;UNTIL=%s", dstart(today.AddDate(0, 0, 7)), until(today.AddDate(0, 0, 28)))
+	_, err = env.CreateTestEventWithRRule(class.ID, ruleB, admin.ID)
+	require.NoError(t, err)
+
+	// "Cancel all future sessions" from today: a cancelled series from today onward,
+	// and a closed series whose UNTIL marks the cut (today - 1).
+	newSeries := models.ProgramClassEvent{
+		Duration:       "2h",
+		RecurrenceRule: fmt.Sprintf("DTSTART:%s\nRRULE:FREQ=WEEKLY;UNTIL=%s", dstart(today), until(today.AddDate(0, 0, 28))),
+		RoomID:         rowA.RoomID,
+		InstructorID:   rowA.InstructorID,
+		IsCancelled:    true,
+	}
+	closedSeries := models.ProgramClassEvent{
+		RecurrenceRule: fmt.Sprintf("DTSTART:%s\nRRULE:FREQ=WEEKLY;UNTIL=%s", dstart(today.AddDate(0, 0, -28)), until(today.AddDate(0, 0, -1))),
+	}
+
+	writeCtx := &models.QueryContext{Ctx: env.Context, Timezone: "UTC", UserID: admin.ID}
+	require.NoError(t, env.DB.CreateRescheduleEventSeries(writeCtx, class.ID, newSeries, closedSeries))
+
+	readCtx := &models.QueryContext{Ctx: env.Context, Timezone: "UTC", All: true}
+	instances, err := env.DB.GetClassEventInstancesWithAttendanceForRecurrence(int(class.ID), readCtx, "", "", nil, true)
+	require.NoError(t, err)
+	require.NotEmpty(t, instances)
+
+	todayStr := today.Format("2006-01-02")
+	var futureCancelled, pastActive int
+	for _, inst := range instances {
+		if inst.Date >= todayStr {
+			require.True(t, inst.IsCancelled,
+				"every session on/after the cut must be cancelled, but %s is active", inst.Date)
+			futureCancelled++
+		} else if !inst.IsCancelled {
+			pastActive++
+		}
+	}
+	require.Positive(t, futureCancelled, "future sessions should appear as cancelled")
+	require.Positive(t, pastActive, "past sessions before the cut should be preserved as active")
+
+	// The stray future-only row (B) must be soft-deleted, not left generating sessions.
+	var activeRows int64
+	require.NoError(t, env.DB.Model(&models.ProgramClassEvent{}).
+		Where("class_id = ? AND is_cancelled = ?", class.ID, false).
+		Count(&activeRows).Error)
+	require.Equal(t, int64(1), activeRows, "only the capped original row should remain active")
+}
+
+// TestUncancelSeriesRestoresFutureSessions verifies that a series cancellation can be
+// undone: the sessions-tab "Undo" routes to uncancel-series, which must bring the
+// future sessions back as active.
+func TestUncancelSeriesRestoresFutureSessions(t *testing.T) {
+	env := SetupTestEnv(t)
+	defer env.CleanupTestEnv()
+
+	facility, err := env.CreateTestFacility("Uncancel Facility")
+	require.NoError(t, err)
+
+	admin, err := env.CreateTestUser("uncanceladmin", models.FacilityAdmin, facility.ID, "")
+	require.NoError(t, err)
+
+	program, err := env.CreateTestProgram("Uncancel Program", models.FundingType(models.FederalGrants), []models.ProgramType{}, []models.ProgramCreditType{}, true, nil)
+	require.NoError(t, err)
+	require.NoError(t, env.SetFacilitiesToProgram(program.ID, []uint{facility.ID}))
+
+	class, err := env.CreateTestClass(program, facility, models.Active, &admin.ID)
+	require.NoError(t, err)
+
+	now := time.Now().UTC()
+	today := time.Date(now.Year(), now.Month(), now.Day(), 0, 0, 0, 0, time.UTC)
+	dstart := func(t time.Time) string { return t.Format("20060102") + "T090000Z" }
+	until := func(t time.Time) string { return t.Format("20060102") + "T235959Z" }
+
+	rowA, err := env.CreateTestEventWithRRule(class.ID,
+		fmt.Sprintf("DTSTART:%s\nRRULE:FREQ=WEEKLY;UNTIL=%s", dstart(today.AddDate(0, 0, -28)), until(today.AddDate(0, 0, 28))), admin.ID)
+	require.NoError(t, err)
+
+	writeCtx := &models.QueryContext{Ctx: env.Context, Timezone: "UTC", UserID: admin.ID}
+	require.NoError(t, env.DB.CreateRescheduleEventSeries(writeCtx, class.ID,
+		models.ProgramClassEvent{
+			Duration:       "2h",
+			RecurrenceRule: fmt.Sprintf("DTSTART:%s\nRRULE:FREQ=WEEKLY;UNTIL=%s", dstart(today), until(today.AddDate(0, 0, 28))),
+			RoomID:         rowA.RoomID,
+			InstructorID:   rowA.InstructorID,
+			IsCancelled:    true,
+		},
+		models.ProgramClassEvent{
+			RecurrenceRule: fmt.Sprintf("DTSTART:%s\nRRULE:FREQ=WEEKLY;UNTIL=%s", dstart(today.AddDate(0, 0, -28)), until(today.AddDate(0, 0, -1))),
+		}))
+
+	// Locate the cancelled series row created by the cancel.
+	var cancelledSeries models.ProgramClassEvent
+	require.NoError(t, env.DB.Where("class_id = ? AND is_cancelled = ?", class.ID, true).
+		Order("created_at DESC").First(&cancelledSeries).Error)
+
+	// Undo: restore the series from today onward.
+	todayStr := today.Format("2006-01-02")
+	require.NoError(t, env.DB.UncancelEventSeries(writeCtx, cancelledSeries.ID, todayStr))
+
+	readCtx := &models.QueryContext{Ctx: env.Context, Timezone: "UTC", All: true}
+	instances, err := env.DB.GetClassEventInstancesWithAttendanceForRecurrence(int(class.ID), readCtx, "", "", nil, true)
+	require.NoError(t, err)
+
+	var restoredFuture int
+	for _, inst := range instances {
+		if inst.Date >= todayStr {
+			require.False(t, inst.IsCancelled,
+				"session on/after the restore date should be active again, but %s is still cancelled", inst.Date)
+			restoredFuture++
+		}
+	}
+	require.Positive(t, restoredFuture, "future sessions should be restored as active")
+}

--- a/backend/tests/integration/room_conflict_test.go
+++ b/backend/tests/integration/room_conflict_test.go
@@ -52,6 +52,12 @@ func TestRoomConflictDetection(t *testing.T) {
 		testHandlerReturns409OnConflict(t, env, facility, facilityAdmin, program, room.ID)
 	})
 
+	t.Run("Cancelling a series bypasses room conflict check", func(t *testing.T) {
+		room := &models.Room{FacilityID: facility.ID, Name: "Cancel Bypass Room"}
+		require.NoError(t, env.DB.Create(room).Error)
+		testCancelSeriesBypassesConflict(t, env, facility, facilityAdmin, program, room.ID)
+	})
+
 	t.Run("Rejects room from different facility", func(t *testing.T) {
 		otherFacility, err := env.CreateTestFacility("Other Facility")
 		require.NoError(t, err)
@@ -236,6 +242,87 @@ func testNoConflictForDifferentTimes(t *testing.T, env *TestEnv, facility *model
 	})
 	require.NoError(t, err)
 	require.Empty(t, conflicts, "Should NOT detect conflicts for non-overlapping times (9-11 AM vs 2-4 PM)")
+}
+
+// testCancelSeriesBypassesConflict verifies that cancelling a series (event_series
+// with is_cancelled=true) is NOT blocked by a room conflict — a cancellation frees
+// the room rather than booking it.
+func testCancelSeriesBypassesConflict(t *testing.T, env *TestEnv, facility *models.Facility, facilityAdmin *models.User, program *models.Program, roomID uint) {
+	instructor1, err := env.CreateTestInstructor(facility.ID, "cancelbypassa")
+	require.NoError(t, err)
+	instructor2, err := env.CreateTestInstructor(facility.ID, "cancelbypassb")
+	require.NoError(t, err)
+
+	classStartDate := time.Date(2026, 6, 1, 0, 0, 0, 0, time.UTC)
+	classEndDate := time.Date(2026, 6, 30, 0, 0, 0, 0, time.UTC)
+	creditHours := int64(2)
+
+	mkClass := func(name string, instructorID uint) *models.ProgramClass {
+		resp := NewRequest[*models.ProgramClass](env.Client, t, http.MethodPost, fmt.Sprintf("/api/programs/%d/classes", program.ID), models.ProgramClass{
+			ProgramID:    program.ID,
+			FacilityID:   facility.ID,
+			Capacity:     10,
+			Name:         name,
+			InstructorID: &instructorID,
+			Description:  name,
+			StartDt:      classStartDate,
+			EndDt:        &classEndDate,
+			Status:       models.Scheduled,
+			CreditHours:  &creditHours,
+		}).
+			WithTestClaims(&handlers.Claims{Role: models.FacilityAdmin, UserID: facilityAdmin.ID, FacilityID: facility.ID}).
+			Do().
+			ExpectStatus(http.StatusCreated)
+		return resp.GetData()
+	}
+
+	// Blocker class occupies the room daily at 10:00-12:00.
+	blocker := mkClass("Room Blocker", instructor1.ID)
+	NewRequest[any](env.Client, t, http.MethodPost, fmt.Sprintf("/api/program-classes/%d/events", blocker.ID), map[string]interface{}{
+		"duration":        "2h",
+		"room_id":         roomID,
+		"recurrence_rule": "DTSTART:20260601T100000Z\nRRULE:FREQ=DAILY;UNTIL=20260630T000000Z",
+		"instructor_id":   instructor1.ID,
+	}).
+		WithTestClaims(&handlers.Claims{Role: models.FacilityAdmin, UserID: facilityAdmin.ID, FacilityID: facility.ID}).
+		Do().
+		ExpectStatus(http.StatusCreated)
+
+	// Second class with a non-overlapping event (14:00) so creation succeeds.
+	toCancel := mkClass("Class To Cancel", instructor2.ID)
+	NewRequest[any](env.Client, t, http.MethodPost, fmt.Sprintf("/api/program-classes/%d/events", toCancel.ID), map[string]interface{}{
+		"duration":        "2h",
+		"room_id":         roomID,
+		"recurrence_rule": "DTSTART:20260601T140000Z\nRRULE:FREQ=DAILY;UNTIL=20260630T000000Z",
+		"instructor_id":   instructor2.ID,
+	}).
+		WithTestClaims(&handlers.Claims{Role: models.FacilityAdmin, UserID: facilityAdmin.ID, FacilityID: facility.ID}).
+		Do().
+		ExpectStatus(http.StatusCreated)
+
+	var toCancelEvent models.ProgramClassEvent
+	require.NoError(t, env.DB.Where("class_id = ?", toCancel.ID).First(&toCancelEvent).Error)
+
+	// Cancel the series. The cancelled event_series carries the room and a rule that
+	// overlaps the blocker (10:00) — pre-fix this returned 409, now it must succeed.
+	cancelPayload := map[string]interface{}{
+		"event_series": map[string]interface{}{
+			"id":              0,
+			"duration":        "2h",
+			"room_id":         roomID,
+			"instructor_id":   instructor2.ID,
+			"is_cancelled":    true,
+			"recurrence_rule": "DTSTART:20260601T100000Z\nRRULE:FREQ=DAILY;UNTIL=20260630T000000Z",
+		},
+		"closed_event_series": map[string]interface{}{
+			"id":              toCancelEvent.ID,
+			"recurrence_rule": "DTSTART:20260601T140000Z\nRRULE:FREQ=DAILY;UNTIL=20260531T235959Z",
+		},
+	}
+	NewRequest[any](env.Client, t, http.MethodPut, fmt.Sprintf("/api/program-classes/%d/events", toCancel.ID), cancelPayload).
+		WithTestClaims(&handlers.Claims{Role: models.FacilityAdmin, UserID: facilityAdmin.ID, FacilityID: facility.ID}).
+		Do().
+		ExpectStatus(http.StatusCreated)
 }
 
 func testHandlerReturns409OnConflict(t *testing.T, env *TestEnv, facility *models.Facility, facilityAdmin *models.User, program *models.Program, roomID uint) {

--- a/frontend/src/pages/class-detail/SessionsTab.tsx
+++ b/frontend/src/pages/class-detail/SessionsTab.tsx
@@ -213,6 +213,19 @@ export function SessionsTab({ cls, onClassMutate }: SessionsTabProps) {
             overrideId = session.instance.override_id;
         }
 
+        // Series-level cancellation has no override; restore it via uncancel-series.
+        if (!overrideId && session.isCancelled && session.instance.event_id) {
+            const resp = await API.post(
+                `program-classes/${cls.id}/events/${session.instance.event_id}/uncancel-series`,
+                { restore_date: session.instance.date }
+            );
+            if (resp.success) {
+                toast.success('Future sessions restored');
+            }
+            await refreshData();
+            return;
+        }
+
         if (!overrideId) return;
         const hasAppliedFuture =
             rescheduleMaps.appliedFutureDates.size > 0 &&

--- a/frontend/src/pages/class-detail/session-utils.ts
+++ b/frontend/src/pages/class-detail/session-utils.ts
@@ -221,12 +221,13 @@ export function buildRoomOverrideMap(
 
 export function buildRescheduleMaps(events: ProgramClassEvent[]): {
     fromTo: Map<string, RescheduleLink>;
-    toFrom: Map<string, RescheduleLink>;
+    toFrom: Map<string, RescheduleLink[]>;
     appliedFutureDates: Set<string>;
     intermediateDates: Set<string>;
 } {
     const fromTo = new Map<string, RescheduleLink>();
-    const toFrom = new Map<string, RescheduleLink>();
+    // A date maps to a list of targets: several events can be rescheduled to the same date.
+    const toFrom = new Map<string, RescheduleLink[]>();
     const appliedFutureDates = new Set<string>();
     const intermediateDates = new Set<string>();
 
@@ -291,12 +292,14 @@ export function buildRescheduleMaps(events: ProgramClassEvent[]): {
                         overrideId: target.override.id,
                         eventId: event.id
                     });
-                    toFrom.set(target.date, {
+                    const toTargets = toFrom.get(target.date) ?? [];
+                    toTargets.push({
                         date: cancelled.date,
                         overrideId: target.override.id,
                         eventId: event.id,
                         startTime
                     });
+                    toFrom.set(target.date, toTargets);
                     break;
                 } else if (target.override.reason === 'rescheduled') {
                     // Intermediate in re-reschedule chain (B in A→B→C)
@@ -316,12 +319,14 @@ export function buildRescheduleMaps(events: ProgramClassEvent[]): {
                         overrideId: target.override.id,
                         eventId: event.id
                     });
-                    toFrom.set(target.date, {
+                    const toTargets = toFrom.get(target.date) ?? [];
+                    toTargets.push({
                         date: cancelled.date,
                         overrideId: target.override.id,
                         eventId: event.id,
                         startTime
                     });
+                    toFrom.set(target.date, toTargets);
                     break;
                 }
             }
@@ -354,7 +359,7 @@ export function buildSessionDisplays(
     instances: ClassEventInstance[],
     enrolled: number,
     fromTo: Map<string, RescheduleLink>,
-    toFrom: Map<string, RescheduleLink>,
+    toFrom: Map<string, RescheduleLink[]>,
     appliedFutureDates: Set<string>,
     intermediateDates: Set<string>,
     cancellationReasons?: Map<string, string>
@@ -425,7 +430,19 @@ export function buildSessionDisplays(
             const hasAttendance = (inst.attendance_records?.length ?? 0) > 0;
 
             const rescheduleFrom = fromTo.get(inst.date);
-            const rescheduleTo = toFrom.get(inst.date);
+            // Pick the target matching this instance's override, then fall back to time.
+            const rescheduleToCandidates = toFrom.get(inst.date) ?? [];
+            const rescheduleTo =
+                rescheduleToCandidates.find(
+                    (r) => r.overrideId === inst.override_id
+                ) ??
+                rescheduleToCandidates.find(
+                    (r) =>
+                        !r.startTime || inst.class_time.startsWith(r.startTime)
+                ) ??
+                (rescheduleToCandidates.length === 1
+                    ? rescheduleToCandidates[0]
+                    : undefined);
             let isRescheduledFrom = rescheduleFrom != null && inst.is_cancelled;
             // Fallback: backend sets is_rescheduled=true when reason='rescheduled',
             // regardless of linked_override_event_id chain availability.
@@ -514,13 +531,22 @@ export function buildSessionDisplays(
                 s.rescheduledClassTime = s.instance.class_time;
                 continue;
             }
-            // Different-date reschedule: find the separate target row
-            const target = filtered.find(
-                (t) =>
-                    t.instance.date === s.rescheduledDate &&
-                    t !== s &&
-                    (t.isRescheduledTo || t.isCancelledReschedule)
-            );
+            // Match the target by override id first so multiple reschedules to the same
+            // date each resolve to their own target, then fall back to date.
+            const target =
+                filtered.find(
+                    (t) =>
+                        t !== s &&
+                        s.rescheduleOverrideId != null &&
+                        t.instance.override_id === s.rescheduleOverrideId &&
+                        (t.isRescheduledTo || t.isCancelledReschedule)
+                ) ??
+                filtered.find(
+                    (t) =>
+                        t.instance.date === s.rescheduledDate &&
+                        t !== s &&
+                        (t.isRescheduledTo || t.isCancelledReschedule)
+                );
             if (target) {
                 if (target.instance.class_time !== s.instance.class_time) {
                     s.rescheduledClassTime = target.instance.class_time;


### PR DESCRIPTION
## Pre-Submission PR Checklist

- [x] No debug/console/fmt.Println statements
- [x] Unnecessary development comments removed
- [x] All acceptance criteria verified
- [x] Functions according to **ticket specifications**
- [x] Tested manually where applicable
- [x] Branch rebased with latest main
- [x] No business logic exists within the database layer

## Description of the change
PR Fixes a family of bugs related to "apply to all future sessions" that were all formed because a class can have multiple ProgramClassEvent recurrence rows but several code paths assumed one. 

You can now perform all "Apply to future sessions" actions without any classes prior to said action being affected or disapearing.  

- **Related issues**: https://app.asana.com/1/1201607307149189/project/1209460078641109/task/1215176689785898?focus=true
