### PR TITLE
PostHog Behavioral Graphs for SMWRC Learning Record Pilot

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -35,3 +35,11 @@ CORS_ALLOWED_ORIGINS=http://localhost,http://127.0.0.1
 
 VITE_PUBLIC_POSTHOG_KEY=your_posthog_project_api_key
 VITE_PUBLIC_POSTHOG_HOST=https://us.i.posthog.com
+
+# Analytics is OFF unless VITE_DEPLOYMENT is set AND the key above is a real
+# phc_-prefixed project key. Deployed images get these at build time; leave them
+# blank for local development. To deliberately send from local, set
+# VITE_DEPLOYMENT=local — every event is then tagged so it can be excluded in
+# PostHog rather than mixed into facility data.
+VITE_DEPLOYMENT=
+VITE_STATE=

--- a/.github/workflows/container_builds.yml
+++ b/.github/workflows/container_builds.yml
@@ -127,8 +127,6 @@ jobs:
                     VITE_STATE=mocode
                   elif [[ "${GITHUB_REF}" == "refs/heads/demov2" ]]; then
                     # Public demo runs on seeded fake data — noise, not signal.
-                    POSTHOG_KEY=placeholder_for_other_deployments
-                    POSTHOG_HOST=placeholder_for_other_deployments
                     VITE_DEPLOYMENT=development
                     VITE_STATE=demo
                   else

--- a/.github/workflows/container_builds.yml
+++ b/.github/workflows/container_builds.yml
@@ -109,10 +109,14 @@ jobs:
               case $path in
                 "frontend/")
                   echo "Building frontend image"
-                  POSTHOG_KEY=placeholder_for_other_deployments
-                  POSTHOG_HOST=placeholder_for_other_deployments
+                  # Deployments that report to PostHog get the real key; every
+                  # event is tagged with VITE_DEPLOYMENT + VITE_STATE so the
+                  # facilities can be told apart from staging. Builds that should
+                  # not report get a placeholder key, which the frontend rejects
+                  # because it is not phc_-prefixed.
+                  POSTHOG_KEY=${{ secrets.POSTHOG_KEY }}
+                  POSTHOG_HOST=${{ secrets.POSTHOG_HOST }}
                   VITE_DEPLOYMENT=production
-                  # Set environment-specific secrets
                   if [[ "${GITHUB_REF}" == "refs/heads/stlouis" ]]; then
                     VITE_STATE=stlouis
                   elif [[ "${GITHUB_REF}" == "refs/heads/maine" ]]; then
@@ -122,11 +126,12 @@ jobs:
                   elif [[ "${GITHUB_REF}" == "refs/heads/mocode" ]]; then
                     VITE_STATE=mocode
                   elif [[ "${GITHUB_REF}" == "refs/heads/demov2" ]]; then
+                    # Public demo runs on seeded fake data — noise, not signal.
+                    POSTHOG_KEY=placeholder_for_other_deployments
+                    POSTHOG_HOST=placeholder_for_other_deployments
                     VITE_DEPLOYMENT=development
                     VITE_STATE=demo
                   else
-                    POSTHOG_KEY=${{ secrets.POSTHOG_KEY }}
-                    POSTHOG_HOST=${{ secrets.POSTHOG_HOST }}
                     VITE_DEPLOYMENT=development
                     VITE_STATE=staging
                   fi

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -30,6 +30,8 @@ services:
     environment:
       - VITE_PUBLIC_POSTHOG_KEY=${VITE_PUBLIC_POSTHOG_KEY}
       - VITE_PUBLIC_POSTHOG_HOST=${VITE_PUBLIC_POSTHOG_HOST}
+      - VITE_DEPLOYMENT=${VITE_DEPLOYMENT}
+      - VITE_STATE=${VITE_STATE}
 
   kiwix:
     image: jamescherti/kiwix-serve:latest

--- a/frontend/src/api/api.ts
+++ b/frontend/src/api/api.ts
@@ -3,7 +3,7 @@ import {
     ServerResponseOne,
     ServerResponseMany
 } from '@/types/server';
-import { ANALYTICS_EVENTS, captureEvent } from '@/lib/events';
+import { ANALYTICS_EVENTS, analyticsUrl, captureEvent } from '@/lib/events';
 
 class API {
     private static getCSRFToken(): string {
@@ -118,7 +118,7 @@ class API {
             captureEvent(ANALYTICS_EVENTS.ApiError, {
                 status: errCode ?? 0,
                 method,
-                url,
+                ...analyticsUrl(url),
                 message: error.message || 'An error occurred'
             });
             return {

--- a/frontend/src/api/swrFetcher.ts
+++ b/frontend/src/api/swrFetcher.ts
@@ -1,0 +1,47 @@
+import { ANALYTICS_EVENTS, analyticsUrl, captureEvent } from '@/lib/events';
+
+/**
+ * Global SWR fetcher.
+ *
+ * Lives here rather than inline in `main.tsx` so failures can report to the same
+ * `api_error` event the `API.*` wrapper uses. SWR powers most of the app's
+ * page-load GETs, so before this every one of those failures was invisible to
+ * analytics — "error states hit during common flows" was missing the most common
+ * flow of all, loading a page.
+ *
+ * Errors are captured and then rethrown unchanged, so SWR's own error handling
+ * behaves exactly as it did.
+ */
+export const swrFetcher = async (url: string): Promise<unknown> => {
+    let res: Response;
+    try {
+        res = await fetch(url, {
+            credentials: 'include',
+            headers: {
+                'X-Requested-With': 'XMLHttpRequest',
+                Accept: 'application/json',
+                'Content-Type': 'application/json'
+            }
+        });
+    } catch (err) {
+        // Network-level failure: no HTTP status exists, so report 0 to match the
+        // convention in api.ts.
+        captureEvent(ANALYTICS_EVENTS.ApiError, {
+            status: 0,
+            method: 'GET',
+            ...analyticsUrl(url),
+            message: err instanceof Error ? err.message : 'Network error'
+        });
+        throw err;
+    }
+    if (!res.ok) {
+        captureEvent(ANALYTICS_EVENTS.ApiError, {
+            status: res.status,
+            method: 'GET',
+            ...analyticsUrl(url),
+            message: res.statusText || `HTTP ${res.status}`
+        });
+        throw new Error(res.statusText);
+    }
+    return res.json() as Promise<unknown>;
+};

--- a/frontend/src/lib/events.ts
+++ b/frontend/src/lib/events.ts
@@ -20,6 +20,14 @@ export const ANALYTICS_EVENTS = {
     EnrollModalOpened: 'enroll_modal_opened',
     EnrollResidentsSelected: 'enroll_residents_selected',
     EnrollCompleted: 'enroll_completed',
+    // Learning Record form behavior (ID-806). Question-level timing and
+    // interaction rates. Properties are counts and enums only — never answer
+    // content — because the resident consent language promises anonymized
+    // aggregate data. See learningRecordAnalytics.ts for the single mapper.
+    LrEntryStarted: 'lr_entry_started',
+    LrQuestionLeft: 'lr_question_left',
+    LrStepCompleted: 'lr_step_completed',
+    LrEntryCompleted: 'lr_entry_completed',
     // Errors & friction
     ApiError: 'api_error'
 } as const;
@@ -29,6 +37,105 @@ export type AnalyticsEvent =
 
 type AnalyticsValue = string | number | boolean | null | undefined;
 export type AnalyticsProps = Record<string, AnalyticsValue>;
+
+/**
+ * Which deployment these events came from. Registered as super properties so
+ * they ride on *every* event, including autocaptured `$pageview`/`$exception` —
+ * without them, staging traffic and real facility traffic are indistinguishable
+ * in the pilot dashboard (both serve from real hostnames, so PostHog's built-in
+ * localhost/127.0.0.1 internal-user tagging doesn't separate them).
+ */
+function deploymentProps(): AnalyticsProps {
+    return {
+        deployment: import.meta.env.VITE_DEPLOYMENT,
+        state: stateTag()
+    };
+}
+
+/** Deployment identity, or `unknown` if a deployment shipped without one. */
+function stateTag(): string {
+    return import.meta.env.VITE_STATE || 'unknown';
+}
+
+/**
+ * Namespace a user id to its deployment for use as PostHog's `distinct_id`.
+ *
+ * `user.id` is a per-database autoincrement, so it is unique within a deployment
+ * and *not* across them. With only staging reporting there was one id space and
+ * the bare id was safe; now that every state deployment reports, user 1 at
+ * stlouis and user 1 at maine would otherwise resolve to a single PostHog person.
+ * That would make person properties (`role`, `facility_id`, `features`)
+ * last-write-wins between facilities, and would undercount weekly-active-users —
+ * the pilot's headline metric — by collapsing distinct people into one.
+ */
+function analyticsDistinctId(userId: number): string {
+    return `${stateTag()}:${userId}`;
+}
+
+/**
+ * Initialize PostHog, or deliberately don't. Never throws.
+ *
+ * Analytics is enabled only when the key looks like a real PostHog project key
+ * (they are always `phc_`-prefixed) AND a deployment is named. That single rule:
+ *   - rejects the CI `placeholder_for_other_deployments` value used by builds
+ *     that shouldn't report,
+ *   - rejects the `.env.example` sample value,
+ *   - fails closed on forks, where the repo secret resolves to an empty string,
+ *   - and keeps a developer who pastes a real key into `.env` from silently
+ *     sending until they also set VITE_DEPLOYMENT, at which point their events
+ *     are tagged and filterable rather than anonymous noise.
+ */
+export function initAnalytics(): void {
+    try {
+        const key = import.meta.env.VITE_PUBLIC_POSTHOG_KEY;
+        if (!key?.startsWith('phc_') || !import.meta.env.VITE_DEPLOYMENT) {
+            return;
+        }
+        posthog.init(key, {
+            api_host: import.meta.env.VITE_PUBLIC_POSTHOG_HOST,
+            defaults: '2026-01-30',
+            capture_exceptions: true,
+            // Autocapture stays on for the ambient click signal, but its element
+            // text is stripped. Unmasked, `$el_text` sends the text of whatever
+            // was clicked — on resident-facing screens that means names rendered
+            // in tables and links. No insight consumes autocapture text, so this
+            // costs nothing.
+            mask_all_text: true
+        });
+        posthog.register(deploymentProps());
+    } catch {
+        // Missing/invalid config — the app runs without analytics.
+    }
+}
+
+/**
+ * Split a request path into analytics-safe props.
+ *
+ * `url` drops the query string: it carried resident search terms into PostHog,
+ * and it fragmented the "errors by endpoint" breakdown into one row per typed
+ * character. `endpoint` additionally collapses ids so the breakdown groups by
+ * route rather than by resource.
+ *
+ * Both call sites are normalized to the same absolute shape — `api.ts` passes
+ * paths relative to `/api/` while SWR keys are already absolute — so one
+ * breakdown covers every failure in the app.
+ */
+export function analyticsUrl(rawUrl: string): AnalyticsProps {
+    const path = rawUrl.split('?')[0].split('#')[0];
+    const url = path.startsWith('/') ? path : `/api/${path}`;
+    const endpoint = url
+        .split('/')
+        .map((segment) =>
+            /^\d+$/.test(segment) ||
+            /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i.test(
+                segment
+            )
+                ? ':id'
+                : segment
+        )
+        .join('/');
+    return { url, endpoint };
+}
 
 /** Fire a custom event. Never throws. */
 export function captureEvent(
@@ -46,17 +153,29 @@ export function captureEvent(
  * Tie subsequent events to a stable per-user identity so login frequency,
  * weekly-active-users and new-user metrics attribute correctly.
  *
- * Sends id/role/facility only — no names, usernames or emails — to keep staff
- * PII out of PostHog in the corrections context.
+ * Sends id/role/facility/features only — no names, usernames or emails — to keep
+ * staff PII out of PostHog in the corrections context. `features` is the sorted
+ * comma-joined feature_access list rather than a raw array so PostHog breakdowns
+ * on it are usable; it lets pilot metrics be segmented by which flags a facility
+ * actually has enabled.
+ *
+ * The identity is deployment-namespaced — see `analyticsDistinctId`.
  */
 export function identifyUser(
-    user: Pick<User, 'id' | 'role' | 'facility_id'>
+    user: Pick<User, 'id' | 'role' | 'facility_id' | 'feature_access'>
 ): void {
     try {
-        posthog.identify(String(user.id), {
+        posthog.identify(analyticsDistinctId(user.id), {
             role: user.role,
-            facility_id: user.facility_id
+            facility_id: user.facility_id,
+            features: [...(user.feature_access ?? [])].sort().join(',')
         });
+        // Also register facility as a super property. As a person property alone
+        // it is invisible to event-property filters (the pilot dashboard's
+        // facility filter silently matches nothing) and it is last-write-wins,
+        // so an admin switching facilities retroactively re-attributes their
+        // whole history. On the event, it records where the action happened.
+        posthog.register({ facility_id: user.facility_id });
     } catch {
         /* noop */
     }
@@ -65,10 +184,15 @@ export function identifyUser(
 /**
  * Clear the identified user. Critical for shared facility workstations so the
  * next staff member isn't attributed to the previous one.
+ *
+ * `reset()` also clears registered super properties, so the deployment tags are
+ * re-registered immediately — otherwise every event after the first logout would
+ * be missing `deployment`/`state` until the page reloaded.
  */
 export function resetAnalytics(): void {
     try {
         posthog.reset();
+        posthog.register(deploymentProps());
     } catch {
         /* noop */
     }

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -8,17 +8,11 @@ import 'react-big-calendar/lib/css/react-big-calendar.css';
 import '@/styles/globals.css';
 import posthog from 'posthog-js';
 import { PostHogProvider } from 'posthog-js/react';
+import { initAnalytics } from '@/lib/events';
+import { swrFetcher } from '@/api/swrFetcher';
 
-// Initialize PostHog — wrapped so a missing key never crashes the app.
-try {
-    posthog.init(import.meta.env.VITE_PUBLIC_POSTHOG_KEY, {
-        api_host: import.meta.env.VITE_PUBLIC_POSTHOG_HOST,
-        defaults: '2026-01-30',
-        capture_exceptions: true
-    });
-} catch {
-    // Missing/invalid config — app runs without analytics.
-}
+// Gated + tagged in lib/events.ts; a no-op when analytics is disabled.
+initAnalytics();
 
 ReactDOM.createRoot(document.querySelector('#root')!).render(
     <React.StrictMode>
@@ -28,21 +22,7 @@ ReactDOM.createRoot(document.querySelector('#root')!).render(
                     value={{
                         revalidateOnFocus: false,
                         shouldRetryOnError: false,
-                        fetcher: async (url: string) => {
-                            const res = await fetch(url, {
-                                credentials: 'include',
-                                headers: {
-                                    'X-Requested-With': 'XMLHttpRequest',
-                                    Accept: 'application/json',
-                                    'Content-Type': 'application/json'
-                                }
-                            });
-                            if (!res.ok) {
-                                const error = new Error(res.statusText);
-                                throw error;
-                            }
-                            return res.json() as Promise<unknown>;
-                        }
+                        fetcher: swrFetcher
                     }}
                 >
                     <ThemeProvider>

--- a/frontend/src/pages/student/digital-transcript/DigitalTranscriptWysiwygEntry.tsx
+++ b/frontend/src/pages/student/digital-transcript/DigitalTranscriptWysiwygEntry.tsx
@@ -52,6 +52,7 @@ import {
     FUNNEL_FORM_STEPS,
     TOP_SKILLS_MAX
 } from './transcriptReflectionConfig';
+import { LearningRecordTracker } from './learningRecordAnalytics';
 
 /** Maps a TranscriptEntry patch key to its corresponding preview field id. */
 function patchKeyToPreviewField(key: keyof TranscriptEntry): string | null {
@@ -250,6 +251,13 @@ export function DigitalTranscriptWysiwygEntry({
     const achievementListRef = useRef<HTMLDivElement>(null);
     const sessionRef = useRef<TranscriptEntrySession | null>(null);
     sessionRef.current = session;
+    // ID-806 question-level behavior tracking. Driven from patchRow /
+    // handleActiveStepChange / validateFinishRequirements so it does not depend
+    // on the form's markup. Counts and enums only — never answer content.
+    const analyticsRef = useRef<LearningRecordTracker | null>(null);
+    analyticsRef.current ??= new LearningRecordTracker();
+    const analyticsStartedForRef = useRef<string | null>(null);
+    const entriesCommittedThisSessionRef = useRef(0);
 
     const committedIds = useMemo(
         () => new Set(entries.map((e) => e.id)),
@@ -401,6 +409,11 @@ export function DigitalTranscriptWysiwygEntry({
         }
 
         setSaveErrorRowId(null);
+        // Success path only, mirroring the attendance/program convention: the
+        // row is complete and the resident is finishing. The row itself was
+        // already persisted by the autosave in persistActiveRow.
+        entriesCommittedThisSessionRef.current += 1;
+        analyticsRef.current?.entryCompleted(row);
         return true;
     }, []);
 
@@ -408,6 +421,19 @@ export function DigitalTranscriptWysiwygEntry({
         if (!isFunnel || !onRegisterFunnelFinish) return;
         onRegisterFunnelFinish({ validateFinishRequirements });
     }, [isFunnel, onRegisterFunnelFinish, validateFinishRequirements]);
+
+    // ID-806: one lr_entry_started per entry actually opened for editing.
+    // Gated on hydrated + an expanded row so loading and empty renders are not
+    // counted, the same guard the attendance page uses.
+    const analyticsExpandedId = session?.expandedId ?? null;
+    useEffect(() => {
+        if (!isFunnel || !hydrated || !analyticsExpandedId) return;
+        if (analyticsStartedForRef.current === analyticsExpandedId) return;
+        analyticsStartedForRef.current = analyticsExpandedId;
+        analyticsRef.current?.entryStarted(
+            entriesCommittedThisSessionRef.current + 1
+        );
+    }, [isFunnel, hydrated, analyticsExpandedId]);
 
     useEffect(() => {
         if (!isFunnel || !session?.expandedId || !onFunnelAutoSaveStatusChange)
@@ -473,7 +499,14 @@ export function DigitalTranscriptWysiwygEntry({
     }, [session, onExportRowsChange]);
 
     const handleActiveStepChange = useCallback((step: number) => {
-        setActiveStep(step);
+        setActiveStep((prevStep) => {
+            const current = sessionRef.current;
+            const row = current?.rows.find((r) => r.id === current.expandedId);
+            if (row && step !== prevStep) {
+                analyticsRef.current?.stepChanged(row, prevStep, step);
+            }
+            return step;
+        });
         setActivePreviewField(null);
         achievementListRef.current?.scrollTo({ top: 0, behavior: 'smooth' });
     }, []);
@@ -491,6 +524,11 @@ export function DigitalTranscriptWysiwygEntry({
                         previewField !== activePreviewFieldRef.current
                     ) {
                         setActivePreviewField(previewField);
+                    }
+                    const current = sessionRef.current;
+                    const editedRow = current?.rows.find((r) => r.id === id);
+                    if (editedRow) {
+                        analyticsRef.current?.noteEdit(editedRow, patchedKey);
                     }
                 }
             }

--- a/frontend/src/pages/student/digital-transcript/learningRecordAnalytics.ts
+++ b/frontend/src/pages/student/digital-transcript/learningRecordAnalytics.ts
@@ -1,0 +1,244 @@
+import { ANALYTICS_EVENTS, captureEvent, flowTimerSeconds } from '@/lib/events';
+import {
+    FUNNEL_FORM_STEPS,
+    funnelStepFieldAnswered,
+    funnelStepFieldKind,
+    type FunnelStepField,
+    type TranscriptReflectionFields
+} from './transcriptReflectionConfig';
+
+/**
+ * Question-level behavior tracking for the Learning Record form (ID-806).
+ *
+ * The pilot's SQL over `learning_record_entries` shows *what* residents saved but
+ * not *how* they worked: which questions took unusually long, which chip
+ * selectors were engaged versus skipped, how many entries someone adds in a
+ * sitting. These events supply that.
+ *
+ * PRIVACY — this module is the only place that reads entry values, and it reads
+ * exclusively lengths, counts and booleans. Resident consent language promises
+ * anonymized aggregate data, so no answer text may ever become an event
+ * property. Anything added here must stay a number, boolean, or fixed enum.
+ *
+ * The tracker is deliberately driven from two logic choke points in the form
+ * (`patchRow` for edits, `handleActiveStepChange` for navigation) rather than
+ * from per-field focus/blur handlers, so it does not depend on the form's
+ * markup.
+ */
+
+/** How many options are selected for a multi-select question. */
+function selectionCount(
+    entry: TranscriptReflectionFields,
+    field: FunnelStepField
+): number {
+    switch (field) {
+        case 'q5':
+            return entry.q5BeforeTags.length + entry.q5AfterTags.length;
+        case 'q8Selections':
+            return entry.q8Selections.length;
+        case 'q9Selections':
+            return entry.q9Selections.length;
+        default:
+            return 0;
+    }
+}
+
+/** Length only — never the content. */
+function charCount(
+    entry: TranscriptReflectionFields,
+    field: FunnelStepField
+): number {
+    switch (field) {
+        case 'programName':
+            return entry.programName.trim().length;
+        case 'whatMadeYouFinish':
+            return entry.whatMadeYouFinish.trim().length;
+        case 'adviceToPeer':
+            return entry.adviceToPeer.trim().length;
+        case 'oneSentence':
+            return entry.oneSentence.trim().length;
+        case 'q4':
+            return entry.q4Text.trim().length;
+        case 'q5':
+            return entry.q5FreeText.trim().length;
+        default:
+            return 0;
+    }
+}
+
+/** Maps a mutated draft key back to the step field it belongs to. */
+const PATCH_KEY_TO_FIELD: Partial<Record<string, FunnelStepField>> = {
+    programName: 'programName',
+    completionDate: 'completionDate',
+    whatMadeYouFinish: 'whatMadeYouFinish',
+    q4Toggle: 'q4',
+    q4Text: 'q4',
+    q5BeforeTags: 'q5',
+    q5AfterTags: 'q5',
+    q5FreeText: 'q5',
+    adviceToPeer: 'adviceToPeer',
+    confidence: 'confidence',
+    q8Selections: 'q8Selections',
+    q9Selections: 'q9Selections',
+    oneSentence: 'oneSentence'
+};
+
+function funnelFieldForPatchKey(key: string): FunnelStepField | null {
+    return PATCH_KEY_TO_FIELD[key] ?? null;
+}
+
+interface QuestionTiming {
+    field: FunnelStepField;
+    startedMs: number;
+    lastEditMs: number;
+}
+
+/**
+ * Per-entry tracker. One instance per expanded entry; `reset()` starts a new one.
+ * Not a hook — the form holds it in a ref so it survives re-renders.
+ */
+export class LearningRecordTracker {
+    private entryStartMs = Date.now();
+    /**
+     * Set once at construction, which the form does on mount — so
+     * `seconds_since_session_start` measures from when the resident opened the
+     * form, not from when they opened the first entry. Never reset by
+     * `entryStarted`, so it stays comparable across entries in one sitting.
+     */
+    private readonly sessionStartMs = Date.now();
+    private entryIndex = 0;
+    private current: QuestionTiming | null = null;
+    /** Fields edited at least once during this entry. */
+    private touched = new Set<FunnelStepField>();
+    /** Steps already reported, so re-visiting a step does not double count. */
+    private reportedSteps = new Set<number>();
+    private stepStartMs = Date.now();
+
+    /** Called once when the form becomes interactive. */
+    entryStarted(entryIndexInSession: number): void {
+        this.entryIndex = entryIndexInSession;
+        this.entryStartMs = Date.now();
+        this.stepStartMs = Date.now();
+        this.current = null;
+        this.touched.clear();
+        this.reportedSteps.clear();
+        captureEvent(ANALYTICS_EVENTS.LrEntryStarted, {
+            entry_index_in_session: entryIndexInSession
+        });
+    }
+
+    /**
+     * Called on every field mutation. Emits `lr_question_left` for the previous
+     * question when focus effectively moves to a different one.
+     */
+    noteEdit(entry: TranscriptReflectionFields, patchKey: string): void {
+        const field = funnelFieldForPatchKey(patchKey);
+        if (!field) return;
+        this.touched.add(field);
+
+        if (this.current && this.current.field !== field) {
+            this.emitQuestion(entry, this.current.field, true);
+        }
+        const now = Date.now();
+        if (this.current?.field !== field) {
+            this.current = { field, startedMs: now, lastEditMs: now };
+        } else {
+            this.current.lastEditMs = now;
+        }
+    }
+
+    /**
+     * Called when the visible step changes. Emits one `lr_question_left` per
+     * field of the step being left — including untouched ones, so
+     * "selected at least one option vs left blank" has a real denominator —
+     * then `lr_step_completed`.
+     */
+    stepChanged(
+        entry: TranscriptReflectionFields,
+        fromStepIndex: number,
+        toStepIndex: number
+    ): void {
+        const from = FUNNEL_FORM_STEPS[fromStepIndex];
+        if (from && !this.reportedSteps.has(fromStepIndex)) {
+            this.reportedSteps.add(fromStepIndex);
+            let answered = 0;
+            for (const field of from.fields) {
+                if (funnelStepFieldAnswered(entry, field)) answered += 1;
+                this.emitQuestion(entry, field, this.touched.has(field));
+            }
+            captureEvent(ANALYTICS_EVENTS.LrStepCompleted, {
+                step_id: from.id,
+                step_index: fromStepIndex,
+                duration_seconds: flowTimerSeconds(this.stepStartMs),
+                answered_count: answered
+            });
+        }
+        this.current = null;
+        this.stepStartMs = Date.now();
+        void toStepIndex;
+    }
+
+    /** Called when the resident finishes a complete entry. */
+    entryCompleted(entry: TranscriptReflectionFields): void {
+        // Flush the final step so its questions are represented too.
+        const lastIndex = FUNNEL_FORM_STEPS.length - 1;
+        const last = FUNNEL_FORM_STEPS[lastIndex];
+        if (last && !this.reportedSteps.has(lastIndex)) {
+            this.reportedSteps.add(lastIndex);
+            for (const field of last.fields) {
+                this.emitQuestion(entry, field, this.touched.has(field));
+            }
+        }
+        this.current = null;
+
+        let answered = 0;
+        let total = 0;
+        for (const step of FUNNEL_FORM_STEPS) {
+            for (const field of step.fields) {
+                total += 1;
+                if (funnelStepFieldAnswered(entry, field)) answered += 1;
+            }
+        }
+
+        captureEvent(ANALYTICS_EVENTS.LrEntryCompleted, {
+            duration_seconds: flowTimerSeconds(this.entryStartMs),
+            answered_count: answered,
+            total_fields: total,
+            entry_index_in_session: this.entryIndex,
+            seconds_since_session_start: flowTimerSeconds(this.sessionStartMs),
+            submitted_at: new Date().toISOString()
+        });
+    }
+
+    private emitQuestion(
+        entry: TranscriptReflectionFields,
+        field: FunnelStepField,
+        touched: boolean
+    ): void {
+        const kind = funnelStepFieldKind(field);
+        const timing = this.current?.field === field ? this.current : null;
+        // Untouched questions report 0 seconds and touched=false so time charts
+        // can exclude them while selection-rate charts still count them.
+        const duration = timing
+            ? Math.max(
+                  0,
+                  Math.round((timing.lastEditMs - timing.startedMs) / 1000)
+              )
+            : 0;
+        captureEvent(ANALYTICS_EVENTS.LrQuestionLeft, {
+            question_key: field,
+            step_id: stepIdForField(field),
+            kind,
+            duration_seconds: duration,
+            touched,
+            answered: funnelStepFieldAnswered(entry, field),
+            selection_count: selectionCount(entry, field),
+            char_count: charCount(entry, field)
+        });
+    }
+}
+
+function stepIdForField(field: FunnelStepField): string {
+    const step = FUNNEL_FORM_STEPS.find((s) => s.fields.includes(field));
+    return step?.id ?? 'unknown';
+}

--- a/frontend/src/pages/student/digital-transcript/transcriptReflectionConfig.ts
+++ b/frontend/src/pages/student/digital-transcript/transcriptReflectionConfig.ts
@@ -490,7 +490,37 @@ function funnelCompletionFieldAnswered(
     }
 }
 
-function funnelStepFieldAnswered(
+/** Shape of a funnel step field, for analytics segmentation (ID-806). */
+export type FunnelFieldKind =
+    | 'text'
+    | 'tags'
+    | 'confidence'
+    | 'toggle'
+    | 'date';
+
+/**
+ * Which input shape a step field uses. Lets question-level analytics separate
+ * "chip/multi-select" questions from free-text ones without the analytics layer
+ * needing to know the form's markup.
+ */
+export function funnelStepFieldKind(field: FunnelStepField): FunnelFieldKind {
+    switch (field) {
+        case 'completionDate':
+            return 'date';
+        case 'confidence':
+            return 'confidence';
+        case 'q4':
+            return 'toggle';
+        case 'q5':
+        case 'q8Selections':
+        case 'q9Selections':
+            return 'tags';
+        default:
+            return 'text';
+    }
+}
+
+export function funnelStepFieldAnswered(
     entry: TranscriptReflectionFields,
     field: FunnelStepField
 ): boolean {

--- a/frontend/src/vite-env.d.ts
+++ b/frontend/src/vite-env.d.ts
@@ -3,6 +3,10 @@
 interface ImportMetaEnv {
     readonly VITE_PUBLIC_POSTHOG_KEY: string;
     readonly VITE_PUBLIC_POSTHOG_HOST: string;
+    /** 'production' | 'development' — set per deployment at image build time. Blank locally, which disables analytics. */
+    readonly VITE_DEPLOYMENT: string;
+    /** Deployment identity: 'stlouis' | 'maine' | 'alaska' | 'mocode' | 'demo' | 'staging'. */
+    readonly VITE_STATE: string;
 }
 
 interface ImportMeta {


### PR DESCRIPTION
# feat: PostHog deployment tagging, PII reduction, and Learning Record question-level analytics

Branch: `cpride/posthog_learning_record`
Commits: `3b70a101` (analytics pipeline), `5c16e6d5` (Learning Record instrumentation, ID-806)

## Summary

Two related changes. The first makes the analytics pipeline trustworthy: facilities actually
report, every event says which deployment it came from, resident text stops leaking into
event properties, and page-load request failures become visible. The second, ID-806, adds
question-level behavior tracking to the Learning Record form on top of that foundation.

The second is only meaningful because of the first. The pilot's SQL over
`learning_record_entries` already shows *what* residents saved; these events show *how* they
worked — which questions take long, which chip selectors get skipped, how many records
someone adds in a sitting — and that is only readable if facility traffic can be separated
from staging testing.

No backend schema or API changes.

## Where to see each change

| Route | What changed | What to look for |
| --- | --- | --- |
| `/learning-record-funnel/entry` | Question-level analytics on the funnel form | No visible UI change. With the `learning_record` flag on and a real PostHog key, editing fields and moving between the three steps emits `lr_question_left` / `lr_step_completed`; finishing an entry emits `lr_entry_completed`. |
| `/learning-record-categories/entry` | Intentionally **not** instrumented | Same form, non-funnel variant. The tracker is gated on `isFunnel`, so no `lr_*` events fire here. Confirm that's still what we want. |
| Any page that loads data | SWR failures now report `api_error` | Break the API (stop the backend, or block a request in devtools) and confirm one `api_error` per failed GET, with `endpoint` collapsed to `/api/programs/:id/classes` form. |
| Any page, any click | Autocapture element text is masked | `$autocapture` events still fire, but `$el_text` no longer carries the text of the clicked element — previously resident names in tables and links. |
| Login / logout | Identity is deployment-namespaced | `distinct_id` reads `<state>:<user id>`, e.g. `staging:1`. Logout clears identity and immediately re-registers the deployment tags. |
| Local dev | Analytics is off by default | With a blank `VITE_DEPLOYMENT`, no requests go to `us.i.posthog.com` at all. |

---

# Reviewer notes

## Ordering — the insights cannot be built before this merges

This is the part that is easy to get backwards. The PostHog dashboard work is **downstream**
of the deploy, not a prerequisite for it:

1. Push this branch and open the PR.
2. Merge to `main`.
3. Staging deploys and sends its first tagged events.
4. **Only now** can the PostHog insights be built or repointed. PostHog creates property and
   event definitions lazily on first ingest — `deployment`, `state`, `endpoint`, and all four
   `lr_*` events do not appear in any filter dropdown until at least one has arrived. Building
   the filters early doesn't fail loudly; the properties simply aren't offered and it looks
   broken.
5. Cut the state branches; facility data arrives; verify it is tagged as expected.

**The one pre-merge PostHog config item is already done: session replay is verified OFF**
(Settings → Session replay → "Record user sessions"). That check mattered because screen
recording in a corrections context would capture resident information displayed on screen, and
because the `defaults: '2026-01-30'` preset passes session-recording configuration while the
actual toggle is project-side — so it needed verifying rather than assuming. **Events already
transmitted cannot be un-sent**, which is why it preceded the merge rather than following it.

No PostHog configuration blocks this PR. Everything else that needs configuring is downstream
of the deploy and is written up in **`POSTHOG_FOLLOWUP_PR_NOTE.md`** (same directory), phased by
what unblocks each step.

## ⚠️ Open question for reviewers — consent language vs. individual attribution

**Please weigh in on this before approving.** It is the one thing in this PR I do not think should
be settled without the person who owns the resident-facing copy.

`main` now carries `frontend/src/data/learningRecordResidentCopy.ts` — the actual resident
transparency notice, added in `3df61c7b` and shown on both the Learning Record landing page and the
achievement entry form. It commits to three facts, including that responses are combined *"with all
identifying information removed"* and that *"Nothing you write can be traced back to you
individually."*

Where the `lr_*` instrumentation actually sits against that:

| Claim in the notice | Instrumentation |
| --- | --- |
| Facility staff won't see individual answers | ✅ No answer text is ever sent. Counts, booleans, durations, fixed enums only. |
| Responses combined "with all identifying information removed" | ⚠️ **Not aggregate.** `posthog.identify()` attributes every `lr_*` event to a specific resident. |
| "Nothing you write can be traced back to you individually" | ⚠️ Literally true for content. But `char_count` is derived from what they wrote. |

Concretely, PostHog ends up holding per-resident behavioral rows — *this resident spent 45s on
`q5`, picked 3 chips, answered 8 of 10* — readable by anyone with project access. That is
individual-level behavioral data. It is not answer content, and it is genuinely useful for the
pilot, but it is not the anonymized aggregate the notice describes.

Worth noting the copy file marks itself **"FIRST DRAFT — pending Carolina's final copy,"** so the
wording is still moving. That is exactly why I did not resolve this unilaterally in either
direction: I did not want to quietly narrow working instrumentation to match a draft, nor quietly
ship instrumentation that outruns what residents were told.

**If reviewers want the narrower version, there are two independent levers:**

1. **Drop `char_count`** — one property, the only one derived from written content. Cheap; costs the
   "are residents writing a sentence or a paragraph?" signal.
2. **Send `lr_*` unattributed** — decouple these events from the identified person so they are
   aggregate-only. More invasive, and it would break `entry_index_in_session` and
   `seconds_since_session_start`, which are inherently per-person.

Either can land in this PR or a follow-up. Tell me which and I'll do it.

## Privacy decisions made in code

### Autocapture stays on, its element text is masked — `mask_all_text: true`

`posthog-js` ships `autocapture: true` with `mask_all_text: false` (verified in the installed
1.347.2 bundle — the flag is passed into the autocapture element-props builder, so masking
changes what gets serialized rather than whether the event fires). Unmasked, every
`$autocapture` click carries `$el_text`: clicking a resident's name in a table sent that name
to PostHog. That is a larger exposure than the `api_error` query strings this branch also
fixes, and it would have gone live the moment facilities started reporting.

| Option | Effect | |
| --- | --- | --- |
| Disable autocapture entirely | No `$autocapture` events. Pilot metrics unaffected. | |
| **Keep clicks, drop text** | Click and rageclick events still recorded, element text stripped. | ✅ chosen |
| Accept as-is | Resident names may appear in `$el_text`. | |

Masking is free here: none of the 8 pilot metrics depend on autocapture. Stickiness, WAU, and
Lifecycle all run on `$pageview` + `identify`, which are separate mechanisms.

### Still open — element *attributes* and personal-data properties

`mask_all_text` covers text content only. Element **attributes** are a second channel: with
only this flag set, an `aria-label` or `title` such as "Delete achievement for \<name\>" is
still captured. `mask_all_element_attributes: true` closes it at the same zero cost.

Also worth evaluating: `mask_personal_data_properties` (default off), which redacts
personal-data patterns in properties such as URLs — confirm its exact coverage against
PostHog's docs before relying on it.

**Both are deliberately not in this PR** rather than added silently. They should be decided
before facilities report. Happy to add the attribute flag to this PR if reviewers prefer.

### Query strings stripped from `api_error`

`url` previously carried the full request path including query string, which meant resident
search terms went to PostHog, and the "errors by endpoint" breakdown fragmented into one row
per typed character (`?search=Sm`, `?search=Smi`, `?search=Smit`). Now `url` is path-only and
`endpoint` additionally collapses numeric and UUID segments to `:id`.

### Learning Record properties are counts and enums only

`learningRecordAnalytics.ts` is the single place that reads entry values, and it reads only
lengths, counts, booleans, and fixed enums — never answer text. Any future property on an `lr_*`
event carrying resident text is a regression.

See the open question above for the part this does *not* settle: the events are individually
attributed, which is a weaker guarantee than the "anonymized, aggregate" framing in the resident
notice.

## Why `distinct_id` is namespaced

`user.id` is a per-database autoincrement — unique within a deployment, not across them. While
only staging reported there was one id space and the bare id was safe. With four states
reporting, a bare id would make stlouis user 1 and maine user 1 the same PostHog person:
person properties (`role`, `facility_id`, `features`) would go last-write-wins between
facilities, and weekly-active-users — the pilot's headline metric — would undercount by
collapsing distinct people into one.

There is a second-order effect worth knowing: the project's test-account filter is
`role is not system_admin`, and `role` is a person property. Without namespacing, a shared
person record would flip between `system_admin` and `facility_admin` and that filter would
intermittently drop a real pilot user.

Persons created before this change keep bare numeric ids and will not merge with the
namespaced ones. That is fine — the dashboard filter drops all pre-deploy data anyway. It does
mean a tester who used the app both before and after this change shows up as two persons, which
inflates the person counts currently on the dashboard (4 persons entering the attendance funnel,
3 the enrollment funnel — a couple of people, counted more than once).

## Reference — what the code adds

| Property | Kind | Value | Notes |
| --- | --- | --- | --- |
| `deployment` | Event (super) | `production` \| `development` | On every event incl. `$pageview`, `$exception` |
| `state` | Event (super) | `stlouis` \| `maine` \| `alaska` \| `mocode` \| `demo` \| `staging` | `unknown` if unset |
| `facility_id` | Event (super) **and** person | number | Registered at identify. Cleared on logout and not re-registered — it is user-scoped, unlike `deployment`/`state`, which are re-registered after `reset()` |
| `features` | Person | sorted comma-joined `feature_access` | New |
| `endpoint` | Event (`api_error`) | e.g. `/api/programs/:id/classes` | New; ids collapsed |
| `url` | Event (`api_error`) | e.g. `/api/programs/12/classes` | **Changed:** query string removed, canonicalized |
| `distinct_id` | Identity | e.g. `stlouis:1` | **Changed:** was the bare user id |

New events (ID-806), all on the funnel form only:

| Event | Properties |
| --- | --- |
| `lr_entry_started` | `entry_index_in_session` |
| `lr_question_left` | `question_key`, `step_id`, `kind`, `duration_seconds`, `touched`, `answered`, `selection_count`, `char_count` |
| `lr_step_completed` | `step_id`, `step_index`, `duration_seconds`, `answered_count` |
| `lr_entry_completed` | `duration_seconds`, `answered_count`, `total_fields`, `entry_index_in_session`, `seconds_since_session_start`, `submitted_at` |

Which deployments send data, after this change:

| Branch | Deployment | Reports? |
| --- | --- | --- |
| `stlouis` / `maine` / `alaska` / `mocode` | `production` | **Yes** (new) |
| `main` | `development` / `staging` | Yes (unchanged) |
| `demov2` | `development` / `demo` | No — seeded fake data is noise |
| local development | — | No, unless `VITE_DEPLOYMENT` is set deliberately |
| forks | — | No — secrets resolve empty, key fails the `phc_` check |

Analytics initializes only when the key is `phc_`-prefixed **and** `VITE_DEPLOYMENT` is set.
That single rule rejects the CI placeholder, rejects the `.env.example` sample, fails closed on
forks where the secret resolves empty, and stops a developer who pastes a real key into `.env`
from silently sending until they also name a deployment — at which point their events are
tagged and filterable rather than anonymous noise.

## Rollback

The code side reverts in one line: set `POSTHOG_KEY=placeholder_for_other_deployments` in the
frontend branch of `.github/workflows/container_builds.yml` and rebuild. The frontend rejects
any key that is not `phc_`-prefixed, so the deployments go quiet immediately without touching
the PostHog project.

The PostHog-side changes are all non-destructive filters and breakdowns; reverting them is just
changing them back. Note that **events already transmitted cannot be un-sent** — which is why
the session-replay check belongs before merge.

## Known limitations, not addressed here

Documented so they aren't rediscovered as surprises:

- **`lr_step_completed` never fires for the last step.** It fires when the resident navigates
  *away* from a step, and `entryCompleted` flushes the final step's questions without emitting
  a step event. So the completion funnel must be
  `lr_entry_started → achievement → experience → lr_entry_completed`; adding a `future` step
  would read as total abandonment. Whole-entry time is available via `duration_seconds` on
  `lr_entry_completed`; last-step time is not. Fixable, but deliberately out of scope here.
- **Aborted requests report as errors.** `api.ts` uses a 10-second `AbortController` and its
  catch block treats an abort like any other failure — `api_error` with `status: 0` and
  `message: "signal is aborted without reason"`. A genuine timeout is worth recording; a
  navigation-cancelled request is not. Currently indistinguishable. Pre-existing, unchanged.
- **Non-JSON error bodies become the `message`.** When a response isn't JSON, `api.ts` puts the
  raw body in `message` — a 502 sends roughly 700 characters of nginx HTML as an event
  property. Pre-existing, unchanged.
- **`duration_seconds` measures wall clock**, not active editing time. A resident who opens the
  form and is pulled away inflates it, with no cap or outlier trimming. This is why medians are
  the numbers to quote.
- **`*_started` events double-fire in dev** because React StrictMode invokes effects twice.
  Production builds fire once. Affects raw `*_started` counts only, not durations or funnel
  conversion.

## Follow-up PR

Nothing below blocks this PR. Full detail — including click-by-click steps and what unblocks
each phase — is in **`POSTHOG_FOLLOWUP_PR_NOTE.md`**. Summary of that scope:

- **Steps 2–7:** verify the new properties landed, then add the `deployment` filter to the pilot
  dashboard and repoint the "API errors by endpoint" and facility filters. Step 3 is the one
  with a deadline: until it's done, every dashboard tile mixes facility sessions with the team's
  staging testing.
- **Expect the dashboard to go empty when that filter lands.** Every number on it today is
  internal testing — three to four persons at near-100% conversion, and a 0.5-second average
  "program setup time" that can only be a scripted form fill. The filter hiding all of it is the
  filter working. The note records the current per-tile baseline so this isn't mistaken for a
  regression.
- **Steps 8–11:** build the four Learning Record insights — completion funnel, median time per
  question, answer/skip rate, entries per sitting. Blocked until the `learning_record` flag is
  on somewhere that reports.
- **Corrections to `POSTHOG_DASHBOARD_SETUP.md`:** the §0 event reference is now stale, and §0
  and §2c document three properties (`scheduled_start_at`, `hours_after_session`,
  `recording_delay_bucket`) that have zero occurrences in the codebase and were never shipped —
  so anyone following §2c builds an insight that stays permanently empty.

**Not in the follow-up — already resolved as pre-work:** "Attendance time — avg & median (sec)",
§2a's "core metric", was showing *no matching events*. Cause was the dashboard's saved date range,
not the insight: the test data is sparse and months old, so a rolling window missed it entirely. At
All time the tile renders normably. Verified in code that no application change was needed —
`attendance_session_completed` always carries `duration_seconds` as a number, and `useFlowTimer`
measures the correct span. Recorded in Step 2 of `POSTHOG_CONFIG_UPDATES.md` along with the
known-good insight configuration.


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1217097620641814