### PR TITLE
fix: double booking instructor err

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,4 @@ jar
 /csvs/zims/*.zim
 /.claude
 .worktrees/
+/frontend/node_modules/*

--- a/backend/src/database/instructor_conflicts.go
+++ b/backend/src/database/instructor_conflicts.go
@@ -1,0 +1,133 @@
+package database
+
+import (
+	"UnlockEdv2/src/models"
+	"fmt"
+	"sort"
+	"time"
+
+	"github.com/sirupsen/logrus"
+	"github.com/teambition/rrule-go"
+)
+
+func checkInstructorRRuleConflicts(db *DB, req *models.ConflictCheckRequest) ([]models.RoomConflict, error) {
+	w, err := db.prepareConflictWindow(req)
+	if err != nil {
+		return nil, err
+	}
+	bookings, err := db.getInstructorBookingsInRange(req.FacilityID, req.InstructorID, w.rangeStart, w.rangeEnd, w.facilityTZ)
+	if err != nil {
+		return nil, err
+	}
+	return buildConflictsFromBookings(db, w, bookings, req, models.ConflictTypeInstructor), nil
+}
+
+func (db *DB) getInstructorBookingsInRange(facilityID, instructorID uint, rangeStart, rangeEnd time.Time, facilityTimezone string) ([]models.RoomBooking, error) {
+	var events []models.ProgramClassEvent
+	if err := db.Table("program_class_events e").
+		Select("DISTINCT e.*").
+		Joins("JOIN program_classes c ON c.id = e.class_id").
+		Joins("LEFT JOIN program_class_event_overrides o ON o.event_id = e.id AND o.deleted_at IS NULL").
+		Where("c.facility_id = ? AND e.deleted_at IS NULL AND (e.instructor_id = ? OR o.instructor_id = ?)", facilityID, instructorID, instructorID).
+		Preload("Overrides").
+		Find(&events).Error; err != nil {
+		return nil, newGetRecordsDBError(err, "program_class_events")
+	}
+
+	var bookings []models.RoomBooking
+	for _, event := range events {
+		eventBookings, err := expandEventToInstructorBookings(event, rangeStart, rangeEnd, instructorID, facilityTimezone)
+		if err != nil {
+			return nil, err
+		}
+		bookings = append(bookings, eventBookings...)
+	}
+	return bookings, nil
+}
+
+func expandEventToInstructorBookings(event models.ProgramClassEvent, rangeStart, rangeEnd time.Time, targetInstructorID uint, facilityTimezone string) ([]models.RoomBooking, error) {
+	var bookings []models.RoomBooking
+
+	rule, err := event.GetRRuleWithTimezone(facilityTimezone)
+	if err != nil {
+		return nil, fmt.Errorf("invalid recurrence rule for event %d: %w", event.ID, err)
+	}
+
+	duration, err := time.ParseDuration(event.Duration)
+	if err != nil {
+		return nil, fmt.Errorf("invalid duration '%s' for event %d: %w", event.Duration, event.ID, err)
+	}
+
+	cancelledDates := make(map[string]bool)
+	rescheduledDates := make(map[string]models.ProgramClassEventOverride)
+	for _, override := range event.Overrides {
+		overrideRule, err := rrule.StrToRRule(override.OverrideRrule)
+		if err != nil {
+			logrus.Warnf("skipping override %d with invalid rrule: %v", override.ID, err)
+			continue
+		}
+		for _, occ := range overrideRule.Between(rangeStart, rangeEnd, true) {
+			dateKey := occ.Format("2006-01-02")
+			if override.IsCancelled {
+				cancelledDates[dateKey] = true
+			} else {
+				rescheduledDates[dateKey] = override
+			}
+		}
+	}
+
+	if event.InstructorID != nil && *event.InstructorID == targetInstructorID {
+		for _, occ := range rule.Between(rangeStart, rangeEnd, true) {
+			dateKey := occ.Format("2006-01-02")
+			if cancelledDates[dateKey] {
+				continue
+			}
+			if _, rescheduled := rescheduledDates[dateKey]; rescheduled {
+				continue
+			}
+			bookings = append(bookings, models.RoomBooking{
+				StartTime: occ,
+				EndTime:   occ.Add(duration),
+				EventID:   event.ID,
+				ClassID:   event.ClassID,
+			})
+		}
+	}
+
+	for _, override := range event.Overrides {
+		if override.IsCancelled {
+			continue
+		}
+		effectiveInstructor := event.InstructorID
+		if override.InstructorID != nil {
+			effectiveInstructor = override.InstructorID
+		}
+		if effectiveInstructor == nil || *effectiveInstructor != targetInstructorID {
+			continue
+		}
+		overrideRule, err := rrule.StrToRRule(override.OverrideRrule)
+		if err != nil {
+			logrus.Warnf("skipping override %d with invalid rrule: %v", override.ID, err)
+			continue
+		}
+		overrideDuration, err := time.ParseDuration(override.Duration)
+		if err != nil {
+			overrideDuration = duration
+		}
+		for _, occ := range overrideRule.Between(rangeStart, rangeEnd, true) {
+			bookings = append(bookings, models.RoomBooking{
+				StartTime:  occ,
+				EndTime:    occ.Add(overrideDuration),
+				EventID:    event.ID,
+				ClassID:    event.ClassID,
+				IsOverride: true,
+			})
+		}
+	}
+
+	sort.Slice(bookings, func(i, j int) bool {
+		return bookings[i].StartTime.Before(bookings[j].StartTime)
+	})
+
+	return bookings, nil
+}

--- a/backend/src/database/instructor_conflicts.go
+++ b/backend/src/database/instructor_conflicts.go
@@ -10,11 +10,7 @@ import (
 	"github.com/teambition/rrule-go"
 )
 
-func checkInstructorRRuleConflicts(db *DB, req *models.ConflictCheckRequest) ([]models.RoomConflict, error) {
-	w, err := db.prepareConflictWindow(req)
-	if err != nil {
-		return nil, err
-	}
+func checkInstructorRRuleConflicts(db *DB, w *conflictWindow, req *models.ConflictCheckRequest) ([]models.RoomConflict, error) {
 	bookings, err := db.getInstructorBookingsInRange(req.FacilityID, req.InstructorID, w.rangeStart, w.rangeEnd, w.facilityTZ)
 	if err != nil {
 		return nil, err

--- a/backend/src/database/program_classes.go
+++ b/backend/src/database/program_classes.go
@@ -122,7 +122,7 @@ func (db *DB) CreateProgramClass(content *models.ProgramClass, conflictReq *mode
 		return nil, nil, NewDBError(tx.Error, "unable to start transaction")
 	}
 
-	conflicts, err := LockRoomAndCheckConflicts(tx, conflictReq)
+	conflicts, err := LockAndCheckConflicts(tx, conflictReq)
 	if err != nil {
 		tx.Rollback()
 		return nil, nil, err
@@ -156,7 +156,7 @@ func (db *DB) UpdateProgramClass(content *models.ProgramClass, id int, conflictR
 	}
 
 	if conflictReq != nil {
-		conflicts, err := LockRoomAndCheckConflicts(trans, conflictReq)
+		conflicts, err := LockAndCheckConflicts(trans, conflictReq)
 		if err != nil {
 			trans.Rollback()
 			return nil, nil, err

--- a/backend/src/database/rooms.go
+++ b/backend/src/database/rooms.go
@@ -39,21 +39,58 @@ func (db *DB) CreateRoom(room *models.Room) (*models.Room, error) {
 	return room, nil
 }
 
-func LockRoomAndCheckConflicts(tx *gorm.DB, req *models.ConflictCheckRequest) ([]models.RoomConflict, error) {
-	var room models.Room
-	if err := tx.Clauses(clause.Locking{Strength: "UPDATE"}).First(&room, req.RoomID).Error; err != nil {
-		return nil, newNotFoundDBError(err, "room")
+func LockAndCheckConflicts(tx *gorm.DB, req *models.ConflictCheckRequest) ([]models.RoomConflict, error) {
+	db := &DB{tx}
+	if req.RoomID != 0 {
+		var room models.Room
+		if err := tx.Clauses(clause.Locking{Strength: "UPDATE"}).First(&room, req.RoomID).Error; err != nil {
+			return nil, newNotFoundDBError(err, "room")
+		}
 	}
-	return checkRRuleConflictsInternal(&DB{tx}, req)
+	if req.InstructorID != 0 {
+		var instructor models.User
+		if err := tx.Clauses(clause.Locking{Strength: "UPDATE"}).First(&instructor, req.InstructorID).Error; err != nil {
+			return nil, newNotFoundDBError(err, "instructor")
+		}
+	}
+	return db.CheckConflicts(req)
 }
 
 const maxConflictsToReturn = 50
 
-func (db *DB) CheckRRuleConflicts(req *models.ConflictCheckRequest) ([]models.RoomConflict, error) {
-	return checkRRuleConflictsInternal(db, req)
+func (db *DB) CheckConflicts(req *models.ConflictCheckRequest) ([]models.RoomConflict, error) {
+	var conflicts []models.RoomConflict
+	if req.RoomID != 0 {
+		roomConflicts, err := checkRoomRRuleConflicts(db, req)
+		if err != nil {
+			return nil, err
+		}
+		conflicts = append(conflicts, roomConflicts...)
+	}
+	if req.InstructorID != 0 {
+		instructorConflicts, err := checkInstructorRRuleConflicts(db, req)
+		if err != nil {
+			return nil, err
+		}
+		conflicts = append(conflicts, instructorConflicts...)
+	}
+	return conflicts, nil
 }
 
-func checkRRuleConflictsInternal(db *DB, req *models.ConflictCheckRequest) ([]models.RoomConflict, error) {
+func (db *DB) CheckRRuleConflicts(req *models.ConflictCheckRequest) ([]models.RoomConflict, error) {
+	return checkRoomRRuleConflicts(db, req)
+}
+
+type conflictWindow struct {
+	occurrences []time.Time
+	duration    time.Duration
+	tz          *time.Location
+	facilityTZ  string
+	rangeStart  time.Time
+	rangeEnd    time.Time
+}
+
+func (db *DB) prepareConflictWindow(req *models.ConflictCheckRequest) (*conflictWindow, error) {
 	if req.RecurrenceRule == "" {
 		return nil, NewDBError(errors.New("recurrence rule is required"), "invalid conflict check request")
 	}
@@ -95,12 +132,17 @@ func checkRRuleConflictsInternal(db *DB, req *models.ConflictCheckRequest) ([]mo
 		until = rangeStart.AddDate(1, 0, 0)
 	}
 
-	bookings, err := db.getRoomBookingsInRange(req.FacilityID, req.RoomID, rangeStart, until, facility.Timezone)
-	if err != nil {
-		return nil, err
-	}
+	return &conflictWindow{
+		occurrences: rule.Between(rangeStart, until, true),
+		duration:    duration,
+		tz:          tz,
+		facilityTZ:  facility.Timezone,
+		rangeStart:  rangeStart,
+		rangeEnd:    until,
+	}, nil
+}
 
-	occurrences := rule.Between(rangeStart, until, true)
+func buildConflictsFromBookings(db *DB, w *conflictWindow, bookings []models.RoomBooking, req *models.ConflictCheckRequest, conflictType string) []models.RoomConflict {
 	var conflicts []models.RoomConflict
 
 	classIDs := make(map[uint]struct{})
@@ -123,11 +165,11 @@ func checkRRuleConflictsInternal(db *DB, req *models.ConflictCheckRequest) ([]mo
 		}
 	}
 
-	for _, occ := range occurrences {
+	for _, occ := range w.occurrences {
 		if len(conflicts) >= maxConflictsToReturn {
 			break
 		}
-		endTime := occ.Add(duration)
+		endTime := occ.Add(w.duration)
 		for _, booking := range bookings {
 			if req.ExcludeEventID != nil && booking.EventID == *req.ExcludeEventID {
 				continue
@@ -135,20 +177,19 @@ func checkRRuleConflictsInternal(db *DB, req *models.ConflictCheckRequest) ([]mo
 			if req.ExcludeClassID != nil && booking.ClassID == *req.ExcludeClassID {
 				continue
 			}
-			if hasLocalTimeOverlap(occ, endTime, booking.StartTime, booking.EndTime, tz) {
+			if hasLocalTimeOverlap(occ, endTime, booking.StartTime, booking.EndTime, w.tz) {
 				className := classNamesCache[booking.ClassID]
 				if className == "" {
 					className = "Unknown Class"
 				}
-
-				conflict := models.RoomConflict{
+				conflicts = append(conflicts, models.RoomConflict{
 					ConflictingEventID: booking.EventID,
 					ConflictingClassID: booking.ClassID,
 					ClassName:          className,
 					StartTime:          booking.StartTime,
 					EndTime:            booking.EndTime,
-				}
-				conflicts = append(conflicts, conflict)
+					ConflictType:       conflictType,
+				})
 				if len(conflicts) >= maxConflictsToReturn {
 					break
 				}
@@ -156,7 +197,19 @@ func checkRRuleConflictsInternal(db *DB, req *models.ConflictCheckRequest) ([]mo
 		}
 	}
 
-	return conflicts, nil
+	return conflicts
+}
+
+func checkRoomRRuleConflicts(db *DB, req *models.ConflictCheckRequest) ([]models.RoomConflict, error) {
+	w, err := db.prepareConflictWindow(req)
+	if err != nil {
+		return nil, err
+	}
+	bookings, err := db.getRoomBookingsInRange(req.FacilityID, req.RoomID, w.rangeStart, w.rangeEnd, w.facilityTZ)
+	if err != nil {
+		return nil, err
+	}
+	return buildConflictsFromBookings(db, w, bookings, req, models.ConflictTypeRoom), nil
 }
 
 func (db *DB) getRoomBookingsInRange(facilityID, roomID uint, rangeStart, rangeEnd time.Time, facilityTimezone string) ([]models.RoomBooking, error) {

--- a/backend/src/database/rooms.go
+++ b/backend/src/database/rooms.go
@@ -59,16 +59,23 @@ func LockAndCheckConflicts(tx *gorm.DB, req *models.ConflictCheckRequest) ([]mod
 const maxConflictsToReturn = 50
 
 func (db *DB) CheckConflicts(req *models.ConflictCheckRequest) ([]models.RoomConflict, error) {
+	if req.RoomID == 0 && req.InstructorID == 0 {
+		return nil, nil
+	}
+	w, err := db.prepareConflictWindow(req)
+	if err != nil {
+		return nil, err
+	}
 	var conflicts []models.RoomConflict
 	if req.RoomID != 0 {
-		roomConflicts, err := checkRoomRRuleConflicts(db, req)
+		roomConflicts, err := checkRoomRRuleConflicts(db, w, req)
 		if err != nil {
 			return nil, err
 		}
 		conflicts = append(conflicts, roomConflicts...)
 	}
 	if req.InstructorID != 0 {
-		instructorConflicts, err := checkInstructorRRuleConflicts(db, req)
+		instructorConflicts, err := checkInstructorRRuleConflicts(db, w, req)
 		if err != nil {
 			return nil, err
 		}
@@ -78,7 +85,11 @@ func (db *DB) CheckConflicts(req *models.ConflictCheckRequest) ([]models.RoomCon
 }
 
 func (db *DB) CheckRRuleConflicts(req *models.ConflictCheckRequest) ([]models.RoomConflict, error) {
-	return checkRoomRRuleConflicts(db, req)
+	w, err := db.prepareConflictWindow(req)
+	if err != nil {
+		return nil, err
+	}
+	return checkRoomRRuleConflicts(db, w, req)
 }
 
 type conflictWindow struct {
@@ -200,11 +211,7 @@ func buildConflictsFromBookings(db *DB, w *conflictWindow, bookings []models.Roo
 	return conflicts
 }
 
-func checkRoomRRuleConflicts(db *DB, req *models.ConflictCheckRequest) ([]models.RoomConflict, error) {
-	w, err := db.prepareConflictWindow(req)
-	if err != nil {
-		return nil, err
-	}
+func checkRoomRRuleConflicts(db *DB, w *conflictWindow, req *models.ConflictCheckRequest) ([]models.RoomConflict, error) {
 	bookings, err := db.getRoomBookingsInRange(req.FacilityID, req.RoomID, w.rangeStart, w.rangeEnd, w.facilityTZ)
 	if err != nil {
 		return nil, err

--- a/backend/src/handlers/class_events.go
+++ b/backend/src/handlers/class_events.go
@@ -440,39 +440,29 @@ func (srv *Server) handleCreateEvent(w http.ResponseWriter, r *http.Request, log
 		if err != nil {
 			return newDatabaseServiceError(err)
 		}
+		conflictReq := &models.ConflictCheckRequest{
+			FacilityID:     class.FacilityID,
+			RecurrenceRule: event.RecurrenceRule,
+			Duration:       event.Duration,
+		}
 		if event.RoomID != nil {
 			if _, err := srv.Db.GetRoomByIDForFacility(*event.RoomID, class.FacilityID); err != nil {
 				return newDatabaseServiceError(err)
 			}
-			conflicts, err := srv.Db.CheckRRuleConflicts(&models.ConflictCheckRequest{
-				FacilityID:     class.FacilityID,
-				RoomID:         *event.RoomID,
-				RecurrenceRule: event.RecurrenceRule,
-				Duration:       event.Duration,
-			})
-			if err != nil {
-				return newDatabaseServiceError(err)
-			}
-			if len(conflicts) > 0 {
-				return writeConflictResponse(w, conflicts)
-			}
+			conflictReq.RoomID = *event.RoomID
 		}
 		if event.InstructorID != nil {
 			if name, err := srv.Db.GetInstructorNameByID(*event.InstructorID, class.FacilityID); err != nil || name == "" {
 				return newBadRequestServiceError(err, "invalid instructor for this facility")
 			}
-			conflicts, err := srv.Db.CheckConflicts(&models.ConflictCheckRequest{
-				FacilityID:     class.FacilityID,
-				InstructorID:   *event.InstructorID,
-				RecurrenceRule: event.RecurrenceRule,
-				Duration:       event.Duration,
-			})
-			if err != nil {
-				return newDatabaseServiceError(err)
-			}
-			if len(conflicts) > 0 {
-				return writeConflictResponse(w, conflicts)
-			}
+			conflictReq.InstructorID = *event.InstructorID
+		}
+		conflicts, err := srv.Db.CheckConflicts(conflictReq)
+		if err != nil {
+			return newDatabaseServiceError(err)
+		}
+		if len(conflicts) > 0 {
+			return writeConflictResponse(w, conflicts)
 		}
 	}
 	_, err = srv.WithUserContext(r).CreateNewEvent(classID, event)

--- a/backend/src/handlers/class_events.go
+++ b/backend/src/handlers/class_events.go
@@ -435,25 +435,44 @@ func (srv *Server) handleCreateEvent(w http.ResponseWriter, r *http.Request, log
 		return newJSONReqBodyServiceError(err)
 	}
 	event.ClassID = uint(classID)
-	if event.RoomID != nil {
+	if event.RoomID != nil || event.InstructorID != nil {
 		class, err := srv.Db.GetClassByID(classID)
 		if err != nil {
 			return newDatabaseServiceError(err)
 		}
-		if _, err := srv.Db.GetRoomByIDForFacility(*event.RoomID, class.FacilityID); err != nil {
-			return newDatabaseServiceError(err)
+		if event.RoomID != nil {
+			if _, err := srv.Db.GetRoomByIDForFacility(*event.RoomID, class.FacilityID); err != nil {
+				return newDatabaseServiceError(err)
+			}
+			conflicts, err := srv.Db.CheckRRuleConflicts(&models.ConflictCheckRequest{
+				FacilityID:     class.FacilityID,
+				RoomID:         *event.RoomID,
+				RecurrenceRule: event.RecurrenceRule,
+				Duration:       event.Duration,
+			})
+			if err != nil {
+				return newDatabaseServiceError(err)
+			}
+			if len(conflicts) > 0 {
+				return writeConflictResponse(w, conflicts)
+			}
 		}
-		conflicts, err := srv.Db.CheckRRuleConflicts(&models.ConflictCheckRequest{
-			FacilityID:     class.FacilityID,
-			RoomID:         *event.RoomID,
-			RecurrenceRule: event.RecurrenceRule,
-			Duration:       event.Duration,
-		})
-		if err != nil {
-			return newDatabaseServiceError(err)
-		}
-		if len(conflicts) > 0 {
-			return writeConflictResponse(w, conflicts)
+		if event.InstructorID != nil {
+			if name, err := srv.Db.GetInstructorNameByID(*event.InstructorID, class.FacilityID); err != nil || name == "" {
+				return newBadRequestServiceError(err, "invalid instructor for this facility")
+			}
+			conflicts, err := srv.Db.CheckConflicts(&models.ConflictCheckRequest{
+				FacilityID:     class.FacilityID,
+				InstructorID:   *event.InstructorID,
+				RecurrenceRule: event.RecurrenceRule,
+				Duration:       event.Duration,
+			})
+			if err != nil {
+				return newDatabaseServiceError(err)
+			}
+			if len(conflicts) > 0 {
+				return writeConflictResponse(w, conflicts)
+			}
 		}
 	}
 	_, err = srv.WithUserContext(r).CreateNewEvent(classID, event)

--- a/backend/src/handlers/classes_handler.go
+++ b/backend/src/handlers/classes_handler.go
@@ -191,15 +191,23 @@ func (srv *Server) handleCreateClass(w http.ResponseWriter, r *http.Request, log
 	}
 
 	var conflictReq *models.ConflictCheckRequest
-	if len(class.Events) > 0 && class.Events[0].RoomID != nil {
-		if _, err := srv.Db.GetRoomByIDForFacility(*class.Events[0].RoomID, class.FacilityID); err != nil {
-			return newDatabaseServiceError(err)
+	if len(class.Events) > 0 && class.Events[0].RecurrenceRule != "" && class.Events[0].Duration != "" {
+		event := class.Events[0]
+		if event.RoomID != nil {
+			if _, err := srv.Db.GetRoomByIDForFacility(*event.RoomID, class.FacilityID); err != nil {
+				return newDatabaseServiceError(err)
+			}
 		}
 		conflictReq = &models.ConflictCheckRequest{
 			FacilityID:     class.FacilityID,
-			RoomID:         *class.Events[0].RoomID,
-			RecurrenceRule: class.Events[0].RecurrenceRule,
-			Duration:       class.Events[0].Duration,
+			RecurrenceRule: event.RecurrenceRule,
+			Duration:       event.Duration,
+		}
+		if event.RoomID != nil {
+			conflictReq.RoomID = *event.RoomID
+		}
+		if class.InstructorID != nil {
+			conflictReq.InstructorID = *class.InstructorID
 		}
 	}
 
@@ -271,21 +279,47 @@ func (srv *Server) handleUpdateClass(w http.ResponseWriter, r *http.Request, log
 	class.UpdateUserID = models.UintPtr(claims.UserID)
 
 	var conflictReq *models.ConflictCheckRequest
-	if len(class.Events) > 0 && class.Events[0].RoomID != nil {
-		if _, err := srv.Db.GetRoomByIDForFacility(*class.Events[0].RoomID, existing.FacilityID); err != nil {
-			return newDatabaseServiceError(err)
+	if len(existing.Events) > 0 {
+		existingEvent := existing.Events[0]
+
+		var roomChanged bool
+		if len(class.Events) > 0 && class.Events[0].RoomID != nil {
+			if _, err := srv.Db.GetRoomByIDForFacility(*class.Events[0].RoomID, existing.FacilityID); err != nil {
+				return newDatabaseServiceError(err)
+			}
+			existingRoomID := uint(0)
+			if existingEvent.RoomID != nil {
+				existingRoomID = *existingEvent.RoomID
+			}
+			if *class.Events[0].RoomID != existingRoomID {
+				roomChanged = true
+			}
 		}
-		existingRoomID := uint(0)
-		if len(existing.Events) > 0 && existing.Events[0].RoomID != nil {
-			existingRoomID = *existing.Events[0].RoomID
+
+		var instructorChanged bool
+		if instructorIDProvided && class.InstructorID != nil {
+			existingInstructorID := uint(0)
+			if existingEvent.InstructorID != nil {
+				existingInstructorID = *existingEvent.InstructorID
+			}
+			if *class.InstructorID != existingInstructorID {
+				instructorChanged = true
+			}
 		}
-		if *class.Events[0].RoomID != existingRoomID {
+
+		if (roomChanged || instructorChanged) && existingEvent.RecurrenceRule != "" && existingEvent.Duration != "" {
 			conflictReq = &models.ConflictCheckRequest{
 				FacilityID:     existing.FacilityID,
-				RoomID:         *class.Events[0].RoomID,
-				RecurrenceRule: existing.Events[0].RecurrenceRule,
-				Duration:       existing.Events[0].Duration,
-				ExcludeEventID: &existing.Events[0].ID,
+				RecurrenceRule: existingEvent.RecurrenceRule,
+				Duration:       existingEvent.Duration,
+				ExcludeEventID: &existingEvent.ID,
+				ExcludeClassID: &existing.ID,
+			}
+			if roomChanged {
+				conflictReq.RoomID = *class.Events[0].RoomID
+			}
+			if instructorChanged {
+				conflictReq.InstructorID = *class.InstructorID
 			}
 		}
 	}

--- a/backend/src/handlers/server.go
+++ b/backend/src/handlers/server.go
@@ -584,13 +584,33 @@ func writeConflictResponse(w http.ResponseWriter, conflicts []models.RoomConflic
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(http.StatusConflict)
 	resp := models.Resource[[]models.RoomConflict]{
-		Message: "room is already booked during this time",
+		Message: conflictResponseMessage(conflicts),
 		Data:    conflicts,
 	}
 	if err := json.NewEncoder(w).Encode(resp); err != nil {
 		return newResponseServiceError(err)
 	}
 	return nil
+}
+
+func conflictResponseMessage(conflicts []models.RoomConflict) string {
+	var hasRoom, hasInstructor bool
+	for _, c := range conflicts {
+		switch c.ConflictType {
+		case models.ConflictTypeInstructor:
+			hasInstructor = true
+		default:
+			hasRoom = true
+		}
+	}
+	switch {
+	case hasRoom && hasInstructor:
+		return "the room and instructor are already booked during this time"
+	case hasInstructor:
+		return "the instructor is already teaching during this time"
+	default:
+		return "room is already booked during this time"
+	}
 }
 
 func writeDeleteConflictResponse(w http.ResponseWriter, message string, blockers models.DeleteBlockingChildren) error {

--- a/backend/src/models/facilities.go
+++ b/backend/src/models/facilities.go
@@ -53,11 +53,17 @@ type RoomBooking struct {
 type ConflictCheckRequest struct {
 	FacilityID     uint
 	RoomID         uint
+	InstructorID   uint
 	RecurrenceRule string
 	Duration       string
 	ExcludeEventID *uint
 	ExcludeClassID *uint
 }
+
+const (
+	ConflictTypeRoom       = "room"
+	ConflictTypeInstructor = "instructor"
+)
 
 type RoomConflict struct {
 	ConflictingEventID uint      `json:"conflicting_event_id"`
@@ -65,4 +71,5 @@ type RoomConflict struct {
 	ClassName          string    `json:"class_name"`
 	StartTime          time.Time `json:"start_time"`
 	EndTime            time.Time `json:"end_time"`
+	ConflictType       string    `json:"conflict_type"`
 }

--- a/backend/tests/integration/instructor_conflict_test.go
+++ b/backend/tests/integration/instructor_conflict_test.go
@@ -1,0 +1,163 @@
+package integration
+
+import (
+	"fmt"
+	"net/http"
+	"testing"
+	"time"
+
+	"UnlockEdv2/src/handlers"
+	"UnlockEdv2/src/models"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestInstructorConflictDetection covers ID-642: assigning an instructor who is
+// already teaching another class at an overlapping time must be detected.
+func TestInstructorConflictDetection(t *testing.T) {
+	env := SetupTestEnv(t)
+	defer env.CleanupTestEnv()
+
+	facility, err := env.CreateTestFacility("Instructor Conflict Facility")
+	require.NoError(t, err)
+
+	facilityAdmin, err := env.CreateTestUser("instconflictadmin", models.FacilityAdmin, facility.ID, "")
+	require.NoError(t, err)
+
+	program, err := env.CreateTestProgram("Instructor Conflict Program", models.FundingType(models.FederalGrants), []models.ProgramType{}, []models.ProgramCreditType{}, true, nil)
+	require.NoError(t, err)
+
+	err = env.SetFacilitiesToProgram(program.ID, []uint{facility.ID})
+	require.NoError(t, err)
+
+	room := &models.Room{FacilityID: facility.ID, Name: "Instructor Conflict Room"}
+	require.NoError(t, env.DB.Create(room).Error)
+
+	t.Run("Detects overlapping instructor bookings", func(t *testing.T) {
+		testInstructorDetectsOverlap(t, env, facility, facilityAdmin, program, room.ID)
+	})
+
+	t.Run("No conflict for different times", func(t *testing.T) {
+		testInstructorNoConflictDifferentTimes(t, env, facility, facilityAdmin, program, room.ID)
+	})
+
+	t.Run("Handler returns 409 when changing class instructor to a double-booked one", func(t *testing.T) {
+		testHandlerReturns409OnInstructorChange(t, env, facility, facilityAdmin, program, room.ID)
+	})
+}
+
+// helper: create a class with an instructor and a single daily event in the given window.
+func createClassWithEvent(t *testing.T, env *TestEnv, facility *models.Facility, admin *models.User, program *models.Program, name string, instructorID, roomID uint, recurrenceRule, duration string, start time.Time, end time.Time) *models.ProgramClass {
+	creditHours := int64(2)
+	class := models.ProgramClass{
+		ProgramID:    program.ID,
+		FacilityID:   facility.ID,
+		Capacity:     10,
+		Name:         name,
+		InstructorID: &instructorID,
+		Description:  name,
+		StartDt:      start,
+		EndDt:        &end,
+		Status:       models.Scheduled,
+		CreditHours:  &creditHours,
+	}
+	resp := NewRequest[*models.ProgramClass](env.Client, t, http.MethodPost, fmt.Sprintf("/api/programs/%d/classes", program.ID), class).
+		WithTestClaims(&handlers.Claims{Role: models.FacilityAdmin, UserID: admin.ID, FacilityID: facility.ID}).
+		Do().
+		ExpectStatus(http.StatusCreated)
+	created := resp.GetData()
+
+	eventPayload := map[string]interface{}{
+		"duration":        duration,
+		"room_id":         roomID,
+		"recurrence_rule": recurrenceRule,
+		"instructor_id":   instructorID,
+	}
+	NewRequest[any](env.Client, t, http.MethodPost, fmt.Sprintf("/api/program-classes/%d/events", created.ID), eventPayload).
+		WithTestClaims(&handlers.Claims{Role: models.FacilityAdmin, UserID: admin.ID, FacilityID: facility.ID}).
+		Do().
+		ExpectStatus(http.StatusCreated)
+	return created
+}
+
+func testInstructorDetectsOverlap(t *testing.T, env *TestEnv, facility *models.Facility, admin *models.User, program *models.Program, roomID uint) {
+	instructor, err := env.CreateTestInstructor(facility.ID, "instoverlap")
+	require.NoError(t, err)
+
+	start := time.Date(2026, 3, 1, 0, 0, 0, 0, time.UTC)
+	end := time.Date(2026, 3, 31, 0, 0, 0, 0, time.UTC)
+	createClassWithEvent(t, env, facility, admin, program, "Instructor Morning Class", instructor.ID, roomID,
+		"DTSTART:20260302T090000Z\nRRULE:FREQ=DAILY;UNTIL=20260331T000000Z", "2h", start, end)
+
+	// Same instructor, overlapping window (9:30) -> conflict.
+	conflicts, err := env.DB.CheckConflicts(&models.ConflictCheckRequest{
+		FacilityID:     facility.ID,
+		InstructorID:   instructor.ID,
+		RecurrenceRule: "DTSTART:20260302T093000Z\nRRULE:FREQ=DAILY;UNTIL=20260310T000000Z",
+		Duration:       "1h",
+	})
+	require.NoError(t, err)
+	require.NotEmpty(t, conflicts, "should detect instructor double-booking for overlapping times")
+	require.Equal(t, models.ConflictTypeInstructor, conflicts[0].ConflictType, "conflict should be tagged as instructor")
+	require.Equal(t, "Instructor Morning Class", conflicts[0].ClassName)
+}
+
+func testInstructorNoConflictDifferentTimes(t *testing.T, env *TestEnv, facility *models.Facility, admin *models.User, program *models.Program, roomID uint) {
+	instructor, err := env.CreateTestInstructor(facility.ID, "instnoconf")
+	require.NoError(t, err)
+
+	start := time.Date(2026, 5, 1, 0, 0, 0, 0, time.UTC)
+	end := time.Date(2026, 5, 31, 0, 0, 0, 0, time.UTC)
+	createClassWithEvent(t, env, facility, admin, program, "Instructor AM Class", instructor.ID, roomID,
+		"DTSTART:20260504T090000Z\nRRULE:FREQ=DAILY;UNTIL=20260531T000000Z", "2h", start, end)
+
+	// Same instructor but a non-overlapping afternoon window (2-4 PM) -> no conflict.
+	conflicts, err := env.DB.CheckConflicts(&models.ConflictCheckRequest{
+		FacilityID:     facility.ID,
+		InstructorID:   instructor.ID,
+		RecurrenceRule: "DTSTART:20260504T140000Z\nRRULE:FREQ=DAILY;UNTIL=20260510T000000Z",
+		Duration:       "2h",
+	})
+	require.NoError(t, err)
+	require.Empty(t, conflicts, "should NOT detect instructor conflict for non-overlapping times")
+}
+
+// testHandlerReturns409OnInstructorChange reproduces the ticket scenario: change
+// class X's instructor to the instructor of overlapping class Y -> 409.
+func testHandlerReturns409OnInstructorChange(t *testing.T, env *TestEnv, facility *models.Facility, admin *models.User, program *models.Program, roomID uint) {
+	instructor1, err := env.CreateTestInstructor(facility.ID, "instchangea")
+	require.NoError(t, err)
+	instructor2, err := env.CreateTestInstructor(facility.ID, "instchangeb")
+	require.NoError(t, err)
+
+	start := time.Date(2026, 6, 1, 0, 0, 0, 0, time.UTC)
+	end := time.Date(2026, 6, 30, 0, 0, 0, 0, time.UTC)
+
+	// Class 1 taught by instructor1 at 10:00.
+	createClassWithEvent(t, env, facility, admin, program, "Class Y (instructor1)", instructor1.ID, roomID,
+		"DTSTART:20260601T100000Z\nRRULE:FREQ=DAILY;UNTIL=20260630T000000Z", "2h", start, end)
+
+	// Class 2 taught by instructor2 at an overlapping 10:30 (different room avoids a room conflict).
+	room2 := &models.Room{FacilityID: facility.ID, Name: "Instructor Conflict Room 2"}
+	require.NoError(t, env.DB.Create(room2).Error)
+	class2 := createClassWithEvent(t, env, facility, admin, program, "Class X (instructor2)", instructor2.ID, room2.ID,
+		"DTSTART:20260601T103000Z\nRRULE:FREQ=DAILY;UNTIL=20260630T000000Z", "1h", start, end)
+
+	// Changing class X's instructor to instructor1 collides with class Y -> 409.
+	NewRequest[any](env.Client, t, http.MethodPatch, fmt.Sprintf("/api/programs/%d/classes/%d", program.ID, class2.ID), map[string]interface{}{
+		"instructor_id": instructor1.ID,
+	}).
+		WithTestClaims(&handlers.Claims{Role: models.FacilityAdmin, UserID: admin.ID, FacilityID: facility.ID}).
+		Do().
+		ExpectStatus(http.StatusConflict)
+
+	// Changing to a free instructor succeeds.
+	instructor3, err := env.CreateTestInstructor(facility.ID, "instchangec")
+	require.NoError(t, err)
+	NewRequest[any](env.Client, t, http.MethodPatch, fmt.Sprintf("/api/programs/%d/classes/%d", program.ID, class2.ID), map[string]interface{}{
+		"instructor_id": instructor3.ID,
+	}).
+		WithTestClaims(&handlers.Claims{Role: models.FacilityAdmin, UserID: admin.ID, FacilityID: facility.ID}).
+		Do().
+		ExpectStatus(http.StatusOK)
+}

--- a/frontend/src/lib/formatters.ts
+++ b/frontend/src/lib/formatters.ts
@@ -1,6 +1,7 @@
 import { Video } from '@/types/content';
 import { Class } from '@/types/program';
 import { ProgramClassEvent } from '@/types/events';
+import { RoomConflict } from '@/types/facility';
 import { RRule, Weekday } from 'rrule';
 
 export enum Timezones {
@@ -85,6 +86,16 @@ export function formatRoomConflictRange(
 
     if (startDate === endDate) return `${startDate} ${startTime} - ${endTime}`;
     return `${startDate} ${startTime} - ${endDate} ${endTime}`;
+}
+
+export function conflictSubjectLabel(conflicts: RoomConflict[]): string {
+    const hasInstructor = conflicts.some(
+        (c) => c.conflict_type === 'instructor'
+    );
+    const hasRoom = conflicts.some((c) => c.conflict_type !== 'instructor');
+    if (hasInstructor && hasRoom) return 'This class';
+    if (hasInstructor) return 'Instructor';
+    return 'Room';
 }
 
 export function formatLastActive(dateStr?: string | null): string {

--- a/frontend/src/pages/class-detail/EditClassModal.tsx
+++ b/frontend/src/pages/class-detail/EditClassModal.tsx
@@ -36,7 +36,11 @@ import {
     ServerResponseOne,
     NewUserResponse
 } from '@/types';
-import { formatRoomConflictRange, getInstructorId } from '@/lib/formatters';
+import {
+    conflictSubjectLabel,
+    formatRoomConflictRange,
+    getInstructorId
+} from '@/lib/formatters';
 
 interface EditClassModalProps {
     open: boolean;
@@ -46,16 +50,6 @@ interface EditClassModalProps {
 }
 
 type EditClassFormData = EditClassInput;
-
-function conflictSubjectLabel(conflicts: RoomConflict[]): string {
-    const hasInstructor = conflicts.some(
-        (c) => c.conflict_type === 'instructor'
-    );
-    const hasRoom = conflicts.some((c) => c.conflict_type !== 'instructor');
-    if (hasInstructor && hasRoom) return 'This class';
-    if (hasInstructor) return 'Instructor';
-    return 'Room';
-}
 
 const ALL_DAYS = [
     'Monday',
@@ -129,12 +123,15 @@ function parseScheduleFromEvent(
     }
 
     if (duration && startTime) {
-        const durationMatch = /(\d+)h(\d+)m/.exec(duration);
-        if (durationMatch) {
+        const durationMatch = /(?:(\d+)h)?(?:(\d+)m)?/.exec(duration);
+        if (durationMatch && (durationMatch[1] || durationMatch[2])) {
             const [, hours, mins] = durationMatch;
             const [sh, sm] = startTime.split(':').map(Number);
             const totalMin =
-                (sh ?? 0) * 60 + (sm ?? 0) + Number(hours) * 60 + Number(mins);
+                (sh ?? 0) * 60 +
+                (sm ?? 0) +
+                Number(hours ?? 0) * 60 +
+                Number(mins ?? 0);
             const eh = Math.floor(totalMin / 60) % 24;
             const em = totalMin % 60;
             endTime = `${String(eh).padStart(2, '0')}:${String(em).padStart(2, '0')}`;
@@ -375,6 +372,10 @@ export function EditClassModal({
             data.end_dt || undefined // eslint-disable-line @typescript-eslint/prefer-nullish-coalescing -- empty string must collapse to undefined
         );
         const newDuration = formatDuration(data.start_time, data.end_time);
+        if (newDuration === '0h0m0s') {
+            toast.error('End time must be after start time');
+            return;
+        }
 
         const payload = {
             id: cls.id,

--- a/frontend/src/pages/class-detail/EditClassModal.tsx
+++ b/frontend/src/pages/class-detail/EditClassModal.tsx
@@ -47,6 +47,16 @@ interface EditClassModalProps {
 
 type EditClassFormData = EditClassInput;
 
+function conflictSubjectLabel(conflicts: RoomConflict[]): string {
+    const hasInstructor = conflicts.some(
+        (c) => c.conflict_type === 'instructor'
+    );
+    const hasRoom = conflicts.some((c) => c.conflict_type !== 'instructor');
+    if (hasInstructor && hasRoom) return 'This class';
+    if (hasInstructor) return 'Instructor';
+    return 'Room';
+}
+
 const ALL_DAYS = [
     'Monday',
     'Tuesday',
@@ -1101,7 +1111,8 @@ export function EditClassModal({
                             {conflicts.length > 0 && (
                                 <div className="space-y-2">
                                     <p className="text-sm font-medium text-red-700">
-                                        Room has {conflicts.length} scheduling{' '}
+                                        {conflictSubjectLabel(conflicts)} has{' '}
+                                        {conflicts.length} scheduling{' '}
                                         {conflicts.length === 1
                                             ? 'conflict'
                                             : 'conflicts'}

--- a/frontend/src/pages/programs/ClassManagementForm.tsx
+++ b/frontend/src/pages/programs/ClassManagementForm.tsx
@@ -21,7 +21,11 @@ import {
     ClassManagementFormValues
 } from '@/lib/validation';
 import { isCompletedCancelledOrArchived } from '@/lib/classStatus';
-import { formatRoomConflictRange, getInstructorId } from '@/lib/formatters';
+import {
+    conflictSubjectLabel,
+    formatRoomConflictRange,
+    getInstructorId
+} from '@/lib/formatters';
 import { PageHeader } from '@/components/shared';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
@@ -1744,8 +1748,8 @@ export function ClassManagementFormInner({
             <FormModal
                 open={showConflicts}
                 onOpenChange={setShowConflicts}
-                title="Room Scheduling Conflict"
-                description={`The selected room has ${conflicts.length} conflicts with existing classes.`}
+                title="Scheduling Conflict"
+                description={`${conflictSubjectLabel(conflicts)} has ${conflicts.length} ${conflicts.length === 1 ? 'conflict' : 'conflicts'} with existing classes.`}
             >
                 <div className="max-h-[50vh] overflow-y-auto space-y-3 pr-1">
                     {conflicts.map((c, i) => (

--- a/frontend/src/types/facility.ts
+++ b/frontend/src/types/facility.ts
@@ -21,6 +21,7 @@ export interface RoomConflict {
     class_name: string;
     start_time: string;
     end_time: string;
+    conflict_type: 'room' | 'instructor';
 }
 
 export interface FacilityWithStats {


### PR DESCRIPTION
## Pre-Submission PR Checklist

- [x] No debug/console/fmt.Println statements
- [x] Unnecessary development comments removed
- [x] All acceptance criteria verified
- [x] Functions according to **ticket spexifications**
- [x] Tested manually where applicable
- [x] Branch rebased with latest main
- [x] No business logic exists within the database layer

## Description of the change
There was an issue with double-booking instructors, and the eligibility of instructors during assignment. This PR implements a double-booking detection system similar to double-booking rooms. 
- New database/instructor_conflicts.go: expands an instructor's events/overrides into time slots (getInstructorBookingsInRange) and
  detects overlaps against a candidate schedule, honoring per-occurrence instructor overrides, cancellations, and facility timezone.
  - Refactored rooms.go to share the recurrence-window + overlap + class-name logic (prepareConflictWindow,
  buildConflictsFromBookings) between room and instructor checks (DRY). LockAndCheckConflicts now locks and checks room and/or
  instructor; conflicts are tagged with ConflictType.
  - Wired into handleCreateClass, handleUpdateClass (the ticket's "change a class's instructor" path), and handleCreateEvent; returns
  HTTP 409 with a type-aware message (instructor vs room). Added instructor-belongs-to-facility validation on the event path.
  - Frontend: EditClassModal shows an instructor-aware conflict heading; RoomConflict type gains conflict_type.
  - Tests: new instructor_conflict_test.go covering overlap detection, non-overlap, and the 409-on-instructor-change scenario.
 
  - Related issues: https://app.asana.com/1/1201607307149189/project/1209460078641109/task/1214430813078163?focus=true



- **Related issues**: Link to related Asana ticket that this closes.

