### PR TITLE
fix: cap statewide program completion rate at 100% (ID-716)

### DIFF
--- a/backend/src/database/programs.go
+++ b/backend/src/database/programs.go
@@ -36,7 +36,7 @@ func (db *DB) FetchEnrollmentMetrics(programID int, facilityId uint) (*models.Pr
 		COUNT(DISTINCT CASE WHEN pce.enrollment_status = 'Enrolled' AND pce.enrolled_at IS NOT NULL AND (pce.enrollment_ended_at IS NULL OR pce.enrollment_ended_at > CURRENT_TIMESTAMP) THEN pce.user_id END) as active_residents,
 		CASE
 			WHEN COUNT(CASE WHEN pc.status = 'Completed' AND pce.enrolled_at IS NOT NULL AND pce.enrollment_status != 'Enrolled' THEN 1 END) = 0 THEN 0
-			ELSE COUNT(CASE WHEN pc.status = 'Completed' AND pce.enrollment_status = 'Completed' THEN 1 END) * 1.0
+			ELSE COUNT(CASE WHEN pc.status = 'Completed' AND pce.enrolled_at IS NOT NULL AND pce.enrollment_status = 'Completed' THEN 1 END) * 1.0
 				/ COUNT(CASE WHEN pc.status = 'Completed' AND pce.enrolled_at IS NOT NULL AND pce.enrollment_status != 'Enrolled' THEN 1 END) * 100
 		END AS completion_rate
 	`

--- a/backend/tests/integration/programs_stats_test.go
+++ b/backend/tests/integration/programs_stats_test.go
@@ -330,6 +330,37 @@ func (suite *ProgramsStatsTestSuite) TestGetProgramsFacilityStats_FacilitySpecif
 	assert.Equal(suite.T(), float64(2), *stats.AvgActiveProgramsPerFacility) // For single facility, this equals program count
 }
 
+// TestFetchEnrollmentMetrics_CompletionRateCappedAt100 is a regression for ID-716
+// ("Statewide Program View — Avg Completion Rate = 130%"). FetchEnrollmentMetrics counted
+// Completed enrollments in the numerator without requiring enrolled_at IS NOT NULL, while the
+// denominator required it. Completing a class leaves enrolled_at NULL for enrollments created
+// while the class was not Active, so those rows landed in the numerator but not the denominator,
+// letting the rate exceed 100%.
+func (suite *ProgramsStatsTestSuite) TestFetchEnrollmentMetrics_CompletionRateCappedAt100() {
+	facility := suite.createTestFacility("ID716 Facility")
+	program := suite.createTestProgram("ID716 Program")
+	suite.createProgramFacilityAssociation(program.ID, facility.ID)
+
+	// Class must be Completed for the completion_rate branch to engage.
+	class := suite.createTestClass(program.ID, facility.ID, models.Completed)
+
+	now := time.Now()
+	// Completed enrollment WITH enrolled_at: counts in both numerator and denominator.
+	s1 := suite.createTestUser(facility.ID, models.Student)
+	suite.createTestEnrollment(class.ID, s1.ID, models.EnrollmentCompleted, &now, &now)
+	// Completed enrollment WITHOUT enrolled_at: pre-fix this was counted in the numerator only,
+	// pushing the rate to 200%.
+	s2 := suite.createTestUser(facility.ID, models.Student)
+	suite.createTestEnrollment(class.ID, s2.ID, models.EnrollmentCompleted, nil, nil)
+
+	metrics, err := suite.env.DB.FetchEnrollmentMetrics(int(program.ID), facility.ID)
+	assert.NoError(suite.T(), err)
+	assert.LessOrEqual(suite.T(), metrics.CompletionRate, float64(100),
+		"completion rate must never exceed 100%")
+	assert.Equal(suite.T(), float64(100), metrics.CompletionRate,
+		"1 completed-with-enrolled_at / 1 terminal-with-enrolled_at should be 100%")
+}
+
 func TestProgramsStatsTestSuite(t *testing.T) {
 	suite.Run(t, new(ProgramsStatsTestSuite))
 }


### PR DESCRIPTION
## Pre-Submission PR Checklist

- [x] No debug/console/fmt.Println statements
- [x] Unnecessary development comments removed
- [x] All acceptance criteria verified
- [x] Functions according to **ticket specifications**
- [x] Tested manually where applicable
- [x] Branch rebased with latest main
- [x] No business logic exists within the database layer

## Description of the change
FetchEnrollmentMetrics counted Completed enrollments in the numerator without requiring enrolled_at IS NOT NULL, but the denominator required it. Completed enrollments with a NULL enrolled_at (common: completing a class never backfills enrolled_at for rows created while the class was not Active) landed in the numerator but not the denominator, so the rate could exceed 100% (reported 130%).

Constrain the numerator to the same enrolled_at IS NOT NULL base as the denominator. Added a regression test asserting the rate never exceeds 100%.

- **Related issues**: https://app.asana.com/1/1201607307149189/project/1209460078641109/task/1215727990979790?focus=true
