### PR TITLE
fix: add logic for fixing canvas calls that lock screen per id 796

### DIFF
--- a/backend/src/handlers/canvas_classes_cache.go
+++ b/backend/src/handlers/canvas_classes_cache.go
@@ -1,0 +1,333 @@
+package handlers
+
+import (
+	"UnlockEdv2/src/models"
+	"context"
+	"encoding/json"
+	"fmt"
+	"sync"
+	"time"
+
+	log "github.com/sirupsen/logrus"
+)
+
+// The facility classes index must never block on the Canvas API: listing every
+// course for a provider and then fetching each course's enrollments is dozens of
+// sequential HTTP round trips. Instead the expensive part is cached in NATS KV
+// per provider platform and refreshed by a background goroutine, mirroring the
+// approach used for the programs list (see warmCanvasProgramCache).
+//
+// What gets cached is the raw course metadata plus per-facility enrollment counts
+// rather than the expanded ProgramClass rows: the statewide view is a
+// facility × course cross product that would blow past the NATS message size
+// limit, and expanding it in Go on each request costs nothing.
+
+// canvasClassesFreshFor is how long a cached entry is served without triggering a
+// background refresh. Entries older than this are still served immediately while
+// the refresh runs (the KV bucket TTL is deliberately longer, see
+// setupNatsKvBuckets).
+const canvasClassesFreshFor = 5 * time.Minute
+
+// canvasClassesRefreshTimeout bounds one background refresh. srv.Client has no
+// timeout of its own, so without a deadline an unresponsive Canvas host would pin
+// the refresh in flight and leave the cache stuck reporting Loading.
+const canvasClassesRefreshTimeout = 5 * time.Minute
+
+// cachedCanvasCourse is one Canvas course with its mapped enrollment counts
+// broken down by facility, which is all the classes index needs.
+type cachedCanvasCourse struct {
+	RawID              uint               `json:"raw_id"`
+	Name               string             `json:"name"`
+	Description        string             `json:"description"`
+	StartDt            time.Time          `json:"start_dt"`
+	EndDt              *time.Time         `json:"end_dt"`
+	Status             models.ClassStatus `json:"status"`
+	EnrolledByFacility map[uint]int64     `json:"enrolled_by_facility"`
+}
+
+// CachedCanvasClasses is the NATS KV payload for one Canvas provider platform.
+type CachedCanvasClasses struct {
+	ProviderName string               `json:"provider_name"`
+	Courses      []cachedCanvasCourse `json:"courses"`
+	LastUpdated  time.Time            `json:"last_updated"`
+	// Loading marks a refresh as in flight so concurrent requests neither
+	// re-enter the fetch nor treat an empty payload as "no classes".
+	Loading bool `json:"loading"`
+}
+
+type canvasCacheState int
+
+const (
+	// canvasCacheFresh - cached data is recent enough to serve as-is.
+	canvasCacheFresh canvasCacheState = iota
+	// canvasCacheLoading - a background refresh is already running.
+	canvasCacheLoading
+	// canvasCacheStale - data is present but expired; serve it and refresh.
+	canvasCacheStale
+	// canvasCacheMiss - nothing usable cached.
+	canvasCacheMiss
+)
+
+func canvasClassesCacheKey(providerID uint) string {
+	return fmt.Sprintf("canvas_classes_%d", providerID)
+}
+
+// getCanvasClasses builds the Canvas portion of the classes index from cache.
+// facilityID nil (or 0) returns one class per facility × course for the statewide
+// view; otherwise classes are scoped to that facility.
+//
+// The returned loading flag means at least one provider's data is still being
+// fetched, so the caller should tell the client to poll rather than treat the
+// result as complete.
+func (srv *Server) getCanvasClasses(facilityID *uint) ([]models.ProgramClass, bool, error) {
+	providers, err := srv.Db.GetAllActiveProviderPlatforms()
+	if err != nil {
+		return nil, false, err
+	}
+	canvasProviders := make([]models.ProviderPlatform, 0, len(providers))
+	for _, provider := range providers {
+		if isCanvasProvider(&provider) {
+			canvasProviders = append(canvasProviders, provider)
+		}
+	}
+	if len(canvasProviders) == 0 {
+		return nil, false, nil
+	}
+
+	facilities, err := srv.canvasClassFacilities(facilityID)
+	if err != nil {
+		return nil, false, err
+	}
+
+	kv := srv.buckets[CanvasClasses]
+	if kv == nil {
+		// Without the cache there is nowhere to publish background results, so
+		// fall back to fetching inline rather than returning nothing forever.
+		log.Warn("canvas_classes NATS bucket is nil, fetching canvas classes inline")
+		var result []models.ProgramClass
+		for i := range canvasProviders {
+			provider := &canvasProviders[i]
+			courses, err := srv.fetchCanvasCoursesWithCounts(context.Background(), provider)
+			if err != nil {
+				log.WithError(err).Warnf("failed to fetch canvas courses for provider %d, skipping", provider.ID)
+				continue
+			}
+			result = append(result, expandCanvasClasses(provider, courses, facilities)...)
+		}
+		return result, false, nil
+	}
+
+	var (
+		result  []models.ProgramClass
+		loading bool
+	)
+	for i := range canvasProviders {
+		provider := &canvasProviders[i]
+		cached, state := srv.readCanvasClassesCache(provider.ID)
+		if state == canvasCacheMiss || state == canvasCacheStale {
+			var stale []cachedCanvasCourse
+			if cached != nil {
+				stale = cached.Courses
+			}
+			srv.warmCanvasClassesCache(provider, stale)
+		}
+		if state != canvasCacheFresh {
+			loading = true
+		}
+		if cached != nil {
+			result = append(result, expandCanvasClasses(provider, cached.Courses, facilities)...)
+		}
+	}
+	return result, loading, nil
+}
+
+// canvasClassFacilities resolves the facilities the Canvas classes are expanded
+// over: every facility for the statewide view, or just the requested one.
+func (srv *Server) canvasClassFacilities(facilityID *uint) ([]models.Facility, error) {
+	if facilityID == nil || *facilityID == 0 {
+		return srv.Db.GetAllFacilitiesOrdered()
+	}
+	facility, err := srv.Db.GetFacilityByID(int(*facilityID))
+	if err != nil {
+		return nil, err
+	}
+	return []models.Facility{*facility}, nil
+}
+
+// readCanvasClassesCache returns the cached payload for a provider (possibly
+// stale, possibly nil) along with what the caller should do about it.
+func (srv *Server) readCanvasClassesCache(providerID uint) (*CachedCanvasClasses, canvasCacheState) {
+	kv := srv.buckets[CanvasClasses]
+	if kv == nil {
+		return nil, canvasCacheMiss
+	}
+	entry, err := kv.Get(canvasClassesCacheKey(providerID))
+	if err != nil {
+		return nil, canvasCacheMiss
+	}
+	var cached CachedCanvasClasses
+	if err := json.Unmarshal(entry.Value(), &cached); err != nil {
+		log.WithError(err).Warnf("readCanvasClassesCache: corrupt entry for provider %d", providerID)
+		return nil, canvasCacheMiss
+	}
+	switch {
+	case cached.Loading && cached.LastUpdated.Add(canvasClassesRefreshTimeout).After(time.Now()):
+		return &cached, canvasCacheLoading
+	case cached.Loading:
+		// A refresh that outlived its own timeout never wrote a result (e.g. the
+		// process restarted mid-fetch); treat it as stale so it gets retried
+		// instead of reporting Loading until the bucket TTL expires.
+		return &cached, canvasCacheStale
+	case cached.LastUpdated.Add(canvasClassesFreshFor).After(time.Now()):
+		return &cached, canvasCacheFresh
+	default:
+		return &cached, canvasCacheStale
+	}
+}
+
+// warmCanvasClassesCache fires a background goroutine that refreshes the Canvas
+// course cache for one provider. stale is the data already cached, which is kept
+// in place (flagged Loading) so requests during the refresh still see classes,
+// and restored if the refresh fails.
+func (srv *Server) warmCanvasClassesCache(provider *models.ProviderPlatform, stale []cachedCanvasCourse) {
+	if _, loaded := srv.canvasClassesInflight.LoadOrStore(provider.ID, struct{}{}); loaded {
+		return
+	}
+	kv := srv.buckets[CanvasClasses]
+	if kv == nil {
+		srv.canvasClassesInflight.Delete(provider.ID)
+		return
+	}
+	providerCopy := *provider
+	cacheKey := canvasClassesCacheKey(provider.ID)
+	putEntry := func(courses []cachedCanvasCourse, updated time.Time, loading bool) {
+		payload := CachedCanvasClasses{
+			ProviderName: providerCopy.Name,
+			Courses:      courses,
+			LastUpdated:  updated,
+			Loading:      loading,
+		}
+		data, err := json.Marshal(payload)
+		if err != nil {
+			log.WithError(err).Warnf("warmCanvasClassesCache: failed to marshal entry for provider %d", providerCopy.ID)
+			return
+		}
+		if _, err := kv.Put(cacheKey, data); err != nil {
+			log.WithError(err).Warnf("warmCanvasClassesCache: failed to write entry for provider %d", providerCopy.ID)
+		}
+	}
+	// Claim the key before returning so a request arriving a moment later sees
+	// Loading rather than kicking off its own fetch.
+	putEntry(stale, time.Now(), true)
+
+	go func() {
+		defer srv.canvasClassesInflight.Delete(providerCopy.ID)
+		ctx, cancel := context.WithTimeout(context.Background(), canvasClassesRefreshTimeout)
+		defer cancel()
+		courses, err := srv.fetchCanvasCoursesWithCounts(ctx, &providerCopy)
+		if err != nil {
+			log.WithError(err).Warnf("warmCanvasClassesCache: failed to fetch canvas courses for provider %d", providerCopy.ID)
+			if len(stale) > 0 {
+				// Keep serving the last known good data instead of polling a
+				// provider that is currently unreachable.
+				putEntry(stale, time.Now(), false)
+			} else if err := kv.Delete(cacheKey); err != nil {
+				log.WithError(err).Warnf("warmCanvasClassesCache: failed to clear entry for provider %d", providerCopy.ID)
+			}
+			return
+		}
+		putEntry(courses, time.Now(), false)
+		log.Debugf("warmCanvasClassesCache: cached %d canvas courses for provider %d", len(courses), providerCopy.ID)
+	}()
+}
+
+// fetchCanvasCoursesWithCounts lists every course for a Canvas provider and
+// resolves each course's mapped enrollment counts per facility. This is the
+// expensive, network-bound work the cache exists to keep off the request path.
+func (srv *Server) fetchCanvasCoursesWithCounts(ctx context.Context, provider *models.ProviderPlatform) ([]cachedCanvasCourse, error) {
+	apiURL := provider.BaseUrl + "/api/v1/accounts/" + provider.AccountID + "/courses?per_page=100"
+	rawCourses, err := srv.fetchAllCanvasPages(ctx, provider, apiURL, 0)
+	if err != nil {
+		return nil, err
+	}
+	now := time.Now()
+	entries := make([]canvasCourseEntry, 0, len(rawCourses))
+	for _, course := range rawCourses {
+		entry, ok := parseCanvasCourse(course, provider.ID, now)
+		if !ok {
+			continue
+		}
+		entries = append(entries, entry)
+	}
+	// One Canvas call plus one DB query per course, returning counts for every
+	// facility at once, so this stays O(courses) rather than O(courses × facilities).
+	courses := make([]cachedCanvasCourse, len(entries))
+	var wg sync.WaitGroup
+	sem := make(chan struct{}, 10)
+	for i := range entries {
+		wg.Add(1)
+		sem <- struct{}{}
+		go func(idx int) {
+			defer wg.Done()
+			defer func() { <-sem }()
+			counts := srv.countMappedCanvasEnrolleesPerFacility(ctx, provider, entries[idx].rawID)
+			if counts == nil {
+				counts = map[uint]int64{}
+			}
+			courses[idx] = cachedCanvasCourse{
+				RawID:              entries[idx].rawID,
+				Name:               entries[idx].name,
+				Description:        entries[idx].description,
+				StartDt:            entries[idx].startDt,
+				EndDt:              entries[idx].endDt,
+				Status:             entries[idx].status,
+				EnrolledByFacility: counts,
+			}
+		}(i)
+	}
+	wg.Wait()
+	return courses, nil
+}
+
+// expandCanvasClasses turns cached course data into the ProgramClass rows the
+// classes index returns, one per facility × course.
+func expandCanvasClasses(provider *models.ProviderPlatform, courses []cachedCanvasCourse, facilities []models.Facility) []models.ProgramClass {
+	programID := models.CanvasProgramIDOffset + provider.ID
+	result := make([]models.ProgramClass, 0, len(courses)*len(facilities))
+	for i := range facilities {
+		facility := &facilities[i]
+		for _, course := range courses {
+			result = append(result, models.ProgramClass{
+				DatabaseFields: models.DatabaseFields{ID: encodeFacilityCanvasClassID(facility.ID, provider.ID, course.RawID)},
+				ProgramID:      programID,
+				FacilityID:     facility.ID,
+				Facility:       facility,
+				Name:           course.Name,
+				Description:    course.Description,
+				StartDt:        course.StartDt,
+				EndDt:          course.EndDt,
+				Status:         course.Status,
+				Enrolled:       course.EnrolledByFacility[facility.ID],
+				IsCanvas:       true,
+				Program: &models.Program{
+					DatabaseFields: models.DatabaseFields{ID: programID},
+					Name:           "College - " + provider.Name,
+				},
+			})
+		}
+	}
+	return result
+}
+
+// invalidateCanvasClassesCache drops the cached course data for a provider so the
+// next classes request refreshes it. Called when Canvas user mappings change,
+// since those feed the enrollment counts.
+func (srv *Server) invalidateCanvasClassesCache(providerID uint) {
+	kv := srv.buckets[CanvasClasses]
+	if kv == nil {
+		return
+	}
+	if err := kv.Delete(canvasClassesCacheKey(providerID)); err != nil {
+		log.WithError(err).Warnf("invalidateCanvasClassesCache: failed to delete entry for provider %d", providerID)
+	}
+}

--- a/backend/src/handlers/canvas_programs.go
+++ b/backend/src/handlers/canvas_programs.go
@@ -129,19 +129,19 @@ func (srv *Server) fetchCanvasMappedUsers(providerID uint, canvasUserIDs []strin
 // fetchCanvasCourseEnrolleeIDs fetches active student enrollments for a Canvas
 // course and returns the Canvas user IDs as strings, ready to query
 // provider_user_mappings.external_user_id.
-func (srv *Server) fetchCanvasCourseEnrolleeIDs(provider *models.ProviderPlatform, rawCourseID uint) ([]string, error) {
-	ids, _, err := srv.fetchCanvasCourseEnrollmentData(provider, rawCourseID)
+func (srv *Server) fetchCanvasCourseEnrolleeIDs(ctx context.Context, provider *models.ProviderPlatform, rawCourseID uint) ([]string, error) {
+	ids, _, err := srv.fetchCanvasCourseEnrollmentData(ctx, provider, rawCourseID)
 	return ids, err
 }
 
 // fetchCanvasCourseEnrollmentData fetches active student enrollments for a Canvas
 // course and returns both the Canvas user IDs and a map of userID → enrollment created_at.
-func (srv *Server) fetchCanvasCourseEnrollmentData(provider *models.ProviderPlatform, rawCourseID uint) ([]string, map[string]*time.Time, error) {
+func (srv *Server) fetchCanvasCourseEnrollmentData(ctx context.Context, provider *models.ProviderPlatform, rawCourseID uint) ([]string, map[string]*time.Time, error) {
 	enrollURL := fmt.Sprintf(
 		"%s/api/v1/courses/%d/enrollments?type[]=StudentEnrollment&state[]=active&per_page=100",
 		provider.BaseUrl, rawCourseID,
 	)
-	enrollments, err := srv.fetchAllCanvasPages(context.Background(), provider, enrollURL, 0)
+	enrollments, err := srv.fetchAllCanvasPages(ctx, provider, enrollURL, 0)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -351,9 +351,9 @@ func (srv *Server) fetchCanvasProviderProgram(provider *models.ProviderPlatform,
 			defer wg.Done()
 			var n int64
 			if facilityID != 0 {
-				n = srv.countMappedCanvasEnrolleesForFacility(provider, rawID, facilityID)
+				n = srv.countMappedCanvasEnrolleesForFacility(context.Background(), provider, rawID, facilityID)
 			} else {
-				n = srv.countMappedCanvasEnrollees(provider, rawID)
+				n = srv.countMappedCanvasEnrollees(context.Background(), provider, rawID)
 			}
 			mu.Lock()
 			activeEnrollments += n
@@ -592,171 +592,6 @@ func (srv *Server) fetchCanvasCalendarEvents(
 	return events, nil
 }
 
-// fetchCanvasClassesAllProviders returns a ProgramClass for every Canvas course
-// across all active Canvas provider platforms. Failures per-provider are logged
-// and skipped so a single unreachable provider doesn't break the response.
-// facilityID must be non-nil and non-zero; for the statewide (all-facilities) case
-// use fetchCanvasClassesAllProvidersAllFacilities instead.
-func (srv *Server) fetchCanvasClassesAllProviders(facilityID *uint) ([]models.ProgramClass, error) {
-	providers, err := srv.Db.GetAllActiveProviderPlatforms()
-	if err != nil {
-		return nil, err
-	}
-	now := time.Now()
-	var facility *models.Facility
-	if facilityID != nil && *facilityID != 0 {
-		if f, err := srv.Db.GetFacilityByID(int(*facilityID)); err == nil {
-			facility = f
-		}
-	}
-	var result []models.ProgramClass
-	for _, provider := range providers {
-		if !isCanvasProvider(&provider) {
-			continue
-		}
-		programID := models.CanvasProgramIDOffset + provider.ID
-		apiURL := provider.BaseUrl + "/api/v1/accounts/" + provider.AccountID + "/courses?per_page=100"
-		courses, err := srv.fetchAllCanvasPages(context.Background(), &provider, apiURL, 0)
-		if err != nil {
-			log.WithError(err).Warnf("failed to fetch canvas courses for provider %d, skipping", provider.ID)
-			continue
-		}
-		entries := make([]canvasCourseEntry, 0, len(courses))
-		for _, course := range courses {
-			entry, ok := parseCanvasCourse(course, provider.ID, now)
-			if !ok {
-				continue
-			}
-			entries = append(entries, entry)
-		}
-		if facilityID == nil || *facilityID == 0 {
-			continue
-		}
-		counts := make([]int64, len(entries))
-		var wg sync.WaitGroup
-		var mu sync.Mutex
-		sem := make(chan struct{}, 10)
-		for i := range entries {
-			wg.Add(1)
-			sem <- struct{}{}
-			go func(idx int) {
-				defer wg.Done()
-				defer func() { <-sem }()
-				n := srv.countMappedCanvasEnrolleesForFacility(&provider, entries[idx].rawID, *facilityID)
-				mu.Lock()
-				counts[idx] = n
-				mu.Unlock()
-			}(i)
-		}
-		wg.Wait()
-		for i, entry := range entries {
-			result = append(result, models.ProgramClass{
-				DatabaseFields: models.DatabaseFields{ID: encodeFacilityCanvasClassID(*facilityID, provider.ID, entry.rawID)},
-				ProgramID:      programID,
-				FacilityID:     *facilityID,
-				Facility:       facility,
-				Name:           entry.name,
-				Description:    entry.description,
-				StartDt:        entry.startDt,
-				EndDt:          entry.endDt,
-				Status:         entry.status,
-				Enrolled:       counts[i],
-				IsCanvas:       true,
-				Program: &models.Program{
-					DatabaseFields: models.DatabaseFields{ID: programID},
-					Name:           "College - " + provider.Name,
-				},
-			})
-		}
-	}
-	return result, nil
-}
-
-// fetchCanvasClassesAllProvidersAllFacilities returns one ProgramClass per
-// (facility × Canvas course) with facility-scoped IDs. Used by the statewide
-// classes index when facility=all so every returned class has a navigable,
-// facility-scoped ID.
-func (srv *Server) fetchCanvasClassesAllProvidersAllFacilities() ([]models.ProgramClass, error) {
-	providers, err := srv.Db.GetAllActiveProviderPlatforms()
-	if err != nil {
-		return nil, err
-	}
-	facilities, err := srv.Db.GetAllFacilitiesOrdered()
-	if err != nil {
-		return nil, err
-	}
-	now := time.Now()
-	var result []models.ProgramClass
-	for _, provider := range providers {
-		if !isCanvasProvider(&provider) {
-			continue
-		}
-		programID := models.CanvasProgramIDOffset + provider.ID
-		apiURL := provider.BaseUrl + "/api/v1/accounts/" + provider.AccountID + "/courses?per_page=100"
-		courses, err := srv.fetchAllCanvasPages(context.Background(), &provider, apiURL, 0)
-		if err != nil {
-			log.WithError(err).Warnf("failed to fetch canvas courses for provider %d, skipping", provider.ID)
-			continue
-		}
-		entries := make([]canvasCourseEntry, 0, len(courses))
-		for _, course := range courses {
-			entry, ok := parseCanvasCourse(course, provider.ID, now)
-			if !ok {
-				continue
-			}
-			entries = append(entries, entry)
-		}
-		// Fetch per-facility enrollment counts for each course concurrently.
-		// countMappedCanvasEnrolleesPerFacility makes one Canvas HTTP call and
-		// one DB query per course, returning counts for all facilities at once,
-		// so this is O(courses) HTTP calls rather than O(courses × facilities).
-		facilityCounts := make([]map[uint]int64, len(entries))
-		var wg sync.WaitGroup
-		var mu sync.Mutex
-		sem := make(chan struct{}, 10)
-		for i := range entries {
-			wg.Add(1)
-			sem <- struct{}{}
-			go func(idx int) {
-				defer wg.Done()
-				defer func() { <-sem }()
-				counts := srv.countMappedCanvasEnrolleesPerFacility(&provider, entries[idx].rawID)
-				mu.Lock()
-				facilityCounts[idx] = counts
-				mu.Unlock()
-			}(i)
-		}
-		wg.Wait()
-		for _, facility := range facilities {
-			facilityPtr := facility
-			for i, entry := range entries {
-				enrolled := int64(0)
-				if facilityCounts[i] != nil {
-					enrolled = facilityCounts[i][facility.ID]
-				}
-				result = append(result, models.ProgramClass{
-					DatabaseFields: models.DatabaseFields{ID: encodeFacilityCanvasClassID(facility.ID, provider.ID, entry.rawID)},
-					ProgramID:      programID,
-					FacilityID:     facility.ID,
-					Facility:       &facilityPtr,
-					Name:           entry.name,
-					Description:    entry.description,
-					StartDt:        entry.startDt,
-					EndDt:          entry.endDt,
-					Status:         entry.status,
-					Enrolled:       enrolled,
-					IsCanvas:       true,
-					Program: &models.Program{
-						DatabaseFields: models.DatabaseFields{ID: programID},
-						Name:           "College - " + provider.Name,
-					},
-				})
-			}
-		}
-	}
-	return result, nil
-}
-
 // appendCanvasEventsForFacility iterates all active Canvas provider platforms
 // and collects calendar events for the given date range.
 func (srv *Server) appendCanvasEventsForFacility(dtRng *models.DateRange) ([]models.FacilityProgramClassEvent, error) {
@@ -944,9 +779,9 @@ func (srv *Server) handleGetCanvasClasses(w http.ResponseWriter, r *http.Request
 			_, rawID := decodeCanvasClassID(classes[idx].ID)
 			var n int64
 			if facilityID != 0 {
-				n = srv.countMappedCanvasEnrolleesForFacility(provider, rawID, facilityID)
+				n = srv.countMappedCanvasEnrolleesForFacility(r.Context(), provider, rawID, facilityID)
 			} else {
-				n = srv.countMappedCanvasEnrollees(provider, rawID)
+				n = srv.countMappedCanvasEnrollees(r.Context(), provider, rawID)
 			}
 			mu.Lock()
 			counts[classes[idx].ID] = n
@@ -1039,7 +874,7 @@ func (srv *Server) handleGetCanvasClassesByFacility(w http.ResponseWriter, r *ht
 		go func(idx int) {
 			defer wg.Done()
 			rawID := entries[idx].rawID
-			counts := srv.countMappedCanvasEnrolleesPerFacility(provider, rawID)
+			counts := srv.countMappedCanvasEnrolleesPerFacility(r.Context(), provider, rawID)
 			mu.Lock()
 			facilityCounts[idx] = counts
 			mu.Unlock()
@@ -1204,36 +1039,38 @@ func (srv *Server) fetchCanvasCoursesScheduleEvents(
 	return result
 }
 
-// invalidateCanvasProgramCache deletes the NATS KV cache entries for the given Canvas
-// provider so the next read recomputes enrollment counts. Both the global (scopedFacility=0)
-// entry and the facility-scoped entry for the unlinked user's facility are purged.
+// invalidateCanvasCachesForUser deletes the NATS KV cache entries for the given Canvas
+// provider so the next read recomputes enrollment counts, covering both the programs
+// cache and the classes cache. For programs, both the global (scopedFacility=0) entry
+// and the facility-scoped entry for the unlinked user's facility are purged.
 // Non-Canvas providers and nil buckets are silently skipped.
-func (srv *Server) invalidateCanvasProgramCache(providerID uint, userID int) {
+func (srv *Server) invalidateCanvasCachesForUser(providerID uint, userID int) {
 	provider, err := srv.Db.GetProviderPlatformByID(int(providerID))
 	if err != nil || !isCanvasProvider(provider) {
 		return
 	}
+	srv.invalidateCanvasClassesCache(providerID)
 	kv := srv.buckets[CanvasPrograms]
 	if kv == nil {
 		return
 	}
 	globalKey := fmt.Sprintf("canvas_program_%d_0", providerID)
 	if err := kv.Delete(globalKey); err != nil {
-		log.WithError(err).Warnf("invalidateCanvasProgramCache: failed to delete key %s", globalKey)
+		log.WithError(err).Warnf("invalidateCanvasCachesForUser: failed to delete key %s", globalKey)
 	}
 	user, err := srv.Db.GetUserByID(uint(userID))
 	if err == nil && user.FacilityID != 0 {
 		facilityKey := fmt.Sprintf("canvas_program_%d_%d", providerID, user.FacilityID)
 		if err := kv.Delete(facilityKey); err != nil {
-			log.WithError(err).Warnf("invalidateCanvasProgramCache: failed to delete key %s", facilityKey)
+			log.WithError(err).Warnf("invalidateCanvasCachesForUser: failed to delete key %s", facilityKey)
 		}
 	}
 }
 
 // countMappedCanvasEnrolleesPerFacility fetches active enrollments for a Canvas course
 // and returns a map of facility_id → count of mapped users from that facility.
-func (srv *Server) countMappedCanvasEnrolleesPerFacility(provider *models.ProviderPlatform, rawCourseID uint) map[uint]int64 {
-	canvasUserIDs, err := srv.fetchCanvasCourseEnrolleeIDs(provider, rawCourseID)
+func (srv *Server) countMappedCanvasEnrolleesPerFacility(ctx context.Context, provider *models.ProviderPlatform, rawCourseID uint) map[uint]int64 {
+	canvasUserIDs, err := srv.fetchCanvasCourseEnrolleeIDs(ctx, provider, rawCourseID)
 	if err != nil {
 		log.WithError(err).Warnf("countMappedCanvasEnrolleesPerFacility: failed to fetch enrollments for course %d", rawCourseID)
 		return nil
@@ -1286,8 +1123,8 @@ func resolveCanvasClassParts(classID uint) (facilityID, providerID, rawCourseID 
 
 // countMappedCanvasEnrolleesForFacility is like countMappedCanvasEnrollees but
 // only counts users belonging to the given facility.
-func (srv *Server) countMappedCanvasEnrolleesForFacility(provider *models.ProviderPlatform, rawCourseID uint, facilityID uint) int64 {
-	canvasUserIDs, err := srv.fetchCanvasCourseEnrolleeIDs(provider, rawCourseID)
+func (srv *Server) countMappedCanvasEnrolleesForFacility(ctx context.Context, provider *models.ProviderPlatform, rawCourseID uint, facilityID uint) int64 {
+	canvasUserIDs, err := srv.fetchCanvasCourseEnrolleeIDs(ctx, provider, rawCourseID)
 	if err != nil {
 		log.WithError(err).Warnf("countMappedCanvasEnrolleesForFacility: failed to fetch enrollments for course %d", rawCourseID)
 		return 0
@@ -1305,8 +1142,8 @@ func (srv *Server) countMappedCanvasEnrolleesForFacility(provider *models.Provid
 
 // countMappedCanvasEnrollees fetches active student enrollments for a Canvas
 // course and returns how many of those students have a ProviderUserMapping.
-func (srv *Server) countMappedCanvasEnrollees(provider *models.ProviderPlatform, rawCourseID uint) int64 {
-	canvasUserIDs, err := srv.fetchCanvasCourseEnrolleeIDs(provider, rawCourseID)
+func (srv *Server) countMappedCanvasEnrollees(ctx context.Context, provider *models.ProviderPlatform, rawCourseID uint) int64 {
+	canvasUserIDs, err := srv.fetchCanvasCourseEnrolleeIDs(ctx, provider, rawCourseID)
 	if err != nil {
 		log.WithError(err).Warnf("countMappedCanvasEnrollees: failed to fetch enrollments for course %d", rawCourseID)
 		return 0
@@ -1454,9 +1291,9 @@ func (srv *Server) handleGetCanvasClassDetail(w http.ResponseWriter, r *http.Req
 	}
 	var enrolled int64
 	if facilityID != 0 {
-		enrolled = srv.countMappedCanvasEnrolleesForFacility(provider, rawCourseID, facilityID)
+		enrolled = srv.countMappedCanvasEnrolleesForFacility(r.Context(), provider, rawCourseID, facilityID)
 	} else {
-		enrolled = srv.countMappedCanvasEnrollees(provider, rawCourseID)
+		enrolled = srv.countMappedCanvasEnrollees(r.Context(), provider, rawCourseID)
 	}
 
 	var facility *models.Facility
@@ -1649,7 +1486,7 @@ func (srv *Server) handleGetCanvasClassEnrollments(w http.ResponseWriter, r *htt
 		return newInvalidIdServiceError(fmt.Errorf("provider access disabled for provider %d", providerID), "class ID")
 	}
 
-	canvasUserIDs, enrollmentDates, err := srv.fetchCanvasCourseEnrollmentData(provider, rawCourseID)
+	canvasUserIDs, enrollmentDates, err := srv.fetchCanvasCourseEnrollmentData(r.Context(), provider, rawCourseID)
 	if err != nil {
 		return newInternalServerServiceError(err, "failed to fetch canvas enrollments")
 	}

--- a/backend/src/handlers/classes_handler.go
+++ b/backend/src/handlers/classes_handler.go
@@ -139,23 +139,24 @@ func (srv *Server) handleIndexClassesForFacility(w http.ResponseWriter, r *http.
 	if err != nil {
 		return newDatabaseServiceError(err)
 	}
+	var canvasLoading bool
+	var canvasClasses []models.ProgramClass
+	var canvasErr error
 	if claims.hasFeatureAccess(models.ProviderAccess) {
-		var canvasClasses []models.ProgramClass
-		var canvasErr error
-		if facilityID == nil {
-			canvasClasses, canvasErr = srv.fetchCanvasClassesAllProvidersAllFacilities()
-		} else {
-			canvasClasses, canvasErr = srv.fetchCanvasClassesAllProviders(facilityID)
-		}
+		// Canvas classes come from a background-refreshed cache so this request never
+		// waits on the Canvas API. canvasLoading tells the client to poll for the rest.
+		canvasClasses, canvasLoading, canvasErr = srv.getCanvasClasses(facilityID)
 		if canvasErr != nil {
 			logrus.WithError(canvasErr).Warn("failed to fetch canvas classes, returning DB classes only")
+			canvasLoading = false
 		} else {
-			canvasClasses = srv.filterClassesByProviderAccess(canvasClasses)
 			classes = append(classes, canvasClasses...)
 			args.Total += int64(len(canvasClasses))
 		}
 	}
-	return writePaginatedResponse(w, http.StatusOK, classes, args.IntoMeta())
+	meta := args.IntoMeta()
+	meta.CanvasLoading = canvasLoading
+	return writePaginatedResponse(w, http.StatusOK, classes, meta)
 }
 
 // filterClassesByProviderAccess drops Canvas classes belonging to a facility that has

--- a/backend/src/handlers/provider_user_management.go
+++ b/backend/src/handlers/provider_user_management.go
@@ -58,7 +58,7 @@ func (srv *Server) handleMapProviderUser(w http.ResponseWriter, r *http.Request,
 	if err != nil {
 		return newDatabaseServiceError(err)
 	}
-	srv.invalidateCanvasProgramCache(provider.ID, int(user.ID))
+	srv.invalidateCanvasCachesForUser(provider.ID, int(user.ID))
 	// create login for user
 	if provider.OidcID != 0 {
 		if err := srv.registerProviderLogin(provider, user); err != nil {

--- a/backend/src/handlers/provider_user_mapping_handler.go
+++ b/backend/src/handlers/provider_user_mapping_handler.go
@@ -83,7 +83,7 @@ func (srv *Server) handleCreateProviderUserMapping(w http.ResponseWriter, r *htt
 		log.add("userId", mapping.UserID)
 		return newDatabaseServiceError(err)
 	}
-	srv.invalidateCanvasProgramCache(mapping.ProviderPlatformID, int(mapping.UserID))
+	srv.invalidateCanvasCachesForUser(mapping.ProviderPlatformID, int(mapping.UserID))
 	return writeJsonResponse(w, http.StatusCreated, mapping)
 }
 
@@ -103,6 +103,6 @@ func (srv *Server) handleDeleteProviderUserMapping(w http.ResponseWriter, r *htt
 		log.add("providerId", providerId)
 		return newDatabaseServiceError(err)
 	}
-	srv.invalidateCanvasProgramCache(uint(providerId), userId)
+	srv.invalidateCanvasCachesForUser(uint(providerId), userId)
 	return writeJsonResponse(w, http.StatusNoContent, "Mapping deleted successfully")
 }

--- a/backend/src/handlers/server.go
+++ b/backend/src/handlers/server.go
@@ -10,6 +10,7 @@ import (
 	"os"
 	"reflect"
 	"runtime"
+	"slices"
 	"strconv"
 	"strings"
 	"sync"
@@ -26,23 +27,24 @@ import (
 )
 
 type Server struct {
-	sesClient      *sesv2.Client
-	port           string
-	Db             *database.DB
-	Mux            *http.ServeMux
-	OryClient      *ory.APIClient
-	Client         *http.Client
-	nats           *nats.Conn
-	dev            bool
-	buckets        map[string]nats.KeyValue
-	features       []models.FeatureAccess
-	testingMode    bool
-	s3             *s3.Client
-	presigner      *s3.PresignClient
-	s3Bucket       string
-	wsClient       *ClientManager
-	scheduler      *tasks.Scheduler
-	canvasInflight sync.Map
+	sesClient             *sesv2.Client
+	port                  string
+	Db                    *database.DB
+	Mux                   *http.ServeMux
+	OryClient             *ory.APIClient
+	Client                *http.Client
+	nats                  *nats.Conn
+	dev                   bool
+	buckets               map[string]nats.KeyValue
+	features              []models.FeatureAccess
+	testingMode           bool
+	s3                    *s3.Client
+	presigner             *s3.PresignClient
+	s3Bucket              string
+	wsClient              *ClientManager
+	scheduler             *tasks.Scheduler
+	canvasInflight        sync.Map
+	canvasClassesInflight sync.Map
 }
 
 type routeDef struct {
@@ -276,6 +278,7 @@ const (
 	LoginMetrics   string = "login_metrics"
 	AdminLayer2    string = "admin_layer_2"
 	CanvasPrograms string = "canvas_programs"
+	CanvasClasses  string = "canvas_classes"
 )
 
 func (srv *Server) setupNatsKvBuckets() error {
@@ -285,7 +288,7 @@ func (srv *Server) setupNatsKvBuckets() error {
 		return err
 	}
 	buckets := map[string]nats.KeyValue{}
-	for _, bucket := range []string{CachedUsers, LibraryPaths, LoginMetrics, OAuthState, AdminLayer2, CanvasPrograms} {
+	for _, bucket := range []string{CachedUsers, LibraryPaths, LoginMetrics, OAuthState, AdminLayer2, CanvasPrograms, CanvasClasses} {
 		kv, err := js.KeyValue(bucket)
 		if err != nil {
 			cfg := &nats.KeyValueConfig{
@@ -299,6 +302,8 @@ func (srv *Server) setupNatsKvBuckets() error {
 				cfg.TTL = time.Minute * 10
 			case CanvasPrograms:
 				cfg.TTL = time.Minute * 5
+			case CanvasClasses:
+				cfg.TTL = time.Hour * 1
 			default:
 				cfg.TTL = time.Hour * 24
 			}
@@ -312,6 +317,15 @@ func (srv *Server) setupNatsKvBuckets() error {
 	}
 	srv.buckets = buckets
 	return nil
+}
+
+func (srv *Server) hasFeatureAccess(axx ...models.FeatureAccess) bool {
+	for _, a := range axx {
+		if !slices.Contains(srv.features, a) {
+			return false
+		}
+	}
+	return true
 }
 
 func (srv *Server) checkForAdminInKratos(ctx context.Context) (string, error) {

--- a/backend/src/handlers/user_matching.go
+++ b/backend/src/handlers/user_matching.go
@@ -198,7 +198,7 @@ func (srv *Server) handleApplyMatches(w http.ResponseWriter, r *http.Request, lo
 			failed = append(failed, c.CanvasUser.Username)
 			continue
 		}
-		srv.invalidateCanvasProgramCache(service.ProviderPlatformID, int(c.UnlockEdUserID))
+		srv.invalidateCanvasCachesForUser(service.ProviderPlatformID, int(c.UnlockEdUserID))
 		if provider.OidcID != 0 {
 			if err := srv.registerProviderLogin(provider, user); err != nil {
 				log.errorf("error registering provider login for user %d: %v", c.UnlockEdUserID, err)
@@ -246,7 +246,7 @@ func (srv *Server) handleApplyMatches(w http.ResponseWriter, r *http.Request, lo
 			failed = append(failed, cu.Username)
 			continue
 		}
-		srv.invalidateCanvasProgramCache(service.ProviderPlatformID, int(newUser.ID))
+		srv.invalidateCanvasCachesForUser(service.ProviderPlatformID, int(newUser.ID))
 		if provider.OidcID != 0 {
 			if err := srv.registerProviderLogin(provider, &newUser); err != nil {
 				log.errorf("error registering provider login for %s: %v", cu.Username, err)

--- a/backend/src/models/resource.go
+++ b/backend/src/models/resource.go
@@ -32,6 +32,7 @@ type PaginationMeta struct {
 	LastPage    int   `json:"last_page"`
 	PerPage     int   `json:"per_page"`
 	Total       int64 `json:"total"`
+	CanvasLoading bool `json:"canvas_loading,omitempty"`
 }
 
 func NewPaginationInfo(currentPage, perPage int, total int64) PaginationMeta {

--- a/frontend/src/pages/ClassesPage.tsx
+++ b/frontend/src/pages/ClassesPage.tsx
@@ -1,5 +1,6 @@
 import { useState, useMemo, useEffect } from 'react';
 import { useUrlPagination } from '@/hooks/useUrlPagination';
+import { useCanvasLoadingPoll } from '@/hooks/useCanvasLoadingPoll';
 import { useNavigate, Link } from 'react-router-dom';
 import useSWR from 'swr';
 import { useAuth, canSwitchFacility } from '@/auth/useAuth';
@@ -40,7 +41,8 @@ import {
     Filter,
     MapPin,
     Users,
-    RefreshCw
+    RefreshCw,
+    Loader2
 } from 'lucide-react';
 
 const CANVAS_CLASS_ID_OFFSET = 100_000_000;
@@ -110,6 +112,13 @@ export default function ClassesPage() {
         : '/api/program-classes?per_page=100';
     const { data: classesResp, mutate: mutateClasses } =
         useSWR<ServerResponseMany<Class>>(classesUrl);
+    // Canvas classes are served from a background-refreshed cache, so the first
+    // load can come back with only the local classes. Poll until Canvas is in.
+    const canvasSyncing = classesResp?.meta?.canvas_loading ?? false;
+    const { exhausted: canvasPollExhausted } = useCanvasLoadingPoll(
+        canvasSyncing,
+        mutateClasses
+    );
     const programsUrl =
         showCreateModal || showFacilityModal
             ? `/api/programs?per_page=100${programSearch ? `&search=${encodeURIComponent(programSearch)}` : ''}${selectedFacilityForClass ? `&facility_id=${selectedFacilityForClass}` : ''}`
@@ -128,7 +137,9 @@ export default function ClassesPage() {
     const facilityClasses = useMemo(() => {
         if (crossFacility || !user) return allClasses;
         return allClasses.filter(
-            (c) => c.id >= CANVAS_CLASS_ID_OFFSET || c.facility_id === user.facility.id
+            (c) =>
+                c.id >= CANVAS_CLASS_ID_OFFSET ||
+                c.facility_id === user.facility.id
         );
     }, [allClasses, crossFacility, user]);
 
@@ -383,12 +394,31 @@ export default function ClassesPage() {
                     </div>
                 </div>
 
-                <div className="mb-4 text-sm text-gray-600">
-                    Showing {filteredClasses.length}{' '}
-                    {filteredClasses.length === 1 ? 'class' : 'classes'}
-                    {todayOnly &&
-                        ` scheduled for today (${new Date().toLocaleDateString('en-US', { weekday: 'long' })})`}
-                    {attendanceConcerns && ' with attendance concerns'}
+                <div className="mb-4 flex items-center gap-3 text-sm text-gray-600">
+                    <span>
+                        Showing {filteredClasses.length}{' '}
+                        {filteredClasses.length === 1 ? 'class' : 'classes'}
+                        {todayOnly &&
+                            ` scheduled for today (${new Date().toLocaleDateString('en-US', { weekday: 'long' })})`}
+                        {attendanceConcerns && ' with attendance concerns'}
+                    </span>
+                    {canvasSyncing &&
+                        (canvasPollExhausted ? (
+                            <span className="text-xs text-amber-600">
+                                Canvas classes are taking longer than expected —{' '}
+                                <button
+                                    className="underline"
+                                    onClick={() => void mutateClasses()}
+                                >
+                                    retry
+                                </button>
+                            </span>
+                        ) : (
+                            <span className="flex items-center gap-1.5 text-xs text-blue-600">
+                                <Loader2 className="size-3 animate-spin text-blue-500" />
+                                Syncing classes from Canvas…
+                            </span>
+                        ))}
                 </div>
 
                 <div className="card-block overflow-hidden">
@@ -438,7 +468,11 @@ export default function ClassesPage() {
                                         key={cls.id}
                                         cls={cls}
                                         showFacility={crossFacility}
-                                        onClick={() => navigate(`/program-classes/${cls.id}/detail`)}
+                                        onClick={() =>
+                                            navigate(
+                                                `/program-classes/${cls.id}/detail`
+                                            )
+                                        }
                                         onAttendance={() =>
                                             setAttendanceClass(cls)
                                         }
@@ -641,7 +675,9 @@ function ClassRow({
             onClick={onClick}
             className={cn(
                 'transition-colors',
-                onClick ? 'hover:bg-surface-hover/50 cursor-pointer' : 'cursor-default'
+                onClick
+                    ? 'hover:bg-surface-hover/50 cursor-pointer'
+                    : 'cursor-default'
             )}
         >
             <td className="px-6 py-4">
@@ -733,7 +769,10 @@ function ClassRow({
             </td>
             <td className="px-6 py-4">
                 {isCanvas && (
-                    <Badge variant="outline" className="text-blue-700 border-blue-300 bg-blue-50 gap-1 whitespace-nowrap">
+                    <Badge
+                        variant="outline"
+                        className="text-blue-700 border-blue-300 bg-blue-50 gap-1 whitespace-nowrap"
+                    >
                         <RefreshCw className="size-3" />
                         Canvas
                     </Badge>

--- a/frontend/src/types/server.ts
+++ b/frontend/src/types/server.ts
@@ -5,6 +5,7 @@ export interface PaginationMeta {
     current_page: number;
     last_page: number;
     per_page: number;
+    canvas_loading?: boolean;
 }
 
 export interface ServerResponseBase {


### PR DESCRIPTION
## DO NOT REVIEW PLEASE


## Pre-Submission PR Checklist

- [X] No debug/console/fmt.Println statements
- [X] Unnecessary development comments removed
- [X] All acceptance criteria verified
- [x] Functions according to **ticket specifications**
- [X] Tested manually where applicable
- [x] Branch rebased with latest main
- [X] No business logic exists within the database layer

## Description of the change

Added code for handling the long running canvas api calls so that the screen doesn't appear locked.

- **Related issues**: Link to related Asana ticket that this closes: [Classes taking a really long time to load in demo](https://app.asana.com/1/1201607307149189/project/1209460078641109/task/1216839254575425?focus=true)

NOTE: To test click the classes link in the nav bar to test.