### PR TITLE
fix: duplicate wording in enroll resident

### DIFF
--- a/backend/src/database/class_enrollments.go
+++ b/backend/src/database/class_enrollments.go
@@ -447,7 +447,7 @@ func (db *DB) CheckSchedulingConflicts(classID int, userIDs []int) ([]models.Con
 				return nil, err
 			}
 
-			if hasOverlap, start, end := checkEventsOverlap(targetEvents, existingClassEvents); hasOverlap {
+			if hasOverlap, start, end, days := checkEventsOverlap(targetEvents, existingClassEvents); hasOverlap {
 				var user models.User
 				if err := db.First(&user, userID).Error; err != nil {
 					return nil, err
@@ -459,7 +459,7 @@ func (db *DB) CheckSchedulingConflicts(classID int, userIDs []int) ([]models.Con
 					ConflictingClass: enrollment.Class.Name,
 					ConflictStart:    start,
 					ConflictEnd:      end,
-					Reason:           fmt.Sprintf("Conflict with class: %s", enrollment.Class.Name),
+					ConflictDays:     days,
 				})
 			}
 		}
@@ -468,7 +468,7 @@ func (db *DB) CheckSchedulingConflicts(classID int, userIDs []int) ([]models.Con
 	return conflicts, nil
 }
 
-func checkEventsOverlap(newEvents, existingEvents []models.ProgramClassEvent) (bool, time.Time, time.Time) {
+func checkEventsOverlap(newEvents, existingEvents []models.ProgramClassEvent) (bool, time.Time, time.Time, []string) {
 	startWindow := time.Now().UTC()
 	endWindow := startWindow.AddDate(0, 6, 0)
 
@@ -484,6 +484,8 @@ func checkEventsOverlap(newEvents, existingEvents []models.ProgramClassEvent) (b
 		existingInstances = append(existingInstances, insts...)
 	}
 
+	var firstStart, firstEnd time.Time
+	seenDays := make(map[time.Weekday]bool)
 	for _, newInst := range newInstances {
 		newStart := newInst.StartTime
 		newEnd := newStart.Add(newInst.Duration)
@@ -493,10 +495,23 @@ func checkEventsOverlap(newEvents, existingEvents []models.ProgramClassEvent) (b
 			exEnd := exStart.Add(exInst.Duration)
 
 			if newStart.Before(exEnd) && newEnd.After(exStart) {
-				return true, newStart, newEnd
+				if firstStart.IsZero() {
+					firstStart, firstEnd = newStart, newEnd
+				}
+				seenDays[newStart.Weekday()] = true
 			}
 		}
 	}
 
-	return false, time.Time{}, time.Time{}
+	if len(seenDays) == 0 {
+		return false, time.Time{}, time.Time{}, nil
+	}
+
+	days := make([]string, 0, len(seenDays))
+	for wd := time.Sunday; wd <= time.Saturday; wd++ {
+		if seenDays[wd] {
+			days = append(days, wd.String())
+		}
+	}
+	return true, firstStart, firstEnd, days
 }

--- a/backend/src/models/program_classes.go
+++ b/backend/src/models/program_classes.go
@@ -318,7 +318,7 @@ type ConflictDetail struct {
 	ConflictingClass string    `json:"conflicting_class"`
 	ConflictStart    time.Time `json:"conflict_start"`
 	ConflictEnd      time.Time `json:"conflict_end"`
-	Reason           string    `json:"reason"`
+	ConflictDays     []string  `json:"conflict_days"`
 }
 
 type BulkCancelSessionsRequest struct {

--- a/frontend/src/pages/class-detail/EnrollResidentsModal.tsx
+++ b/frontend/src/pages/class-detail/EnrollResidentsModal.tsx
@@ -216,8 +216,9 @@ export function EnrollResidentsModal({
                                                     Already enrolled in &quot;
                                                     {conflict.conflicting_class}
                                                     &quot;
-                                                    {conflict.reason &&
-                                                        ` - ${conflict.reason}`}
+                                                    {conflict.conflict_days
+                                                        ?.length > 0 &&
+                                                        ` on ${conflict.conflict_days.join(', ')}`}
                                                 </span>
                                             </div>
                                         )}

--- a/frontend/src/pages/programs/AddClassEnrollments.tsx
+++ b/frontend/src/pages/programs/AddClassEnrollments.tsx
@@ -425,9 +425,9 @@ export default function AddClassEnrollments() {
                                     {c.conflict_start} - {c.conflict_end}
                                 </div>
                             )}
-                            {c.reason && (
+                            {c.conflict_days?.length > 0 && (
                                 <div className="text-xs text-gray-500 mt-0.5">
-                                    {c.reason}
+                                    on {c.conflict_days.join(', ')}
                                 </div>
                             )}
                         </div>

--- a/frontend/src/types/program.ts
+++ b/frontend/src/types/program.ts
@@ -249,7 +249,7 @@ export interface ConflictDetail {
     conflicting_class: string;
     conflict_start: string;
     conflict_end: string;
-    reason: string;
+    conflict_days: string[];
 }
 
 export interface OverrideForm {


### PR DESCRIPTION
## Pre-Submission PR Checklist

- [x] No debug/console/fmt.Println statements
- [x] Unnecessary development comments removed
- [x] All acceptance criteria verified
- [x] Functions according to **ticket specifications**
- [x] Tested manually where applicable
- [x] Branch rebased with latest main
- [x] No business logic exists within the database layer

## Description of the change

Fixes the repetitive conflict language when enrolling residents to update and match figma. Before this PR a scheduling conflict would render the class name twice. 

Had to update checkEventsOverlap to collect all of the overlapping weekdays instead of returning on the first conflict. 

- **Related issues**: https://app.asana.com/1/1201607307149189/project/1209460078641109/task/1216311486398732?focus=true

## Screenshot(s)
<img width="557" height="835" alt="image" src="https://github.com/user-attachments/assets/3b9ada85-3f00-40c8-8055-0d40d35e200a" />
