### PR TITLE
feat: add logic for feature flagging resident facing page for programs while program hub is enabled per ticket id 754

### DIFF
--- a/backend/migrations/00072_add_resident_programs_feature.sql
+++ b/backend/migrations/00072_add_resident_programs_feature.sql
@@ -1,0 +1,28 @@
+-- +goose Up
+-- +goose NO TRANSACTION
+-- A newly added enum value cannot be referenced inside the transaction that adds
+-- it, so this migration runs unwrapped and the INSERT below autocommits separately.
+ALTER TYPE feature ADD VALUE IF NOT EXISTS 'resident_programs';
+
+-- Resident-facing visibility of the Programs page is ON by default: once program
+-- tracking is enabled, residents keep access to their own program information
+-- unless an admin explicitly turns it off for their facility.
+INSERT INTO public.page_feature_flags (feature_flag_id, page_feature, enabled, created_at)
+SELECT id, 'resident_programs', TRUE, now()
+FROM public.feature_flags WHERE name = 'program_management'
+ON CONFLICT (page_feature) DO NOTHING;
+
+-- +goose Down
+-- +goose NO TRANSACTION
+DELETE FROM public.facility_feature_flags WHERE feature = 'resident_programs';
+DELETE FROM public.page_feature_flags WHERE page_feature = 'resident_programs';
+
+ALTER TYPE feature RENAME TO feature_old;
+
+CREATE TYPE feature AS ENUM ('open_content', 'provider_platforms', 'program_management', 'request_content', 'helpful_links', 'upload_video', 'learning_record');
+
+ALTER TABLE public.feature_flags ALTER COLUMN name TYPE feature USING name::text::feature;
+ALTER TABLE public.page_feature_flags ALTER COLUMN page_feature TYPE feature USING page_feature::text::feature;
+ALTER TABLE public.facility_feature_flags ALTER COLUMN feature TYPE feature USING feature::text::feature;
+
+DROP TYPE feature_old;

--- a/backend/src/handlers/class_events.go
+++ b/backend/src/handlers/class_events.go
@@ -16,7 +16,7 @@ func (srv *Server) registerClassEventsRoutes() []routeDef {
 	axx := models.ProgramAccess
 	resolver := FacilityAdminResolver("program_classes", "class_id")
 	return []routeDef{
-		featureRoute("GET /api/student-calendar", srv.handleGetStudentCalendar, axx),
+		validatedFeatureRoute("GET /api/student-calendar", srv.handleGetStudentCalendar, axx, ResidentFeatureResolver(models.ResidentProgramsAccess)),
 		featureRoute("GET /api/program-classes/{class_id}/events", srv.handleGetProgramClassEvents, axx),
 		adminFeatureRoute("GET /api/program-classes/{class_id}/canvas-schedule", srv.handleGetCanvasClassSchedule, axx),
 		/* admin */

--- a/backend/src/handlers/middleware.go
+++ b/backend/src/handlers/middleware.go
@@ -302,3 +302,28 @@ func UserRoleResolver(routeId string) RouteResolver {
 		return err == nil && user.FacilityID == claims.FacilityID
 	}
 }
+
+func ResidentFeatureResolver(feature models.FeatureAccess) RouteResolver {
+	return func(tx *database.DB, r *http.Request) bool {
+		claims, ok := r.Context().Value(ClaimsKey).(*Claims)
+		if !ok {
+			return false
+		}
+		if slices.Contains(models.AdminRoles, claims.Role) {
+			return true
+		}
+		return claims.hasFeatureAccess(feature)
+	}
+}
+
+// AllResolvers passes only when every resolver passes, for routes that need more than one check.
+func AllResolvers(resolvers ...RouteResolver) RouteResolver {
+	return func(tx *database.DB, r *http.Request) bool {
+		for _, resolve := range resolvers {
+			if !resolve(tx, r) {
+				return false
+			}
+		}
+		return true
+	}
+}

--- a/backend/src/handlers/user_handler.go
+++ b/backend/src/handlers/user_handler.go
@@ -23,7 +23,8 @@ func (srv *Server) registerUserRoutes() []routeDef {
 	resolver := UserRoleResolver("id")
 	return []routeDef{
 		validatedRoute("GET /api/users/{id}", srv.handleShowUser, resolver),
-		validatedRoute("GET /api/users/{id}/programs", srv.handleGetUserPrograms, resolver),
+		validatedRoute("GET /api/users/{id}/programs", srv.handleGetUserPrograms,
+			AllResolvers(resolver, ResidentFeatureResolver(models.ResidentProgramsAccess))),
 		validatedRoute("GET /api/users/{id}/attendance-trend", srv.handleGetUserAttendanceTrend, resolver),
 		validatedRoute("GET /api/users/{id}/notes", srv.handleGetUserNotes, resolver),
 		validatedAdminRoute("POST /api/users/{id}/notes", srv.handleCreateUserNote, FacilityAdminResolver("users", "id")),

--- a/backend/src/models/feature_flags.go
+++ b/backend/src/models/feature_flags.go
@@ -41,13 +41,14 @@ const (
 	ProgramAccess        FeatureAccess = "program_management"
 	LearningRecordAccess FeatureAccess = "learning_record"
 
-	// these are the page level features
-	RequestContentAccess FeatureAccess = "request_content"
-	HelpfulLinksAccess   FeatureAccess = "helpful_links"
-	UploadVideoAccess    FeatureAccess = "upload_video"
+	// these are the page/sub level features
+	RequestContentAccess   FeatureAccess = "request_content"
+	HelpfulLinksAccess     FeatureAccess = "helpful_links"
+	UploadVideoAccess      FeatureAccess = "upload_video"
+	ResidentProgramsAccess FeatureAccess = "resident_programs"
 )
 
-var AllFeatures = []FeatureAccess{OpenContentAccess, ProviderAccess, ProgramAccess, LearningRecordAccess, RequestContentAccess, HelpfulLinksAccess, UploadVideoAccess}
+var AllFeatures = []FeatureAccess{OpenContentAccess, ProviderAccess, ProgramAccess, LearningRecordAccess, RequestContentAccess, HelpfulLinksAccess, UploadVideoAccess, ResidentProgramsAccess}
 
 // TopLevelFeatures are the features shown as their own card/pill on the Feature Control
 // page. Page-level (sub-)features are nested under their parent below.
@@ -56,9 +57,10 @@ var TopLevelFeatures = []FeatureAccess{OpenContentAccess, ProviderAccess, Progra
 // SubFeatureParent maps a page-level feature to the top-level feature that gates it:
 // a sub-feature can never be enabled at a facility where its parent is disabled.
 var SubFeatureParent = map[FeatureAccess]FeatureAccess{
-	RequestContentAccess: OpenContentAccess,
-	HelpfulLinksAccess:   OpenContentAccess,
-	UploadVideoAccess:    OpenContentAccess,
+	RequestContentAccess:   OpenContentAccess,
+	HelpfulLinksAccess:     OpenContentAccess,
+	UploadVideoAccess:      OpenContentAccess,
+	ResidentProgramsAccess: ProgramAccess,
 }
 
 func Feature(kinds ...FeatureAccess) []FeatureAccess {

--- a/backend/tests/integration/resident_programs_feature_test.go
+++ b/backend/tests/integration/resident_programs_feature_test.go
@@ -1,0 +1,143 @@
+package integration
+
+import (
+	"UnlockEdv2/src/handlers"
+	"UnlockEdv2/src/models"
+	"fmt"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// resident_programs governs only the resident-facing Programs page. It defaults
+// to on wherever program tracking is on, cascades off with its parent, and never
+// changes what an admin can see.
+func TestResidentProgramsAccess_EffectiveState(t *testing.T) {
+	env = SetupTestEnv(t)
+	defer env.CleanupTestEnv()
+
+	facility, err := env.CreateTestFacility("Resident Programs Facility")
+	require.NoError(t, err)
+
+	statewide := []models.FeatureAccess{models.ProgramAccess, models.ResidentProgramsAccess}
+	args := &models.QueryContext{Ctx: env.Context}
+
+	t.Run("defaults to on once program tracking is on", func(t *testing.T) {
+		effective, err := env.DB.GetFacilityFeatureAccess(facility.ID, statewide)
+		require.NoError(t, err)
+		require.Contains(t, effective, models.ResidentProgramsAccess,
+			"an admin must take an explicit action to hide the Programs page")
+	})
+
+	t.Run("turning it off leaves program tracking itself on", func(t *testing.T) {
+		require.NoError(t, env.DB.UpsertFacilityFeatureFlag(args, facility.ID, models.ResidentProgramsAccess, false, statewide))
+
+		effective, err := env.DB.GetFacilityFeatureAccess(facility.ID, statewide)
+		require.NoError(t, err)
+		require.NotContains(t, effective, models.ResidentProgramsAccess)
+		require.Contains(t, effective, models.ProgramAccess)
+	})
+
+	t.Run("turning it back on restores resident visibility", func(t *testing.T) {
+		require.NoError(t, env.DB.UpsertFacilityFeatureFlag(args, facility.ID, models.ResidentProgramsAccess, true, statewide))
+
+		effective, err := env.DB.GetFacilityFeatureAccess(facility.ID, statewide)
+		require.NoError(t, err)
+		require.Contains(t, effective, models.ResidentProgramsAccess)
+	})
+
+	// If program tracking is later turned off entirely, the Programs page must
+	// behave as if the flag is off regardless of its last set value.
+	t.Run("disabling program tracking cascades even with the flag left on", func(t *testing.T) {
+		require.NoError(t, env.DB.UpsertFacilityFeatureFlag(args, facility.ID, models.ProgramAccess, false, statewide))
+
+		effective, err := env.DB.GetFacilityFeatureAccess(facility.ID, statewide)
+		require.NoError(t, err)
+		require.NotContains(t, effective, models.ProgramAccess)
+		require.NotContains(t, effective, models.ResidentProgramsAccess,
+			"resident_programs is still stored as enabled, but its parent is off")
+
+		err = env.DB.UpsertFacilityFeatureFlag(args, facility.ID, models.ResidentProgramsAccess, true, statewide)
+		require.Error(t, err, "the flag isn't toggleable while program tracking is off")
+	})
+
+	t.Run("cannot be enabled for one facility when disabled statewide", func(t *testing.T) {
+		programOnly := []models.FeatureAccess{models.ProgramAccess}
+		err := env.DB.UpsertFacilityFeatureFlag(args, facility.ID, models.ResidentProgramsAccess, true, programOnly)
+		require.Error(t, err)
+	})
+}
+
+// Direct navigation to the resident Programs page must not render, which means
+// the endpoints behind it have to refuse the resident — not just the nav item
+// disappearing client-side.
+func TestResidentProgramsAccess_RouteGating(t *testing.T) {
+	env = SetupTestEnv(t)
+	defer env.CleanupTestEnv()
+
+	facility, err := env.CreateTestFacility("Resident Programs Route Facility")
+	require.NoError(t, err)
+	resident, err := env.CreateTestUser("residentprograms", models.Student, facility.ID, "")
+	require.NoError(t, err)
+
+	withPage := []models.FeatureAccess{models.ProgramAccess, models.ResidentProgramsAccess}
+	withoutPage := []models.FeatureAccess{models.ProgramAccess}
+
+	residentClaims := func(features []models.FeatureAccess) *handlers.Claims {
+		return &handlers.Claims{
+			UserID:        resident.ID,
+			Role:          models.Student,
+			FacilityID:    facility.ID,
+			FeatureAccess: features,
+		}
+	}
+	programsURL := fmt.Sprintf("/api/users/%d/programs", resident.ID)
+	calendarURL := "/api/student-calendar"
+
+	// handleGetUserPrograms runs raw Postgres-only SQL, so it can't return 200
+	// against the in-memory SQLite test DB. Asserting "not refused" is what this
+	// test is actually about: the gate let the request through to the handler.
+	expectNotRefused := func(t *testing.T, claims *handlers.Claims, url string) {
+		t.Helper()
+		resp := NewRequest[any](env.Client, t, http.MethodGet, url, nil).
+			WithTestClaims(claims).
+			Do()
+		require.NotEqual(t, http.StatusUnauthorized, resp.resp.StatusCode,
+			"the resident_programs gate must not block this caller")
+	}
+
+	t.Run("resident with the page enabled reaches their programs", func(t *testing.T) {
+		expectNotRefused(t, residentClaims(withPage), programsURL)
+	})
+
+	t.Run("resident with the page enabled reaches the class calendar", func(t *testing.T) {
+		NewRequest[any](env.Client, t, http.MethodGet, calendarURL, nil).
+			WithTestClaims(residentClaims(withPage)).
+			Do().
+			ExpectStatus(http.StatusOK)
+	})
+
+	t.Run("resident with the page hidden is refused their programs", func(t *testing.T) {
+		NewRequest[any](env.Client, t, http.MethodGet, programsURL, nil).
+			WithTestClaims(residentClaims(withoutPage)).
+			Do().
+			ExpectStatus(http.StatusUnauthorized)
+	})
+
+	t.Run("resident with the page hidden is refused the class calendar", func(t *testing.T) {
+		NewRequest[any](env.Client, t, http.MethodGet, calendarURL, nil).
+			WithTestClaims(residentClaims(withoutPage)).
+			Do().
+			ExpectStatus(http.StatusUnauthorized)
+	})
+
+	// Hiding the page from residents must not touch any admin-side view.
+	t.Run("admin without the flag still sees the resident's programs", func(t *testing.T) {
+		expectNotRefused(t, &handlers.Claims{
+			Role:          models.FacilityAdmin,
+			FacilityID:    facility.ID,
+			FeatureAccess: withoutPage,
+		}, programsURL)
+	})
+}

--- a/frontend/src/auth/useAuth.ts
+++ b/frontend/src/auth/useAuth.ts
@@ -202,7 +202,10 @@ const getResidentLink = (user: User): string => {
     ) {
         return '/home';
     }
-    if (user.feature_access.includes(FeatureAccess.ProgramAccess)) {
+    if (
+        user.feature_access.includes(FeatureAccess.ProgramAccess) &&
+        user.feature_access.includes(FeatureAccess.ResidentProgramsAccess)
+    ) {
         return '/resident-programs';
     }
     return '/temp-home';

--- a/frontend/src/components/navigation/Sidebar.tsx
+++ b/frontend/src/components/navigation/Sidebar.tsx
@@ -311,7 +311,13 @@ function StudentNav({
         user,
         FeatureAccess.LearningRecordAccess
     );
-    const hasProgram = hasFeature(user, FeatureAccess.ProgramAccess);
+    // Residents only see Programs when program tracking is on *and* the
+    // resident-facing sub-feature hasn't been turned off for their facility.
+    const hasProgram = hasFeature(
+        user,
+        FeatureAccess.ProgramAccess,
+        FeatureAccess.ResidentProgramsAccess
+    );
     const hasHome = hasOpen || hasLearningRecord;
 
     const tourHighlight = (target: string) =>

--- a/frontend/src/pages/admin/FeatureControl.tsx
+++ b/frontend/src/pages/admin/FeatureControl.tsx
@@ -77,30 +77,59 @@ const FEATURE_CARDS: {
 const FEATURE_LABELS: Partial<Record<FeatureAccess, string>> =
     Object.fromEntries(FEATURE_CARDS.map((c) => [c.feature, c.title]));
 
-const SUB_FEATURES: {
+interface SubFeature {
     feature: FeatureAccess;
     label: string;
     description: string;
-}[] = [
-    {
-        feature: FeatureAccess.RequestContentAccess,
-        label: 'Request Content Button',
-        description:
-            'Allows residents to submit requests for new content to be added to the Knowledge Center'
+}
+
+// Sub-features nested under the top-level feature that gates them. `note` is the
+// line above the group explaining when the group applies — for Programs it also
+// explains why the default is on, so admins read turning it off as a deliberate
+// setup step rather than a suggested one. A group whose parent is off stays
+// visible but disabled, so admins can see which sub-features exist.
+const SUB_FEATURE_GROUPS: Partial<
+    Record<FeatureAccess, { note: string; features: SubFeature[] }>
+> = {
+    [FeatureAccess.OpenContentAccess]: {
+        note: 'Sub-features (only available when Knowledge Center is enabled)',
+        features: [
+            {
+                feature: FeatureAccess.RequestContentAccess,
+                label: 'Request Content Button',
+                description:
+                    'Allows residents to submit requests for new content to be added to the Knowledge Center'
+            },
+            {
+                feature: FeatureAccess.HelpfulLinksAccess,
+                label: 'Helpful Links',
+                description:
+                    'Enables the Helpful Links tab for residents and allows admins to add/manage helpful resources'
+            },
+            {
+                feature: FeatureAccess.UploadVideoAccess,
+                label: 'Videos',
+                description:
+                    'Enables video content viewing for residents and allows admins to upload/manage videos'
+            }
+        ]
     },
-    {
-        feature: FeatureAccess.HelpfulLinksAccess,
-        label: 'Helpful Links',
-        description:
-            'Enables the Helpful Links tab for residents and allows admins to add/manage helpful resources'
-    },
-    {
-        feature: FeatureAccess.UploadVideoAccess,
-        label: 'Videos',
-        description:
-            'Enables video content viewing for residents and allows admins to upload/manage videos'
+    [FeatureAccess.ProgramAccess]: {
+        note: 'Residents can see their own program information by default (only available when Program Hub & Tracking is enabled).',
+        features: [
+            {
+                feature: FeatureAccess.ResidentProgramsAccess,
+                label: 'Programs Page for Residents',
+                description:
+                    'Shows the Programs page and its nav item in the resident portal. Program tracking, data, and admin views are unaffected either way.'
+            }
+        ]
     }
-];
+};
+
+const ALL_SUB_FEATURES: SubFeature[] = Object.values(
+    SUB_FEATURE_GROUPS
+).flatMap((group) => group.features);
 
 type FilterValue = 'all' | `${FeatureAccess}:true` | `${FeatureAccess}:false`;
 
@@ -141,7 +170,7 @@ function SubFeatureRow({
     disabled,
     onToggle
 }: {
-    sub: (typeof SUB_FEATURES)[number];
+    sub: SubFeature;
     enabled: boolean;
     disabled: boolean;
     onToggle: () => void;
@@ -228,8 +257,6 @@ export default function FeatureControl() {
 
     if (!user) return null;
 
-    const kcEnabled = isEnabled(FeatureAccess.OpenContentAccess);
-
     async function refreshOwnClaimsIfAffected(facilityId: number) {
         if (user?.facility_id === facilityId) {
             const updated = await fetchUser();
@@ -241,7 +268,7 @@ export default function FeatureControl() {
         if (selectedFacilityId === null || pendingFeature !== null) return;
         const label =
             FEATURE_LABELS[feature] ??
-            SUB_FEATURES.find((s) => s.feature === feature)?.label ??
+            ALL_SUB_FEATURES.find((s) => s.feature === feature)?.label ??
             feature;
         setPendingFeature(feature);
         try {
@@ -428,6 +455,8 @@ export default function FeatureControl() {
                             <div className="space-y-4">
                                 {FEATURE_CARDS.map((card) => {
                                     const enabled = isEnabled(card.feature);
+                                    const subGroup =
+                                        SUB_FEATURE_GROUPS[card.feature];
                                     return (
                                         <div
                                             key={card.feature}
@@ -459,20 +488,16 @@ export default function FeatureControl() {
                                                 />
                                             </div>
 
-                                            {card.feature ===
-                                                FeatureAccess.OpenContentAccess && (
+                                            {subGroup && (
                                                 <div className="mt-4 bg-surface-hover rounded-md p-4">
                                                     <div className="flex items-start gap-2 mb-4 text-sm text-muted-foreground">
                                                         <AlertCircle className="size-4 shrink-0" />
                                                         <span>
-                                                            Sub-features (only
-                                                            available when
-                                                            Knowledge Center is
-                                                            enabled)
+                                                            {subGroup.note}
                                                         </span>
                                                     </div>
                                                     <div className="space-y-4">
-                                                        {SUB_FEATURES.map(
+                                                        {subGroup.features.map(
                                                             (sub) => {
                                                                 const subEnabled =
                                                                     isEnabled(
@@ -490,7 +515,7 @@ export default function FeatureControl() {
                                                                             subEnabled
                                                                         }
                                                                         disabled={
-                                                                            !kcEnabled ||
+                                                                            !enabled ||
                                                                             pendingFeature !==
                                                                                 null ||
                                                                             detailLoading

--- a/frontend/src/routes/program-routes.tsx
+++ b/frontend/src/routes/program-routes.tsx
@@ -36,7 +36,10 @@ export const ProgramRoutes = declareAuthenticatedRoutes(
         }
     ],
     [UserRole.Student],
-    [FeatureAccess.ProgramAccess]
+    // ResidentProgramsAccess is the resident-facing visibility sub-feature; when an
+    // admin turns it off (or program tracking itself is off) the route falls through
+    // to the auth callback rather than rendering.
+    [FeatureAccess.ProgramAccess, FeatureAccess.ResidentProgramsAccess]
 );
 
 export const DeptAdminProgramRoutes = declareAuthenticatedRoutes(

--- a/frontend/src/types/user.ts
+++ b/frontend/src/types/user.ts
@@ -22,7 +22,8 @@ export enum FeatureAccess {
     LearningRecordAccess = 'learning_record',
     RequestContentAccess = 'request_content',
     HelpfulLinksAccess = 'helpful_links',
-    UploadVideoAccess = 'upload_video'
+    UploadVideoAccess = 'upload_video',
+    ResidentProgramsAccess = 'resident_programs'
 }
 
 export interface User {


### PR DESCRIPTION
## Pre-Submission PR Checklist

- [X] No debug/console/fmt.Println statements
- [X] Unnecessary development comments removed
- [X] All acceptance criteria verified
- [X] Functions according to **ticket specifications**
- [X] Tested manually where applicable
- [X] Branch rebased with latest main
- [X] No business logic exists within the database layer

## Description of the change

Added feature flag for turning on/off resident facing view of the programs listing while program hub is enabled for admins.

NOTE: log on as resident to see that the programs list doesn't exist when the program hub is enabled and the programs is disabled for residents

- **Related issues**: Link to related Asana ticket that this closes: [Feature flag "programs" page in resident view](https://app.asana.com/1/1201607307149189/project/1209460078641109/task/1216839164978428?focus=true)


https://github.com/user-attachments/assets/92697186-1f56-469f-9202-96e22c373460

