### PR TITLE
fix: sidenav unexpected behavior

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -64,7 +64,7 @@
         "sonner": "^2.0.3",
         "swr": "^2.2.5",
         "tailwind-merge": "^3",
-        "tailwindcss-animate": "^1.0.7",
+        "tw-animate-css": "^1.4.0",
         "usehooks-ts": "^3.1.0",
         "vaul": "^1.1.2"
     },

--- a/frontend/src/components/navigation/MobileNav.tsx
+++ b/frontend/src/components/navigation/MobileNav.tsx
@@ -1,4 +1,9 @@
-import { Sheet, SheetContent, SheetTrigger } from '@/components/ui/sheet';
+import {
+    Sheet,
+    SheetContent,
+    SheetTitle,
+    SheetTrigger
+} from '@/components/ui/sheet';
 import { Button } from '@/components/ui/button';
 import { Menu } from 'lucide-react';
 import { useState } from 'react';
@@ -15,11 +20,13 @@ export default function MobileNav() {
                 </Button>
             </SheetTrigger>
             <SheetContent side="left" className="w-64 p-0">
+                <SheetTitle className="sr-only">Navigation menu</SheetTitle>
                 <Sidebar
                     collapsed={false}
                     onToggleCollapse={() => {
                         // no-op: mobile nav doesn't collapse
                     }}
+                    showCollapseToggle={false}
                     onNavigate={() => setOpen(false)}
                 />
             </SheetContent>

--- a/frontend/src/components/navigation/Sidebar.tsx
+++ b/frontend/src/components/navigation/Sidebar.tsx
@@ -36,13 +36,15 @@ interface SidebarProps {
     onToggleCollapse: () => void;
     onNavigate?: () => void;
     onToggleHelpCenter?: () => void;
+    showCollapseToggle?: boolean;
 }
 
 export default function Sidebar({
     collapsed,
     onToggleCollapse,
     onNavigate,
-    onToggleHelpCenter
+    onToggleHelpCenter,
+    showCollapseToggle = true
 }: SidebarProps) {
     const { user } = useAuth();
     const location = useLocation();
@@ -61,20 +63,22 @@ export default function Sidebar({
         >
             <div className="h-16 border-b border-border flex items-center justify-between px-4 shrink-0">
                 {!collapsed && <Brand />}
-                <button
-                    onClick={onToggleCollapse}
-                    className="p-2 rounded-lg hover:bg-accent transition-colors"
-                    aria-label={
-                        collapsed ? 'Expand sidebar' : 'Collapse sidebar'
-                    }
-                >
-                    <ChevronRightIcon
-                        className={cn(
-                            'size-5 text-muted-foreground transition-transform',
-                            !collapsed && 'rotate-180'
-                        )}
-                    />
-                </button>
+                {showCollapseToggle && (
+                    <button
+                        onClick={onToggleCollapse}
+                        className="p-2 rounded-lg hover:bg-accent transition-colors"
+                        aria-label={
+                            collapsed ? 'Expand sidebar' : 'Collapse sidebar'
+                        }
+                    >
+                        <ChevronRightIcon
+                            className={cn(
+                                'size-5 text-muted-foreground transition-transform',
+                                !collapsed && 'rotate-180'
+                            )}
+                        />
+                    </button>
+                )}
             </div>
 
             <nav className="p-3 space-y-1 overflow-y-auto flex-1">

--- a/frontend/src/styles/globals.css
+++ b/frontend/src/styles/globals.css
@@ -1,4 +1,5 @@
 @import 'tailwindcss';
+@import 'tw-animate-css';
 
 @custom-variant dark (&:is(.dark *));
 
@@ -515,50 +516,4 @@ input[type='checkbox']:focus {
 .unlocked-calendar .rbc-show-more:hover {
     background-color: #f0fdf4;
     text-decoration: underline;
-}
-
-/* Sheet slide animation — targeting Radix dialog data-state directly */
-@keyframes sheet-slide-in-right {
-    from {
-        transform: translateX(100%);
-    }
-    to {
-        transform: translateX(0);
-    }
-}
-@keyframes sheet-slide-out-right {
-    from {
-        transform: translateX(0);
-    }
-    to {
-        transform: translateX(100%);
-    }
-}
-@keyframes sheet-fade-in {
-    from {
-        opacity: 0;
-    }
-    to {
-        opacity: 1;
-    }
-}
-@keyframes sheet-fade-out {
-    from {
-        opacity: 1;
-    }
-    to {
-        opacity: 0;
-    }
-}
-[data-slot='sheet-content'][data-state='open'] {
-    animation: sheet-slide-in-right 300ms cubic-bezier(0.16, 1, 0.3, 1);
-}
-[data-slot='sheet-content'][data-state='closed'] {
-    animation: sheet-slide-out-right 200ms ease-in;
-}
-[data-slot='sheet-overlay'][data-state='open'] {
-    animation: sheet-fade-in 300ms ease-out;
-}
-[data-slot='sheet-overlay'][data-state='closed'] {
-    animation: sheet-fade-out 200ms ease-in;
 }

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -2970,11 +2970,6 @@ tailwind-merge@^3:
   resolved "https://registry.yarnpkg.com/tailwind-merge/-/tailwind-merge-3.5.0.tgz#06502f4496ba15151445d97d916a26564d50d1ca"
   integrity sha512-I8K9wewnVDkL1NTGoqWmVEIlUcB9gFriAEkXkfCjX5ib8ezGxtR3xD7iZIxrfArjEsH7F1CHD4RFUtxefdqV/A==
 
-tailwindcss-animate@^1.0.7:
-  version "1.0.7"
-  resolved "https://registry.yarnpkg.com/tailwindcss-animate/-/tailwindcss-animate-1.0.7.tgz#318b692c4c42676cc9e67b19b78775742388bef4"
-  integrity sha512-bl6mpH3T7I3UFxuvDEXLxy/VuFxBk5bbzplh7tXI68mwMokNYd1t9qPBHlnyTwfa4JGC4zP516I1hYYtQ/vspA==
-
 tailwindcss@4.2.1, tailwindcss@^4:
   version "4.2.1"
   resolved "https://registry.yarnpkg.com/tailwindcss/-/tailwindcss-4.2.1.tgz#018c4720b58baf98a6bf56b0a12aa797c6cfef1d"
@@ -3023,6 +3018,11 @@ tslib@^2.0.0, tslib@^2.1.0, tslib@^2.4.0, tslib@^2.8.1:
   version "2.8.1"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.8.1.tgz#612efe4ed235d567e8aba5f2a5fab70280ade83f"
   integrity sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==
+
+tw-animate-css@^1.4.0:
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/tw-animate-css/-/tw-animate-css-1.4.0.tgz#b4a06f68244cba39428aa47e65e6e4c0babc21ee"
+  integrity sha512-7bziOlRqH0hJx80h/3mbicLW7o8qLsH5+RaLR2t+OHM3D0JlWGODQKQ4cxbK7WlvmUxpcj6Kgu6EKqjrGFe3QQ==
 
 type-check@^0.4.0, type-check@~0.4.0:
   version "0.4.0"


### PR DESCRIPTION
## Pre-Submission PR Checklist

- [x] No debug/console/fmt.Println statements
- [x] Unnecessary development comments removed
- [x] All acceptance criteria verified
- [x] Functions according to **ticket specifications**
- [x] Tested manually where applicable
- [x] Branch rebased with latest main
- [x] No business logic exists within the database layer

## Description of the change
Fixes the mobile side navigation sliding off to the right and disappearing when the user taps outside it on small screens. The issue was caused by shacn's sheet's animation utilities not being loaded. 


  Changes:
  - Replaced the dead tailwindcss-animate dependency with tw-animate-css
  (the Tailwind v4 successor) and imported it in globals.css; removed
  the hand-rolled right-only sheet-* keyframes. The Sheet's own
  side-aware classes now drive the animation, so the left sheet slides
  left and right-docked sheets slide right.
  - Added a visually-hidden SheetTitle to the mobile nav (resolves the
  Radix DialogContent requires a DialogTitle screen-reader warning).
  - Removed the non-functional collapse chevron from the mobile sheet
  header (it was a no-op on mobile, sitting next to the close X) via a
  new showCollapseToggle prop on Sidebar; the desktop collapse toggle is
  unchanged.



- **Related issues**: https://app.asana.com/1/1201607307149189/project/1209460078641109/task/1215145641561038?focus=true

## Screenshot(s)
<img width="525" height="886" alt="image" src="https://github.com/user-attachments/assets/94f4f2a7-b2bc-4720-86d9-5a5af3af74cc" />
