### PR TITLE
fix: add css to make component fit within the screen per id 817

### DIFF
--- a/frontend/src/layouts/AuthenticatedLayout.tsx
+++ b/frontend/src/layouts/AuthenticatedLayout.tsx
@@ -160,7 +160,12 @@ export default function AuthenticatedLayout() {
         isKnowledgeCenter ||
         isOperationalInsights ||
         (isProgramDetail && canSwitchFacility(user));
-    const rootClass = 'h-screen bg-background flex overflow-hidden';
+    // Residents get no header bar at `md`+ (see the MobileNav branch below), so
+    // pages that size to the viewport must not reserve 4rem for it there
+    const headerOffsetClass = isAdministrator(user)
+        ? ''
+        : 'app-header-mobile-only';
+    const rootClass = `h-screen bg-background flex overflow-hidden ${headerOffsetClass}`;
     const contentClass = `flex-1 min-h-full ${isResidentKnowledgeCenter ? 'overflow-hidden' : 'overflow-y-auto'} overflow-x-hidden ${needsGrayBg ? 'bg-[#E2E7EA]' : 'bg-[#E2E7EA]'}`;
 
     return (

--- a/frontend/src/pages/student/digital-transcript/DigitalTranscriptEntryPage.tsx
+++ b/frontend/src/pages/student/digital-transcript/DigitalTranscriptEntryPage.tsx
@@ -198,7 +198,7 @@ export default function DigitalTranscriptEntryPage() {
     return (
         <div
             className={cn(
-                'flex h-[calc(100dvh-4rem)] min-h-0 min-w-0 flex-1 flex-col overflow-hidden',
+                'h-below-app-header flex min-h-0 min-w-0 flex-1 flex-col overflow-hidden',
                 dtPageSurface
             )}
         >

--- a/frontend/src/pages/student/digital-transcript/DigitalTranscriptShell.tsx
+++ b/frontend/src/pages/student/digital-transcript/DigitalTranscriptShell.tsx
@@ -7,8 +7,8 @@ import { LEARNING_RECORD_BUTTON_SIZE } from './learningRecordButtons';
 /** Page canvas — shadcn `muted` surface */
 export const dtPageSurface = 'bg-muted';
 
-/** Viewport below TopNav (`h-16`) — fills visible main area on Learning Record routes */
-export const dtShellMinHeight = 'min-h-[calc(100dvh-4rem)]';
+/** Viewport below the app header — fills visible main area on Learning Record routes */
+export const dtShellMinHeight = 'min-h-below-app-header';
 
 interface ShellProps {
     children: ReactNode;

--- a/frontend/src/styles/globals.css
+++ b/frontend/src/styles/globals.css
@@ -258,6 +258,28 @@ html {
     @apply min-h-[calc(100vh-4rem)] bg-surface-hover flex items-center justify-center;
 }
 
+:root {
+    --app-header-h: 4rem;
+}
+
+.app-header-mobile-only {
+    --app-header-h: 4rem;
+}
+
+@media (min-width: 48rem) {
+    .app-header-mobile-only {
+        --app-header-h: 0rem;
+    }
+}
+
+.h-below-app-header {
+    height: calc(100dvh - var(--app-header-h));
+}
+
+.min-h-below-app-header {
+    min-height: calc(100dvh - var(--app-header-h));
+}
+
 .scroll-panel {
     @apply max-h-48 overflow-y-auto bg-gray-50 rounded-lg p-4 space-y-1;
 }


### PR DESCRIPTION
## Pre-Submission PR Checklist

- [x] No debug/console/fmt.Println statements
- [x] Unnecessary development comments removed
- [x] All acceptance criteria verified
- [x] Functions according to **ticket specifications**
- [x] Tested manually where applicable
- [x] Branch rebased with latest main
- [x] No business logic exists within the database layer

## Description of the change

Added CSS to allow the component to fill the screen's viewport.

- **Related issues**: Link to related Asana ticket that this closes: [Bug: Overflow on learning records page](https://app.asana.com/1/1201607307149189/project/1209460078641109/task/1217380269669298?focus=true)

## Screenshot(s)

<img width="1922" height="968" alt="image" src="https://github.com/user-attachments/assets/66b52de5-e570-4b07-99f5-3401787ed548" />
