### PR TITLE
 PostHog analytics instrumentation for pilot tracking

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -33,5 +33,5 @@ SECRETS_SYSTEM=Vg2CngwLX2MxZvZaKJnuyVp66cPiiV5b
 
 CORS_ALLOWED_ORIGINS=http://localhost,http://127.0.0.1
 
-VITE_PUBLIC_POSTHOG_KEY=phc_XTzZrR2jXxeI6znRI0h5Chlg33vZgmyFu2kh0HPgPP1
+VITE_PUBLIC_POSTHOG_KEY=your_posthog_project_api_key
 VITE_PUBLIC_POSTHOG_HOST=https://us.i.posthog.com

--- a/.env.example
+++ b/.env.example
@@ -32,3 +32,6 @@ MIGRATION_DIR=backend/migrations
 SECRETS_SYSTEM=Vg2CngwLX2MxZvZaKJnuyVp66cPiiV5b
 
 CORS_ALLOWED_ORIGINS=http://localhost,http://127.0.0.1
+
+VITE_PUBLIC_POSTHOG_KEY=phc_XTzZrR2jXxeI6znRI0h5Chlg33vZgmyFu2kh0HPgPP1
+VITE_PUBLIC_POSTHOG_HOST=https://us.i.posthog.com

--- a/frontend/src/api/api.ts
+++ b/frontend/src/api/api.ts
@@ -3,6 +3,7 @@ import {
     ServerResponseOne,
     ServerResponseMany
 } from '@/types/server';
+import { ANALYTICS_EVENTS, captureEvent } from '@/lib/analytics';
 
 class API {
     private static getCSRFToken(): string {
@@ -114,6 +115,12 @@ class API {
                 response?: ServerResponseOne<T>;
             };
             const errCode = error.response?.status;
+            captureEvent(ANALYTICS_EVENTS.ApiError, {
+                status: errCode ?? 0,
+                method,
+                url,
+                message: error.message || 'An error occurred'
+            });
             return {
                 type: 'one',
                 success: false,

--- a/frontend/src/auth/AuthProvider.tsx
+++ b/frontend/src/auth/AuthProvider.tsx
@@ -3,6 +3,7 @@ import { INIT_KRATOS_LOGIN_FLOW, User } from '@/types';
 import { AuthContext, fetchUser, handleLogout } from '@/auth/useAuth';
 import { useNavigate } from 'react-router-dom';
 import { tabSessionManager } from '@/session/tabSession';
+import { identifyUser } from '@/lib/analytics';
 
 export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({
     children
@@ -25,6 +26,7 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({
                     await handleLogout();
                     return;
                 }
+                identifyUser(authUser);
                 setUser(authUser);
             }
             setLoading(false);

--- a/frontend/src/auth/useAuth.ts
+++ b/frontend/src/auth/useAuth.ts
@@ -14,6 +14,7 @@ import {
 } from '@/types';
 import API from '@/api/api';
 import { tabSessionManager } from '@/session/tabSession';
+import { resetAnalytics } from '@/lib/analytics';
 
 interface AuthContextType {
     user: User | undefined;
@@ -164,6 +165,7 @@ export const checkExistingFlow: LoaderFunction = async ({ request }) => {
 
 export async function handleLogout(): Promise<void> {
     try {
+        resetAnalytics();
         tabSessionManager.onLogout();
         const resp = await API.post<AuthResponse, object>('logout', {});
         if (resp.success) {

--- a/frontend/src/lib/analytics.ts
+++ b/frontend/src/lib/analytics.ts
@@ -1,0 +1,80 @@
+import posthog from 'posthog-js';
+import type { User } from '@/types';
+
+/**
+ * Central analytics layer for PostHog custom events.
+ *
+ * Import this module rather than calling `posthog.capture` directly so event
+ * names stay typed/stable for PostHog insights and so a missing/blocked
+ * analytics client can never break a user flow.
+ */
+export const ANALYTICS_EVENTS = {
+    // Time & Efficiency
+    AttendanceSessionStarted: 'attendance_session_started',
+    AttendanceSessionCompleted: 'attendance_session_completed',
+    ProgramCreationStarted: 'program_creation_started',
+    ProgramCreationCompleted: 'program_creation_completed',
+    ClassCreationStarted: 'class_creation_started',
+    ClassCreationCompleted: 'class_creation_completed',
+    // Enrollment funnel
+    EnrollModalOpened: 'enroll_modal_opened',
+    EnrollResidentsSelected: 'enroll_residents_selected',
+    EnrollCompleted: 'enroll_completed',
+    // Errors & friction
+    ApiError: 'api_error'
+} as const;
+
+export type AnalyticsEvent =
+    (typeof ANALYTICS_EVENTS)[keyof typeof ANALYTICS_EVENTS];
+
+type AnalyticsValue = string | number | boolean | null | undefined;
+export type AnalyticsProps = Record<string, AnalyticsValue>;
+
+/** Fire a custom event. Never throws. */
+export function captureEvent(
+    event: AnalyticsEvent,
+    props?: AnalyticsProps
+): void {
+    try {
+        posthog.capture(event, props);
+    } catch {
+        // Analytics must never interrupt a user flow.
+    }
+}
+
+/**
+ * Tie subsequent events to a stable per-user identity so login frequency,
+ * weekly-active-users and new-user metrics attribute correctly.
+ *
+ * Sends id/role/facility only — no names, usernames or emails — to keep staff
+ * PII out of PostHog in the corrections context.
+ */
+export function identifyUser(
+    user: Pick<User, 'id' | 'role' | 'facility_id'>
+): void {
+    try {
+        posthog.identify(String(user.id), {
+            role: user.role,
+            facility_id: user.facility_id
+        });
+    } catch {
+        /* noop */
+    }
+}
+
+/**
+ * Clear the identified user. Critical for shared facility workstations so the
+ * next staff member isn't attributed to the previous one.
+ */
+export function resetAnalytics(): void {
+    try {
+        posthog.reset();
+    } catch {
+        /* noop */
+    }
+}
+
+/** Whole-second elapsed time since `startMs`, for *_completed duration props. */
+export function flowTimerSeconds(startMs: number): number {
+    return Math.max(0, Math.round((Date.now() - startMs) / 1000));
+}

--- a/frontend/src/lib/useFlowTimer.ts
+++ b/frontend/src/lib/useFlowTimer.ts
@@ -11,17 +11,23 @@ import {
  * it to flowTimerSeconds() when firing the matching *_completed event.
  *
  * Pass null for startedEvent to skip the started event (edit flows).
+ *
+ * Pass enabled=false to defer the started event until the flow is actually
+ * actionable (e.g. after data loads and validity guards pass); it fires once
+ * enabled flips true, so bad-route/error/unscheduled renders aren't counted.
  */
 export function useFlowTimer(
     startedEvent: AnalyticsEvent | null,
     props?: AnalyticsProps,
-    deps: unknown[] = []
+    deps: unknown[] = [],
+    enabled = true
 ): React.MutableRefObject<number> {
     const startMsRef = useRef(Date.now());
     useEffect(() => {
+        if (!enabled) return;
         startMsRef.current = Date.now();
         if (startedEvent) captureEvent(startedEvent, props);
         // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, deps);
+    }, [...deps, enabled]);
     return startMsRef;
 }

--- a/frontend/src/lib/useFlowTimer.ts
+++ b/frontend/src/lib/useFlowTimer.ts
@@ -1,0 +1,27 @@
+import { useRef, useEffect } from 'react';
+import {
+    type AnalyticsEvent,
+    type AnalyticsProps,
+    captureEvent
+} from './analytics';
+
+/**
+ * Starts a flow timer and fires a *_started analytics event on mount (or when
+ * deps change). Returns a ref holding the start timestamp so callers can pass
+ * it to flowTimerSeconds() when firing the matching *_completed event.
+ *
+ * Pass null for startedEvent to skip the started event (edit flows).
+ */
+export function useFlowTimer(
+    startedEvent: AnalyticsEvent | null,
+    props?: AnalyticsProps,
+    deps: unknown[] = []
+): React.MutableRefObject<number> {
+    const startMsRef = useRef(Date.now());
+    useEffect(() => {
+        startMsRef.current = Date.now();
+        if (startedEvent) captureEvent(startedEvent, props);
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, deps);
+    return startMsRef;
+}

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -6,35 +6,50 @@ import { TourProvider } from '@/contexts/TourContext';
 import App from '@/App';
 import 'react-big-calendar/lib/css/react-big-calendar.css';
 import '@/styles/globals.css';
+import posthog from 'posthog-js';
+import { PostHogProvider } from 'posthog-js/react';
+
+// Initialize PostHog — wrapped so a missing key never crashes the app.
+try {
+    posthog.init(import.meta.env.VITE_PUBLIC_POSTHOG_KEY, {
+        api_host: import.meta.env.VITE_PUBLIC_POSTHOG_HOST,
+        defaults: '2026-01-30',
+        capture_exceptions: true
+    });
+} catch {
+    // Missing/invalid config — app runs without analytics.
+}
 
 ReactDOM.createRoot(document.querySelector('#root')!).render(
     <React.StrictMode>
-        <TourProvider>
-            <SWRConfig
-                value={{
-                    revalidateOnFocus: false,
-                    shouldRetryOnError: false,
-                    fetcher: async (url: string) => {
-                        const res = await fetch(url, {
-                            credentials: 'include',
-                            headers: {
-                                'X-Requested-With': 'XMLHttpRequest',
-                                Accept: 'application/json',
-                                'Content-Type': 'application/json'
+        <PostHogProvider client={posthog}>
+            <TourProvider>
+                <SWRConfig
+                    value={{
+                        revalidateOnFocus: false,
+                        shouldRetryOnError: false,
+                        fetcher: async (url: string) => {
+                            const res = await fetch(url, {
+                                credentials: 'include',
+                                headers: {
+                                    'X-Requested-With': 'XMLHttpRequest',
+                                    Accept: 'application/json',
+                                    'Content-Type': 'application/json'
+                                }
+                            });
+                            if (!res.ok) {
+                                const error = new Error(res.statusText);
+                                throw error;
                             }
-                        });
-                        if (!res.ok) {
-                            const error = new Error(res.statusText);
-                            throw error;
+                            return res.json() as Promise<unknown>;
                         }
-                        return res.json() as Promise<unknown>;
-                    }
-                }}
-            >
-                <ThemeProvider>
-                    <App />
-                </ThemeProvider>
-            </SWRConfig>
-        </TourProvider>
+                    }}
+                >
+                    <ThemeProvider>
+                        <App />
+                    </ThemeProvider>
+                </SWRConfig>
+            </TourProvider>
+        </PostHogProvider>
     </React.StrictMode>
 );

--- a/frontend/src/pages/class-detail/EnrollResidentsModal.tsx
+++ b/frontend/src/pages/class-detail/EnrollResidentsModal.tsx
@@ -41,9 +41,13 @@ export function EnrollResidentsModal({
     const [isSubmitting, setIsSubmitting] = useState(false);
     const [error, setError] = useState('');
     const selectionFiredRef = useRef(false);
+    const wasOpenRef = useRef(false);
 
     useEffect(() => {
-        if (open) {
+        // Only fire on the closed→open transition — prop changes (capacity /
+        // enrolled from parent revalidation) while the modal stays open must
+        // not re-emit the open event or reset the first-selection guard.
+        if (open && !wasOpenRef.current) {
             selectionFiredRef.current = false;
             captureEvent(ANALYTICS_EVENTS.EnrollModalOpened, {
                 class_id: classId,
@@ -51,6 +55,7 @@ export function EnrollResidentsModal({
                 enrolled
             });
         }
+        wasOpenRef.current = open;
     }, [open, classId, capacity, enrolled]);
 
     const encodedSearch = encodeURIComponent(searchQuery);

--- a/frontend/src/pages/class-detail/EnrollResidentsModal.tsx
+++ b/frontend/src/pages/class-detail/EnrollResidentsModal.tsx
@@ -1,5 +1,6 @@
-import { useState, useEffect, useMemo } from 'react';
+import { useState, useEffect, useMemo, useRef } from 'react';
 import useSWR from 'swr';
+import { ANALYTICS_EVENTS, captureEvent } from '@/lib/analytics';
 import { useDebounceValue } from 'usehooks-ts';
 import { Search, AlertTriangle } from 'lucide-react';
 import { toast } from 'sonner';
@@ -39,6 +40,18 @@ export function EnrollResidentsModal({
     const [searchQuery] = useDebounceValue(searchTerm, 300);
     const [isSubmitting, setIsSubmitting] = useState(false);
     const [error, setError] = useState('');
+    const selectionFiredRef = useRef(false);
+
+    useEffect(() => {
+        if (open) {
+            selectionFiredRef.current = false;
+            captureEvent(ANALYTICS_EVENTS.EnrollModalOpened, {
+                class_id: classId,
+                capacity,
+                enrolled
+            });
+        }
+    }, [open, classId, capacity, enrolled]);
 
     const encodedSearch = encodeURIComponent(searchQuery);
     const { data: usersResp } = useSWR<ServerResponseMany<User>>(
@@ -79,6 +92,12 @@ export function EnrollResidentsModal({
         } else {
             next.add(id);
         }
+        if (next.size > 0 && !selectionFiredRef.current) {
+            selectionFiredRef.current = true;
+            captureEvent(ANALYTICS_EVENTS.EnrollResidentsSelected, {
+                class_id: classId
+            });
+        }
         setSelectedIds(next);
     };
 
@@ -105,6 +124,10 @@ export function EnrollResidentsModal({
         });
 
         if (resp.success) {
+            captureEvent(ANALYTICS_EVENTS.EnrollCompleted, {
+                class_id: classId,
+                selected_count: userIds.length
+            });
             toast.success(
                 `${userIds.length} ${userIds.length === 1 ? 'resident' : 'residents'} enrolled in ${className}`
             );

--- a/frontend/src/pages/event-attendance/index.tsx
+++ b/frontend/src/pages/event-attendance/index.tsx
@@ -24,6 +24,12 @@ import {
     diffMinutes,
     formatPartialTime
 } from '@/lib/formatters';
+import {
+    ANALYTICS_EVENTS,
+    captureEvent,
+    flowTimerSeconds
+} from '@/lib/analytics';
+import { useFlowTimer } from '@/lib/useFlowTimer';
 import { PageHeader } from '@/components/shared';
 import Breadcrumbs from '@/components/navigation/Breadcrumbs';
 import { ATTENDANCE_STATUSES } from './constants';
@@ -86,6 +92,11 @@ export default function EventAttendance() {
         Record<number, AttendanceRowErrors>
     >({});
     const [showErrors, setShowErrors] = useState(false);
+    const startMsRef = useFlowTimer(
+        ANALYTICS_EVENTS.AttendanceSessionStarted,
+        { class_id, event_id, date },
+        [class_id, event_id, date]
+    );
 
     const { data, isLoading, error, mutate } = useSWR<
         ServerResponseMany<EnrollmentAttendance>,
@@ -326,6 +337,33 @@ export default function EventAttendance() {
                 payload
             );
             toast.success('Attendance saved successfully');
+
+            const presentCount = payload.filter(
+                (p) => p.attendance_status === Attendance.Present
+            ).length;
+            const partialCount = payload.filter(
+                (p) => p.attendance_status === Attendance.Partial
+            ).length;
+            const absentCount = payload.filter(
+                (p) =>
+                    p.attendance_status === Attendance.Absent_Excused ||
+                    p.attendance_status === Attendance.Absent_Unexcused
+            ).length;
+
+            const submittedAt = new Date();
+
+            captureEvent(ANALYTICS_EVENTS.AttendanceSessionCompleted, {
+                duration_seconds: flowTimerSeconds(startMsRef.current),
+                num_records: payload.length,
+                present_count: presentCount,
+                partial_count: partialCount,
+                absent_count: absentCount,
+                class_id,
+                event_id,
+                date,
+                submitted_at: submittedAt.toISOString()
+            });
+
             void mutate();
             navigate(`/program-classes/${class_id}/detail`);
         } catch {

--- a/frontend/src/pages/event-attendance/index.tsx
+++ b/frontend/src/pages/event-attendance/index.tsx
@@ -338,26 +338,14 @@ export default function EventAttendance() {
             );
             toast.success('Attendance saved successfully');
 
-            const presentCount = payload.filter(
-                (p) => p.attendance_status === Attendance.Present
-            ).length;
-            const partialCount = payload.filter(
-                (p) => p.attendance_status === Attendance.Partial
-            ).length;
-            const absentCount = payload.filter(
-                (p) =>
-                    p.attendance_status === Attendance.Absent_Excused ||
-                    p.attendance_status === Attendance.Absent_Unexcused
-            ).length;
-
             const submittedAt = new Date();
 
             captureEvent(ANALYTICS_EVENTS.AttendanceSessionCompleted, {
                 duration_seconds: flowTimerSeconds(startMsRef.current),
-                num_records: payload.length,
-                present_count: presentCount,
-                partial_count: partialCount,
-                absent_count: absentCount,
+                num_records: rows.length,
+                present_count: summary.present,
+                partial_count: summary.partial,
+                absent_count: summary.absentExcused + summary.absentUnexcused,
                 class_id,
                 event_id,
                 date,

--- a/frontend/src/pages/event-attendance/index.tsx
+++ b/frontend/src/pages/event-attendance/index.tsx
@@ -92,11 +92,6 @@ export default function EventAttendance() {
         Record<number, AttendanceRowErrors>
     >({});
     const [showErrors, setShowErrors] = useState(false);
-    const startMsRef = useFlowTimer(
-        ANALYTICS_EVENTS.AttendanceSessionStarted,
-        { class_id, event_id, date },
-        [class_id, event_id, date]
-    );
 
     const { data, isLoading, error, mutate } = useSWR<
         ServerResponseMany<EnrollmentAttendance>,
@@ -166,6 +161,30 @@ export default function EventAttendance() {
         });
         setRowErrors(next);
     }, [rows, showErrors]);
+
+    // Only start the attendance flow timer once the session is real and
+    // actionable — otherwise 404 / error / unscheduled / future-date renders
+    // would be counted as attendance-session starts.
+    const dateValid = !!date && isoRE.test(date);
+    const todayMidnight = new Date();
+    todayMidnight.setHours(0, 0, 0, 0);
+    const sessionReady =
+        dateValid &&
+        !isLoading &&
+        !datesLoading &&
+        !error &&
+        !!data?.data &&
+        (Array.isArray(dates?.data) ? dates.data : []).some(
+            (d) => d.event_id === Number(event_id) && d.date === date
+        ) &&
+        !(parseLocalDay(date) > todayMidnight);
+
+    const startMsRef = useFlowTimer(
+        ANALYTICS_EVENTS.AttendanceSessionStarted,
+        { class_id, event_id, date },
+        [class_id, event_id, date],
+        sessionReady
+    );
 
     if (!date || !isoRE.test(date)) {
         return <Navigate to="/404" replace />;
@@ -332,10 +351,14 @@ export default function EventAttendance() {
 
         setIsSaving(true);
         try {
-            await API.post(
+            const resp = await API.post(
                 `program-classes/${class_id}/events/${event_id}/attendance`,
                 payload
             );
+            if (!resp.success) {
+                toast.error('Failed to save attendance');
+                return;
+            }
             toast.success('Attendance saved successfully');
 
             const submittedAt = new Date();

--- a/frontend/src/pages/programs/ClassManagementForm.tsx
+++ b/frontend/src/pages/programs/ClassManagementForm.tsx
@@ -5,6 +5,12 @@ import { zodResolver } from '@hookform/resolvers/zod';
 import { toast } from 'sonner';
 import useSWR from 'swr';
 import API from '@/api/api';
+import {
+    ANALYTICS_EVENTS,
+    captureEvent,
+    flowTimerSeconds
+} from '@/lib/analytics';
+import { useFlowTimer } from '@/lib/useFlowTimer';
 import { useAuth } from '@/auth/useAuth';
 import {
     ClassLoaderData,
@@ -155,6 +161,9 @@ export function ClassManagementFormInner({
     const [customRecurrenceInterval, setCustomRecurrenceInterval] = useState(1);
 
     const [instructors, setInstructors] = useState<Instructor[]>([]);
+    const startMsRef = useFlowTimer(
+        isNewClass ? ANALYTICS_EVENTS.ClassCreationStarted : null
+    );
 
     const resolvedFacilityId = facilityIdProp ?? user?.facility.id;
 
@@ -505,6 +514,9 @@ export function ClassManagementFormInner({
                 : 'Class updated successfully'
         );
         if (isNewClass) {
+            captureEvent(ANALYTICS_EVENTS.ClassCreationCompleted, {
+                duration_seconds: flowTimerSeconds(startMsRef.current)
+            });
             if (onCreated) {
                 onCreated();
             }

--- a/frontend/src/pages/programs/ProgramManagementForm.tsx
+++ b/frontend/src/pages/programs/ProgramManagementForm.tsx
@@ -16,6 +16,12 @@ import {
     FundingType
 } from '@/types';
 import { programFormSchema, ProgramFormInput } from '@/lib/validation';
+import {
+    ANALYTICS_EVENTS,
+    captureEvent,
+    flowTimerSeconds
+} from '@/lib/analytics';
+import { useFlowTimer } from '@/lib/useFlowTimer';
 import { PageHeader } from '@/components/shared';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
@@ -73,6 +79,9 @@ export default function ProgramManagementForm() {
     const { user } = useAuth();
     const isEditing = !!program_id;
     const [showFacilityWarning, setShowFacilityWarning] = useState(false);
+    const startMsRef = useFlowTimer(
+        isEditing ? null : ANALYTICS_EVENTS.ProgramCreationStarted
+    );
 
     const { data: programResp } = useSWR<ServerResponseOne<ProgramOverview>>(
         program_id ? `/api/programs/${program_id}` : null
@@ -144,6 +153,11 @@ export default function ProgramManagementForm() {
                 ? 'Program updated successfully'
                 : 'Program created successfully'
         );
+        if (!isEditing) {
+            captureEvent(ANALYTICS_EVENTS.ProgramCreationCompleted, {
+                duration_seconds: flowTimerSeconds(startMsRef.current)
+            });
+        }
         navigate(`/programs/${resp.data.id}`);
     }
 

--- a/frontend/src/vite-env.d.ts
+++ b/frontend/src/vite-env.d.ts
@@ -1,1 +1,10 @@
 /// <reference types="vite/client" />
+
+interface ImportMetaEnv {
+    readonly VITE_PUBLIC_POSTHOG_KEY: string;
+    readonly VITE_PUBLIC_POSTHOG_HOST: string;
+}
+
+interface ImportMeta {
+    readonly env: ImportMetaEnv;
+}


### PR DESCRIPTION
# feat: PostHog analytics instrumentation for pilot tracking

## Summary

Instruments the frontend with PostHog to capture the metrics needed for the facility pilot
(Asana: *"To Dos before pilots: Set up posthog graphs"*). Adds a small typed analytics layer,
custom events across the attendance / program / class / enrollment flows, user identification,
session reset on logout, and error tracking. No backend schema or API changes.

User identification is **PII-minimized**: we send **only** `id`, `role`, and `facility_id` as
person properties — no names, usernames, or emails. Event properties (`class_id`, `event_id`,
`present_count`, `duration_seconds`, etc.) describe objects and aggregate counts, never individuals.

## How this maps to the Asana graph requirements

| Asana graph | Status | PostHog insight | What powers it |
| --- | --- | --- | --- |
| **Time to complete an attendance session** | ✅ | "Attendance time — avg & median (sec)" (Trends) | `attendance_session_started` → `attendance_session_completed` with `duration_seconds` |
| **Time to set up a new program or class** | ✅ | "Program setup time" + "Class setup time" (Trends) | `program_creation_started/_completed`, `class_creation_started/_completed` with `duration_seconds` |
| **Time of day attendance recorded vs scheduled** *(OPTIONAL)* | ⚪️ Deferred | "Attendance recording delay" (planned; not built) | Optional in the ticket; intentionally not shipped for the pilot |
| **Login frequency per user** | ✅ | "Stickiness (days active/week)" (Stickiness) | Default pageviews + `posthog.identify()` (stable per-user id) |
| **Drop-off points in key flows** | ✅ | "Attendance funnel" + "Enrollment funnel" (Funnels) | Funnel-ready events — attendance (`started`→`completed`) and enrollment (`enroll_modal_opened`→`enroll_residents_selected`→`enroll_completed`) |
| **Error states hit during common flows** | ✅ | "API errors by endpoint" (Trends/Table) + built-in Error tracking | `api_error` event + `capture_exceptions: true` |
| **Distinct active users per week** | ✅ | "Weekly active users" (Trends) + "Active users by facility" (Table) | Default identify + pageviews |
| **New users added over time** | ✅ | "User lifecycle" (Lifecycle) | Default identify |

## Events shipped

| Event | Properties | Fires from |
| --- | --- | --- |
| `attendance_session_started` | `class_id`, `event_id`, `date` | `event-attendance/index.tsx` (on open) |
| `attendance_session_completed` | `duration_seconds`, `num_records`, `present_count`, `partial_count`, `absent_count`, `class_id`, `event_id`, `date`, `submitted_at` | `event-attendance/index.tsx` (on save) — counts reflect the **full session roster**, not just edited rows |
| `program_creation_started` | — | `ProgramManagementForm.tsx` (create only) |
| `program_creation_completed` | `duration_seconds` | `ProgramManagementForm.tsx` |
| `class_creation_started` | — | `ClassManagementForm.tsx` (create only) |
| `class_creation_completed` | `duration_seconds` | `ClassManagementForm.tsx` |
| `enroll_modal_opened` | `class_id`, `capacity`, `enrolled` | `EnrollResidentsModal.tsx` |
| `enroll_residents_selected` | `class_id` | `EnrollResidentsModal.tsx` (first selection) |
| `enroll_completed` | `class_id`, `selected_count` | `EnrollResidentsModal.tsx` |
| `api_error` | `status`, `method`, `url`, `message` | `api/api.ts` |

Plus `identify(id, { role, facility_id })` on auth (`AuthProvider`) and `reset()` on logout (`useAuth`).

> **On the empty/lean creation events:**
> - `_started` events have no properties because nothing exists yet to describe — they're just "stopwatch start" markers.
> - `_completed` events carry only `duration_seconds` because the only thing they measure is "how long setup took."
> - You don't lose facility/role filtering — that's attached to the person via `identify()`, so it applies to every event automatically.

## Also fixes (pre-existing backend lint violations surfaced by CI)

These were already in the codebase and unrelated to PostHog, but required fixing to unblock CI on this PR:

- `backend/src/handlers/canvas_programs.go` — `errcheck`: unchecked `resp.Body.Close()` calls wrapped with `_ =` / `defer func() { _ = ... }()`; `staticcheck QF1008`: redundant `.ProgramClass` embedded-field selectors removed
- `backend/src/handlers/external_providers.go` — `errcheck`: bare `defer resp.Body.Close()` wrapped in anonymous func
- `backend/src/handlers/user_handler.go` — `errcheck`: two unchecked `resp.Body.Close()` calls wrapped with `_ =`
- `backend/tests/integration/testenv.go` — `CreateTestEvent` / `CreateTestEventWithRRule`: added `if instructorID == 0` guard so callers can control which instructor is attached
- `.env.example` — replaced live PostHog project key with `your_posthog_project_api_key` placeholder

## Key files

- `frontend/src/main.tsx` — `posthog.init` (`defaults: '2026-01-30'`, `capture_exceptions: true`) + `PostHogProvider`
- `frontend/src/lib/analytics.ts` — central typed layer: `captureEvent`, `identifyUser`, `resetAnalytics`, `flowTimerSeconds`; all wrapped so analytics can never break a user flow
- `frontend/src/auth/AuthProvider.tsx`, `auth/useAuth.ts` — identify / reset
- `frontend/src/api/api.ts` — `api_error` on failed requests
- attendance / program / class / enrollment components — flow events
- `.env.example`, `frontend/src/vite-env.d.ts` — `VITE_PUBLIC_POSTHOG_KEY` / `VITE_PUBLIC_POSTHOG_HOST`

## Resilience — analytics can never break a user flow

Every PostHog call is funneled through the typed layer in `analytics.ts`, and each one is wrapped
so a failing/blocked/unconfigured analytics client can **never** surface to the user. For example,
`captureEvent`:

```ts
/** Fire a custom event. Never throws. */
export function captureEvent(
    event: AnalyticsEvent,
    props?: AnalyticsProps
): void {
    try {
        posthog.capture(event, props);
    } catch {
        // Analytics must never interrupt a user flow.
    }
}
```

The same pattern guards `identifyUser` and `resetAnalytics`. Why this matters:

- **Analytics is non-critical infrastructure.** Taking attendance, creating a class, or enrolling
  a resident must succeed whether or not an event is recorded. The `try/catch` ensures a PostHog
  hiccup (network blip, ad-blocker, missing env config) degrades to *no telemetry*, never to a
  broken click or a crashed flow.
- **It fails closed and quiet.** A missing `VITE_PUBLIC_POSTHOG_KEY` (or a blocked client) makes
  these calls silent no-ops — the app behaves identically, just without analytics. No error
  bubbles into the UI.
- **One choke point.** Because callers go through `captureEvent`/`identifyUser` instead of touching
  `posthog.*` directly, this guarantee is enforced in one place rather than re-implemented (and
  occasionally forgotten) at each call site.

## Testing / Verification

Verified end-to-end by driving each flow in a real browser and confirming every event arrives in
PostHog (visible under Activity → Events), with `identify` correctly attaching `role` +
`facility_id` to the person.

### Prerequisites (do these first — skipping them makes a working build look broken)

> New to PostHog? Read this whole block before the checklist. Most "it's not working" reports
> are one of these six items, not a code bug.

1. **Set the env vars.** Grab both values from PostHog, add them to `frontend/.env` (template in
   `.env.example`), then **restart the dev server**:
   1. In PostHog, open **Settings → Project** and copy the **Project API key** (`phc_…`) →
      `VITE_PUBLIC_POSTHOG_KEY`.
   2. For the host, read your browser's address bar: `us.posthog.com` → `https://us.i.posthog.com`,
      `eu.posthog.com` → `https://eu.i.posthog.com` → `VITE_PUBLIC_POSTHOG_HOST`. (Or copy both at
      once from PostHog's `posthog.init('<key>', { api_host: '<host>' })` install snippet.)

   If skipped, analytics fails *silently*: a missing key sends nothing (only a console warning), and
   a wrong/missing host sends events somewhere they never reach your project.
2. **PostHog access.** Log in to the PostHog project these keys belong to. Events live under
   **Activity → Events** in the left nav.
3. **Use a real browser, not a headless/automated one.** PostHog's bot filter silently drops
   headless traffic (only `/flags/` requests go out) — events won't appear even though the code
   fired correctly.
4. **Turn the "Filter out internal and test users" toggle OFF.** It sits *above the Events table*
   and is **ON by default**. With it on, your own `system_admin` and local `127.0.0.1`/`localhost`
   traffic (tagged `$internal_or_test_user: true`) are hidden — so your testing looks invisible.
5. **Reading events.** Events take a few seconds to ingest — hit **Reload** above the table. Use
   the **"Select an event"** dropdown to filter to one event name, and **click a row to expand its
   properties** (that's how you confirm `duration_seconds`, counts, etc.).
6. **Log in as a non-`system_admin`** user to mirror real facility-staff usage.

### Manual checklist (Activity → Events, internal-user filter OFF)

- [x] Take attendance → `attendance_session_started` + `attendance_session_completed` (expand row → `duration_seconds`)
- [ ] Create a program → `program_creation_started` + `program_creation_completed`
- [ ] Create a class → `class_creation_started` + `class_creation_completed`
- [ ] Open enroll modal, select residents, enroll → `enroll_modal_opened`, `enroll_residents_selected`, `enroll_completed`
- [ ] **Trigger a failed request** → `api_error` (expand → `status`/`method`/`url`/`message`).
      Reliable way: with the app open, log out in another tab (or let the session expire), then
      trigger any data load — the session check returns **401** and fires `api_error`. A validation
      **422** also works if you can push a malformed request past client-side validation.
- [ ] Log in / out → person identified with `role` + `facility_id`; `$reset` fires on logout

### PostHog config — verify the 10 graphs / funnels

This is **project configuration, done once per PostHog project**.

**Before you check each insight:** generate test data first by running the Manual checklist above,
set the insight's **date range to include today**, and keep the **internal-user filter OFF** (or
view as the non-`system_admin` test user) so your test events are counted.

Each item passes when it renders **non-empty** data after the matching flow:

- [ ] **Attendance time — avg & median (sec)** (Trends) — avg/median `duration_seconds` from `attendance_session_completed`; non-zero after one attendance session
- [ ] **Program setup time** (Trends) — avg `duration_seconds` from `program_creation_completed`; non-zero after creating a program
- [ ] **Class setup time** (Trends) — avg `duration_seconds` from `class_creation_completed`; non-zero after creating a class
- [ ] **Stickiness (days active/week)** (Stickiness) — shows days-active distribution from identified pageviews
- [ ] **Attendance funnel** (Funnel) — `attendance_session_started` → `attendance_session_completed`; 2 steps with a conversion %
- [ ] **Enrollment funnel** (Funnel) — `enroll_modal_opened` → `enroll_residents_selected` → `enroll_completed`; 3 steps with conversion %
- [ ] **API errors by endpoint** (Trends/Table) — count of `api_error` broken down by `url`; a row appears after you trigger the 401/422
- [ ] **Weekly active users** (Trends) — distinct identified users per week; ≥ 1 after you log in
- [ ] **Active users by facility** (Table) — WAU broken down by `facility_id`; your test facility's row appears
- [ ] **User lifecycle** (Lifecycle) — new/returning/dormant breakdown; you appear as "new", then "returning" on a later visit

(Built-in **Error tracking** — fed by `capture_exceptions: true` — is a bonus, not one of the 10; check it under the Error tracking section if you want JS exceptions too.)

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1215310633886744