### PR TITLE
Add Learning record privacy notice

### DIFF
--- a/frontend/src/components/learning-record/LearningRecordPrivacyNotice.tsx
+++ b/frontend/src/components/learning-record/LearningRecordPrivacyNotice.tsx
@@ -1,0 +1,52 @@
+import { ShieldCheck } from 'lucide-react';
+import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert';
+import { LEARNING_RECORD_PRIVACY_NOTICE } from '@/data/learningRecordResidentCopy';
+import { cn } from '@/lib/utils';
+
+export interface LearningRecordPrivacyNoticeProps {
+    /**
+     * `short` — Learning Record landing page.
+     * `full` — achievement entry form (expanded wording, same substance).
+     */
+    variant: 'short' | 'full';
+    /** Caller owns spacing; the notice itself sets no margin. */
+    className?: string;
+}
+
+/**
+ * Persistent transparency notice telling residents how their Learning Record
+ * data is used. Informational only — deliberately not dismissible and never a
+ * gate: it must not block or delay starting an entry.
+ *
+ * Copy lives in `LEARNING_RECORD_PRIVACY_NOTICE` so both placements stay
+ * consistent and Carolina's final wording is a one-file change.
+ */
+export function LearningRecordPrivacyNotice({
+    variant,
+    className
+}: LearningRecordPrivacyNoticeProps) {
+    const copy = LEARNING_RECORD_PRIVACY_NOTICE[variant];
+
+    return (
+        <Alert
+            /*
+             * `Alert` hardcodes role="alert" (an assertive live region), which
+             * would interrupt screen readers on every page load. This notice is
+             * passive, so downgrade to `note`. Safe because `Alert` spreads
+             * props after its own role.
+             */
+            role="note"
+            data-slot="learning-record-privacy-notice"
+            className={cn('border-[#556830]/30 bg-[#556830]/5', className)}
+        >
+            <ShieldCheck
+                className="text-[#556830] dark:text-primary"
+                aria-hidden
+            />
+            <AlertTitle className="text-foreground">{copy.title}</AlertTitle>
+            <AlertDescription>
+                <span className="text-sm leading-relaxed">{copy.body}</span>
+            </AlertDescription>
+        </Alert>
+    );
+}

--- a/frontend/src/data/faqData.ts
+++ b/frontend/src/data/faqData.ts
@@ -104,7 +104,7 @@ export const FAQ_CATEGORIES: Record<string, FAQEntry[]> = {
         },
         {
             question: 'Is my activity on UnlockEd private?',
-            answer: 'The UnlockEd team and authorized facility staff can see this information.'
+            answer: "The UnlockEd team and authorized facility staff can see your library and course activity. Your Learning Record entries are separate — staff don't see your individual entries there."
         }
     ],
     'Getting Help and Troubleshooting': [

--- a/frontend/src/data/learningRecordResidentCopy.ts
+++ b/frontend/src/data/learningRecordResidentCopy.ts
@@ -1,24 +1,16 @@
 export const LEARNING_RECORD_PRINT_SHARE_FAQ = {
     question: 'What does "print or share" mean?',
-    answer: 'When you save your record as a PDF, it becomes a single file — like a digital sheet of paper. You can print it out on paper, hand it to a staff member, or send it to someone, such as a case manager or a future employer. Your record stays private and is only seen by people you give it to.'
+    answer: 'When you save your record as a PDF, it becomes a single file — like a digital sheet of paper. You can print it out on paper, hand it to a staff member, or send it to someone, such as a case manager or a future employer. The file you create is only seen by the people you give it to.'
 } as const;
 
 export const LEARNING_RECORD_SAVED_HERE_FAQ = {
     question: 'Where is my record saved?',
-    answer: "It's saved right here in the app. It is not shared with anyone automatically. Nothing leaves this app unless you choose to print or share it."
+    answer: "It's saved right here in the app. Facility staff don't see your individual entries, and nothing leaves this app unless you choose to print or share it. Some information may be used in anonymized, aggregate form to help understand how programs are working — no one can trace this data back to you."
 } as const;
 
-/**
- * Resident data-use transparency notice, shown on the Learning Record landing
- * page (`short`) and the achievement entry form (`full`).
- *
- * FIRST DRAFT — pending Carolina's final copy. Both variants must assert the
- * same three facts, so edit them together:
- *   1. individual entries are not shared with facility staff,
- *   2. some data may be used in anonymized, aggregate form,
- *   3. nothing in that aggregate can be traced back to an individual.
- * Only the length differs between them.
- */
+export const LEARNING_RECORD_START_CARD_BLURB =
+    "Write down a class, program, or skill you finished. Your answers are saved here as you go, and facility staff don't see your individual entries.";
+
 export const LEARNING_RECORD_PRIVACY_NOTICE = {
     short: {
         title: 'Your Learning Record is yours.',

--- a/frontend/src/data/learningRecordResidentCopy.ts
+++ b/frontend/src/data/learningRecordResidentCopy.ts
@@ -7,3 +7,25 @@ export const LEARNING_RECORD_SAVED_HERE_FAQ = {
     question: 'Where is my record saved?',
     answer: "It's saved right here in the app. It is not shared with anyone automatically. Nothing leaves this app unless you choose to print or share it."
 } as const;
+
+/**
+ * Resident data-use transparency notice, shown on the Learning Record landing
+ * page (`short`) and the achievement entry form (`full`).
+ *
+ * FIRST DRAFT — pending Carolina's final copy. Both variants must assert the
+ * same three facts, so edit them together:
+ *   1. individual entries are not shared with facility staff,
+ *   2. some data may be used in anonymized, aggregate form,
+ *   3. nothing in that aggregate can be traced back to an individual.
+ * Only the length differs between them.
+ */
+export const LEARNING_RECORD_PRIVACY_NOTICE = {
+    short: {
+        title: 'Your Learning Record is yours.',
+        body: 'Individual entries are private and not shared with facility staff. Some information may be used in anonymized, aggregate form to help understand how programs are working — no one can trace this data back to you.'
+    },
+    full: {
+        title: 'What you write here is yours.',
+        body: "Facility staff won't see your individual answers. Some responses may be combined with other residents' answers, with all identifying information removed, to help understand what's working well in programs. Nothing you write can be traced back to you individually."
+    }
+} as const;

--- a/frontend/src/pages/student/ResidentHome.tsx
+++ b/frontend/src/pages/student/ResidentHome.tsx
@@ -54,6 +54,7 @@ import { getLearningRecordFormVariant } from '@/pages/student/digital-transcript
 import { learningRecordResidentDisplayName } from '@/pages/student/digital-transcript/learningRecordResidentName';
 import { ViewAllAchievementsSheet } from '@/pages/student/digital-transcript/ViewAllAchievementsSheet';
 import { PrintShareHelpLink } from '@/components/learning-record/PrintShareHelpLink';
+import { LEARNING_RECORD_START_CARD_BLURB } from '@/data/learningRecordResidentCopy';
 
 // -----------------------------------------------------------------------------
 // Types
@@ -626,11 +627,9 @@ export default function ResidentHome() {
                                                     : 'Log a new achievement'}
                                             </h3>
                                             <p className="max-w-xl text-sm leading-relaxed text-white/80">
-                                                Write down a class, program, or
-                                                skill you finished. Your answers
-                                                are saved here as you go.
-                                                Nothing leaves this app unless
-                                                you choose to print or share it.
+                                                {
+                                                    LEARNING_RECORD_START_CARD_BLURB
+                                                }
                                             </p>
                                             <PrintShareHelpLink variant="onDark" />
                                         </div>

--- a/frontend/src/pages/student/digital-transcript/DigitalTranscriptHome.tsx
+++ b/frontend/src/pages/student/digital-transcript/DigitalTranscriptHome.tsx
@@ -75,6 +75,7 @@ import { learningRecordResidentDisplayName } from './learningRecordResidentName'
 import { TranscriptResumePreview } from './TranscriptResumePreview';
 import { ViewAllAchievementsSheet } from './ViewAllAchievementsSheet';
 import { PrintShareHelpLink } from '@/components/learning-record/PrintShareHelpLink';
+import { LearningRecordPrivacyNotice } from '@/components/learning-record/LearningRecordPrivacyNotice';
 import {
     countFunnelFieldsAnswered,
     funnelCompletionTier,
@@ -638,7 +639,12 @@ export default function DigitalTranscriptHome() {
                         title="Build your Learning Record"
                         subtitle={FUNNEL_SUBTITLE}
                     />
-                    <PrintShareHelpLink className="mb-8" />
+                    <PrintShareHelpLink className="mb-4" />
+
+                    <LearningRecordPrivacyNotice
+                        variant="short"
+                        className="mb-8"
+                    />
 
                     <SavedEntriesSection
                         entries={entries}
@@ -690,7 +696,12 @@ export default function DigitalTranscriptHome() {
                         title="Learning Record"
                         subtitle="Write down what you finished and the skills you built. Your answers are saved here as you go. Tap Done when one achievement feels complete."
                     />
-                    <PrintShareHelpLink className="mb-8" />
+                    <PrintShareHelpLink className="mb-4" />
+
+                    <LearningRecordPrivacyNotice
+                        variant="short"
+                        className="mb-8"
+                    />
 
                     <Card className="mb-6 overflow-hidden p-0">
                         <div className="flex flex-col md:flex-row">

--- a/frontend/src/pages/student/digital-transcript/DigitalTranscriptWysiwygEntry.tsx
+++ b/frontend/src/pages/student/digital-transcript/DigitalTranscriptWysiwygEntry.tsx
@@ -9,6 +9,7 @@ import {
 import { Plus } from 'lucide-react';
 import { useSearchParams } from 'react-router-dom';
 import { ConfirmDialog } from '@/components/shared';
+import { LearningRecordPrivacyNotice } from '@/components/learning-record/LearningRecordPrivacyNotice';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import { Card } from '@/components/ui/card';
@@ -640,6 +641,25 @@ export function DigitalTranscriptWysiwygEntry({
             data-slot="transcript-wysiwyg-outer"
             className="flex h-full min-h-0 w-full flex-1 flex-col overflow-hidden"
         >
+            {/*
+              Unconditional: the progress card below is funnel-only, so rendering
+              the notice outside that guard gives both variants the disclosure
+              while still sitting directly above the progress bar where one
+              exists. `shrink-0` keeps it out of the panes' scroll areas.
+            */}
+            {/*
+              `w-auto` is required, not cosmetic: `Alert`'s base classes include
+              `w-full`, which combined with `mx-4` makes the notice 32px wider
+              than its container — the right border overflows and is clipped by
+              the parent's `overflow-hidden`. `w-auto` lets the margins shrink
+              the box instead (twMerge drops `w-full` in favour of it). The
+              sibling progress Card gets away with plain `mx-4` because `Card`
+              has no `w-full`.
+            */}
+            <LearningRecordPrivacyNotice
+                variant="full"
+                className="mx-4 mt-4 w-auto shrink-0 print:hidden"
+            />
             {isFunnel && funnelEntry && funnelCompletionBadgeBg ? (
                 <Card
                     data-slot="funnel-form-progress"


### PR DESCRIPTION
## Pre-Submission PR Checklist

- [x] No debug/console/fmt.Println statements
- [x] Unnecessary development comments removed
- [x] All acceptance criteria verified
- [x] Functions according to **ticket specifications**
- [x] Tested manually where applicable
- [ ] Branch rebased with latest main
- [x] No business logic exists within the database layer

## Description of the change

Residents entering achievements into Learning Records had no on-screen explanation of how their data
is used. This adds a persistent, low-visual-weight transparency notice to both resident-facing
surfaces. It is informational only — not dismissible, and it never gates or delays starting an entry.

| File | Change |
|---|---|
| `data/learningRecordResidentCopy.ts` | + `LEARNING_RECORD_PRIVACY_NOTICE` (`short` / `full`) — one constant, so the two placements can't drift and final wording is a one-file edit |
| `components/learning-record/LearningRecordPrivacyNotice.tsx` | **new** — wraps the existing shadcn `Alert`, styled to match `IncompleteEntryReminder` |
| `digital-transcript/DigitalTranscriptHome.tsx` | `short` variant, in **both** prototype branches, above the "You have X achievements saved here" heading and the "Add achievement" CTA |
| `digital-transcript/DigitalTranscriptWysiwygEntry.tsx` | `full` variant, directly above the My Achievement / My Experience / My Future progress bar |
| `data/learningRecordResidentCopy.ts` (again), `data/faqData.ts`, `student/ResidentHome.tsx` | rewrote four existing strings that contradicted the notice — see below |

Frontend only — no migration, model, handler, database-layer or seeder changes.

Two non-obvious bits, both commented in place — they look like cruft but aren't:

- **`role="note"`** overrides `Alert`'s built-in `role="alert"`, which is an assertive live region and
  would make screen readers interrupt on every page load.
- **`w-auto`** on the entry-form notice — `Alert` ships `w-full`, which combined with `mx-4` makes the
  box 32px wider than its container, pushing the right border past the edge where `overflow-hidden`
  clips it. The sibling progress `Card` needs no override because `Card` has no `w-full`.

### Where to see each change

Log in as a **resident**. `learning_record` ships disabled (migration `00069`), so enable it in
`/feature-control` first — note a flag flipped directly in SQL won't take effect until the server
restarts, since it's read from an in-memory cache populated at boot and refreshed only by the admin
toggle.

| Route | What changed | What to look for |
|---|---|---|
| `/learning-record-funnel` | Notice added | Below the `<h1>`, **above** "You have X achievements saved here" and the Add-achievement CTA |
| `/learning-record-categories` | Notice added | Same notice, above the start card — confirms both prototype variants |
| `/learning-record-funnel/entry` | Notice added | Directly above the My Achievement / My Experience / My Future progress bar. Check the **right** border sits inside the panel, and that you can type immediately — it must not gate the form |
| `/learning-record-categories/entry` | Notice added | Same; no progress bar in this variant, which is correct |
| `/home` | Start-card copy | Green "Log a new achievement" card now ends "…facility staff don't see your individual entries" |
| `/home` → "What does this mean?" | Two FAQ strings | Dialog shows both rewritten answers |
| `/learning-record-funnel` → "View all achievements" → "What does this mean?" | Same two strings | Proves the shared dialog reaches this surface too |
| `/faqs` → "Managing My Account" | All three FAQ strings | Open *print or share*, *Where is my record saved?*, and *Is my activity private?* **one at a time** — the accordion is `type="single"`, so opening one closes the last |

Empty-state check: log in as a resident with zero entries and load either landing route — the notice
still renders above the empty state.

- **Related issues**: Closes Asana ID-807

## Screenshot(s)

All resident-facing at 1366×768.

<img width="1366" height="768" alt="entry_categories" src="https://github.com/user-attachments/assets/2ca52cbf-0924-489e-8949-06d8dfe8d97b" />
<img width="1366" height="768" alt="entry_funnel" src="https://github.com/user-attachments/assets/c8c0d7c7-1daf-4ead-b32e-9bb6471b8656" />
<img width="1366" height="768" alt="help_modal_both_answers" src="https://github.com/user-attachments/assets/2212970b-217b-4e83-b32d-9539bba0b410" />
<img width="1366" height="768" alt="start_card_blurb" src="https://github.com/user-attachments/assets/6fca8d6e-2013-4e3d-87d1-928223f7c26e" />
<img width="1366" height="768" alt="achievements_sheet_modal" src="https://github.com/user-attachments/assets/92bcc73f-baa7-4398-a6a2-a8f83d7950fa" />
<img width="1366" height="768" alt="landing_funnel" src="https://github.com/user-attachments/assets/39fd21d2-87dc-43e6-917c-98be820e6623" />
<img width="1366" height="768" alt="landing_categories" src="https://github.com/user-attachments/assets/16247bf0-d02b-4ab9-a147-6784d6ff65d8" />
<img width="1366" height="768" alt="faq_activity_private" src="https://github.com/user-attachments/assets/a81bbe03-ccc3-4ea8-aa6b-66848fa0d20d" />
<img width="1366" height="768" alt="faq_print_share" src="https://github.com/user-attachments/assets/616640ea-3e39-4c8e-a7a7-4d505dfc827d" />
<img width="1366" height="768" alt="faq_saved_here" src="https://github.com/user-attachments/assets/4e2ba3f9-45fc-4c5b-9f1d-445e5151526a" />


## Additional context

**Copy approved by Carolina** (2026-08-06). Both variants live in one constant, so any future wording
change is a single edit.

### Four existing strings said the opposite — fixed here

The app already told residents things the notice contradicts. Three of them sit in the **same**
"Managing My Account" accordion on `/faqs` — all three questions visible in one frame, so a resident
opening them in turn met the contradiction directly. Carolina approved the rewrite and asked that the "what does this
mean" modal and the "view all achievements" popout be updated too — which they were by construction,
since the two Learning Record strings are single-sourced and the modal and the FAQ render the same
constants (**five render sites**: both landing variants, the achievements popout, the resident home
start card, and `/faqs`).

| Was | Now |
|---|---|
| "Your record stays private and is only seen by people you give it to." | "The file you create is only seen by the people you give it to." — scoped to the PDF |
| "It is not shared with anyone automatically. Nothing leaves this app unless you choose to print or share it." | Keeps the print/share promise, adds the aggregate carve-out **verbatim from the approved notice**, so the two cannot drift |
| "The UnlockEd team and authorized facility staff can see this information." | Scoped to library and course activity, with Learning Record entries explicitly excluded |
| Resident home start card: "…Nothing leaves this app unless you choose to print or share it." | "…Your answers are saved here as you go, and facility staff don't see your individual entries." |

The fourth one is worth a note. It sat in JSX wrapped across five source lines, so no single line held a
matching phrase and two grep sweeps missed it — it was caught by eye, in a screenshot, sitting directly
above its own "What does this mean?" link and contradicting the modal one click away. It's now moved
into the copy module as `LEARNING_RECORD_START_CARD_BLURB`, so **every resident-facing Learning Record
privacy claim is in one file** where a plain grep will find it. If you're checking this kind of thing in
future, normalize whitespace per file before matching; line-based grep gives false confidence on JSX.

Note the aggregate use the notice discloses **isn't built yet** — nothing currently aggregates
`learning_record_entries`. The wording is deliberately permissive ("*may* be used"), so it's accurate
now, stays accurate once aggregation ships, and won't need re-approval. Carolina was told this before
approving.



### Two pre-existing bugs found while testing — neither fixed here

This diff touches no backend files; both reproduce on `main` without it.

1. **`PUT /api/learning-record/draft` returns 500 for every resident, silently** — the autosave label
   still reads "Saved". `UpsertLearningRecordDraft` (`database/learning_record.go:99-102`) infers
   `ON CONFLICT (user_id, client_id)`, but the only matching unique index is partial
   (`... WHERE deleted_at IS NULL`, migration `00069`) and Postgres can't infer a partial index →
   `SQLSTATE 42P10`. It's a planning failure, not a row conflict: it fails even for a brand-new key
   with zero conflicting rows. Reflection content is safe (that saves via `POST`/`PUT /entries`); only
   the draft/resume row is lost, and only cross-device since the frontend also keeps it in
   `localStorage`. Fix is one clause —
   `TargetWhere: clause.Where{Exprs: []clause.Expression{clause.Expr{SQL: "deleted_at IS NULL"}}}`.
   It must be `TargetWhere`, not `Where`: GORM emits the former as the conflict-target predicate, the
   latter after `DO UPDATE SET`, where it wouldn't help. Happy to open a separate PR.



---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1217097620641819