### PR TITLE
fix: move edit program to statewide view

### DIFF
--- a/frontend/src/pages/programs/ProgramOverviewFacilityAdmin.tsx
+++ b/frontend/src/pages/programs/ProgramOverviewFacilityAdmin.tsx
@@ -322,6 +322,8 @@ export default function ProgramOverviewFacilityAdmin() {
     const showFacilityContextBanner = Boolean(
         user && canSwitchFacility(user) && facilityId && facilityName
     );
+    // program edits are statewide; sys/dept admins make them from the statewide overview
+    const canEditStatewide = Boolean(user && canSwitchFacility(user));
 
     if (!program) {
         return (
@@ -604,7 +606,7 @@ export default function ProgramOverviewFacilityAdmin() {
                                             )}
                                         </Tooltip>
                                     </div>
-                                    {!isCanvasProgram && (
+                                    {!isCanvasProgram && !canEditStatewide && (
                                         <Button
                                             variant="outline"
                                             className="border-gray-300 mt-5 focus-visible:border-[#b3b3b3] focus-visible:ring-[3px] focus-visible:ring-[#b3b3b3]/50 focus-visible:ring-offset-0"

--- a/frontend/src/pages/programs/ProgramOverviewStatewide.tsx
+++ b/frontend/src/pages/programs/ProgramOverviewStatewide.tsx
@@ -8,6 +8,7 @@ import {
     BookOpen,
     ChevronDown,
     ChevronUp,
+    Edit,
     Loader2,
     MoreVertical,
     Trash2
@@ -38,6 +39,7 @@ import {
     ReactivateDialog,
     DeleteProgramDialog
 } from '@/components/programs/ProgramDialogs';
+import EditProgramDialog from '@/pages/program-detail/EditProgramDialog';
 import {
     Tooltip,
     TooltipContent,
@@ -143,6 +145,7 @@ export default function ProgramOverviewStatewide() {
         useState(false);
     const [showReactivateDialog, setShowReactivateDialog] = useState(false);
     const [showDeleteDialog, setShowDeleteDialog] = useState(false);
+    const [showEditDialog, setShowEditDialog] = useState(false);
     const [archiveCheckLoading, setArchiveCheckLoading] = useState(false);
     const [archiveBlockingFacilities, setArchiveBlockingFacilities] = useState<
         string[]
@@ -605,6 +608,16 @@ export default function ProgramOverviewStatewide() {
                             >
                                 Archived
                             </Badge>
+                        )}
+                        {!isCanvasProgram && (
+                            <Button
+                                variant="outline"
+                                onClick={() => setShowEditDialog(true)}
+                                className="gap-2 border-gray-300 focus-visible:border-[#b3b3b3] focus-visible:ring-[3px] focus-visible:ring-[#b3b3b3]/50 focus-visible:ring-offset-0"
+                            >
+                                <Edit className="size-4" />
+                                Edit Program
+                            </Button>
                         )}
                         {!isCanvasProgram && (
                             <DropdownMenu>
@@ -1197,6 +1210,12 @@ export default function ProgramOverviewStatewide() {
                     onOpenChange={setShowDeleteDialog}
                     programName={program.name}
                     onConfirm={handleDeleteProgram}
+                />
+
+                <EditProgramDialog
+                    open={showEditDialog}
+                    onOpenChange={setShowEditDialog}
+                    program={program}
                 />
             </div>
         </div>


### PR DESCRIPTION
## Pre-Submission PR Checklist

- [x] No debug/console/fmt.Println statements
- [x] Unnecessary development comments removed
- [x] All acceptance criteria verified
- [x] Functions according to **ticket specifications**
- [x] Tested manually where applicable
- [ ] Branch rebased with latest main
- [x] No business logic exists within the database layer

## Description of the change

Editing a program is a **statewide** operation — `EditProgramDialog` PATCHes `programs/:id` with the
name, description, program types, credit types, funding type, status, and (for dept/sys admins) the
facility assignment list. The button that opens it, however, only lived on the **facility-localized**
program view. A system or department admin would click "View at Facility", see "Edit Program" sitting
next to that facility's metrics, and reasonably assume they were editing that facility's copy of the
program. The statewide overview — the page that actually represents the program across all facilities
— had no edit affordance at all.

This moves the affordance to where the edit actually applies.

- `ProgramOverviewStatewide.tsx` — adds the "Edit Program" button to the header action row, between
  the status button and the kebab menu (`Mark as Inactive · Edit Program · ⋮`), along with the
  `showEditDialog` state and the `<EditProgramDialog>` render. No new data wiring was needed: the
  dialog already revalidates `/api/programs/:id`, which is the same SWR key the statewide page and
  its "Performance by Facility" table read from.
- `ProgramOverviewFacilityAdmin.tsx` — the existing button's gate changes from `!isCanvasProgram` to
  `!isCanvasProgram && !canEditStatewide`, where `canEditStatewide = canSwitchFacility(user)`.

**Facility admins are deliberately untouched** — the facility view is their only program view, so the
button stays exactly where it has always been for them. The gate is role-based rather than keyed on
the `?facility_id=` URL param, so a facility admin cannot lose the button by visiting a URL carrying
someone else's facility id.

Resulting matrix:

| | statewide view | facility view (`?facility_id=`) |
|---|---|---|
| system_admin / department_admin | Edit Program ✅ (new) | Edit Program ❌ (moved away) |
| facility_admin | n/a — never sees this view | Edit Program ✅ (unchanged) |
| any role, Canvas-managed program | ❌ | ❌ |

Two files, +22/−1. No backend, migration, or seeder changes; the PATCH endpoint and its permissions
are untouched.

- **Related issues**: Closes Asana ID-727
## Screenshot(s)
<img width="1710" height="1037" alt="image" src="https://github.com/user-attachments/assets/a7947872-428b-40df-9e0a-0a9e17240946" />


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1216311486398742