### PR TITLE
fix: save Learning Record entries before finishing, fix double-counted question events, add facility tagging (ID-827)

### DIFF
--- a/frontend/src/api/swrFetcher.ts
+++ b/frontend/src/api/swrFetcher.ts
@@ -43,5 +43,18 @@ export const swrFetcher = async (url: string): Promise<unknown> => {
         });
         throw new Error(res.statusText);
     }
-    return res.json() as Promise<unknown>;
+    try {
+        return (await res.json()) as unknown;
+    } catch (err) {
+        // An OK response with an empty or malformed body still fails the page.
+        // Without this the request looks successful to analytics while SWR
+        // surfaces an error to the user.
+        captureEvent(ANALYTICS_EVENTS.ApiError, {
+            status: res.status,
+            method: 'GET',
+            ...analyticsUrl(url),
+            message: err instanceof Error ? err.message : 'Invalid JSON'
+        });
+        throw err;
+    }
 };

--- a/frontend/src/hooks/useTranscriptDraft.ts
+++ b/frontend/src/hooks/useTranscriptDraft.ts
@@ -105,6 +105,19 @@ export function useTranscriptDraft() {
         return fresh;
     }, []);
 
+    /**
+     * Commit an entry to the server, creating or updating based on whether this
+     * client_id has a backend id yet.
+     *
+     * Rejects when the write fails. `API.fetchWithHandling` resolves
+     * `{ success: false }` rather than throwing, so `apiCreateEntry` returns null
+     * and `apiUpdateEntry` returns false on a 500, a timeout, or offline — which
+     * left this function resolving normally on a failed write. Callers read that as
+     * success: the resident saw "Saved", `lr_entry_completed` fired, and Finish
+     * navigated home with the entry never persisted. This is the only place that
+     * can turn a failed write back into a signal, so it throws and lets callers
+     * decide.
+     */
     const upsertCommittedEntry = useCallback(async (entry: TranscriptEntry) => {
         const trimmedEntry = {
             ...entry,
@@ -112,32 +125,46 @@ export function useTranscriptDraft() {
         };
         const backendId = entryBackendIds.current.get(entry.id);
         if (backendId !== undefined) {
-            await apiUpdateEntry(backendId, trimmedEntry);
+            if (!(await apiUpdateEntry(backendId, trimmedEntry))) {
+                throw new Error('failed to update learning record entry');
+            }
             setEntries((prev) =>
                 prev.map((e) => (e.id === entry.id ? trimmedEntry : e))
             );
         } else {
             const result = await apiCreateEntry(trimmedEntry);
-            if (result) {
-                entryBackendIds.current.set(entry.id, result.backendId);
-                setEntries((prev) => {
-                    const idx = prev.findIndex((e) => e.id === entry.id);
-                    if (idx >= 0) {
-                        const next = [...prev];
-                        next[idx] = result.entry;
-                        return next;
-                    }
-                    return [...prev, result.entry];
-                });
+            if (!result) {
+                throw new Error('failed to create learning record entry');
             }
+            entryBackendIds.current.set(entry.id, result.backendId);
+            setEntries((prev) => {
+                const idx = prev.findIndex((e) => e.id === entry.id);
+                if (idx >= 0) {
+                    const next = [...prev];
+                    next[idx] = result.entry;
+                    return next;
+                }
+                return [...prev, result.entry];
+            });
         }
         dispatchEntrySessionUpdated();
     }, []);
 
+    /**
+     * Remove an entry, server-side first.
+     *
+     * Rejects when the delete fails, for the same reason `upsertCommittedEntry`
+     * does — `apiDeleteEntry` returns false rather than throwing. Previously the
+     * local removal ran unconditionally, so a failed delete made the row disappear
+     * while it still existed on the server, and it reappeared on the next hydrate.
+     * Dropping local state only after the server confirms keeps the two in step.
+     */
     const deleteCommittedEntry = useCallback(async (id: string) => {
         const backendId = entryBackendIds.current.get(id);
         if (backendId !== undefined) {
-            await apiDeleteEntry(backendId);
+            if (!(await apiDeleteEntry(backendId))) {
+                throw new Error('failed to delete learning record entry');
+            }
             entryBackendIds.current.delete(id);
         }
         setEntries((prev) => prev.filter((e) => e.id !== id));

--- a/frontend/src/lib/events.ts
+++ b/frontend/src/lib/events.ts
@@ -28,6 +28,9 @@ export const ANALYTICS_EVENTS = {
     LrQuestionLeft: 'lr_question_left',
     LrStepCompleted: 'lr_step_completed',
     LrEntryCompleted: 'lr_entry_completed',
+    // Emitted when the resident leaves the form. The only measure of total time
+    // in the tool that also counts residents who never saved an entry.
+    LrSessionEnded: 'lr_session_ended',
     // Errors & friction
     ApiError: 'api_error'
 } as const;
@@ -70,6 +73,19 @@ function stateTag(): string {
  */
 function analyticsDistinctId(userId: number): string {
     return `${stateTag()}:${userId}`;
+}
+
+/**
+ * Namespace a facility to its deployment (ID-827).
+ *
+ * `facilities.id` is a per-database SERIAL, exactly like `users.id`, so a bare
+ * id names a different facility in every state — breaking any insight down by
+ * `facility_id` merges maine's facility 1 with stlouis's into one row. This is
+ * the key to filter and break down on; it survives facility renames, which
+ * `facility_name` does not.
+ */
+function facilityTag(facilityId: number): string {
+    return `${stateTag()}:${facilityId}`;
 }
 
 /**
@@ -162,20 +178,34 @@ export function captureEvent(
  * The identity is deployment-namespaced — see `analyticsDistinctId`.
  */
 export function identifyUser(
-    user: Pick<User, 'id' | 'role' | 'facility_id' | 'feature_access'>
+    user: Pick<
+        User,
+        'id' | 'role' | 'facility_id' | 'feature_access' | 'facility'
+    >
 ): void {
     try {
+        // Built once and spread into both calls so the person and event copies
+        // cannot drift. `facility` is the stable breakdown key (ID-827);
+        // `facility_name` labels it for readers; `facility_id` is kept because
+        // the existing pilot dashboard filter is built on it.
+        const facilityProps = user.facility_id
+            ? {
+                  facility_id: user.facility_id,
+                  facility: facilityTag(user.facility_id),
+                  facility_name: user.facility?.name ?? ''
+              }
+            : {};
         posthog.identify(analyticsDistinctId(user.id), {
             role: user.role,
-            facility_id: user.facility_id,
-            features: [...(user.feature_access ?? [])].sort().join(',')
+            features: [...(user.feature_access ?? [])].sort().join(','),
+            ...facilityProps
         });
-        // Also register facility as a super property. As a person property alone
-        // it is invisible to event-property filters (the pilot dashboard's
-        // facility filter silently matches nothing) and it is last-write-wins,
+        // Also register facility as super properties. As person properties alone
+        // they are invisible to event-property filters (the pilot dashboard's
+        // facility filter silently matches nothing) and they are last-write-wins,
         // so an admin switching facilities retroactively re-attributes their
-        // whole history. On the event, it records where the action happened.
-        posthog.register({ facility_id: user.facility_id });
+        // whole history. On the event, they record where the action happened.
+        posthog.register(facilityProps);
     } catch {
         /* noop */
     }

--- a/frontend/src/pages/student/digital-transcript/DigitalTranscriptEntryPage.tsx
+++ b/frontend/src/pages/student/digital-transcript/DigitalTranscriptEntryPage.tsx
@@ -137,10 +137,22 @@ export default function DigitalTranscriptEntryPage() {
         navigate(base);
     }, [navigate, base]);
 
-    const handleFinish = useCallback(() => {
-        const ok =
-            funnelFinishRef.current?.validateFinishRequirements() ?? false;
-        if (ok) navigateHome();
+    // Finishing now awaits a save, which leaves a window where a second click
+    // could run the whole flow again. The tracker refuses a duplicate
+    // completion event, but nothing else stops a double navigation.
+    const finishInFlightRef = useRef(false);
+
+    const handleFinish = useCallback(async () => {
+        if (finishInFlightRef.current) return;
+        finishInFlightRef.current = true;
+        try {
+            const ok =
+                (await funnelFinishRef.current?.validateFinishRequirements()) ??
+                false;
+            if (ok) navigateHome();
+        } finally {
+            finishInFlightRef.current = false;
+        }
     }, [navigateHome]);
 
     const handleDownload = useCallback(async () => {
@@ -286,7 +298,9 @@ export default function DigitalTranscriptEntryPage() {
                         upsertCommittedEntry={upsertCommittedEntry}
                         deleteCommittedEntry={deleteCommittedEntry}
                         onExportRowsChange={handleExportRowsChange}
-                        funnelOnFinish={isFunnel ? handleFinish : undefined}
+                        funnelOnFinish={
+                            isFunnel ? () => void handleFinish() : undefined
+                        }
                         onRegisterFunnelFinish={
                             isFunnel ? handleRegisterFunnelFinish : undefined
                         }

--- a/frontend/src/pages/student/digital-transcript/DigitalTranscriptHome.tsx
+++ b/frontend/src/pages/student/digital-transcript/DigitalTranscriptHome.tsx
@@ -585,10 +585,17 @@ export default function DigitalTranscriptHome() {
         if (!deleteTarget || isDeleting) return;
 
         setIsDeleting(true);
-        void deleteCommittedEntry(deleteTarget.id).finally(() => {
-            setIsDeleting(false);
-            setDeleteTarget(null);
-        });
+        // deleteCommittedEntry rejects on a failed delete and leaves the entry in
+        // place, so the resident has to be told rather than watching the row
+        // silently survive.
+        void deleteCommittedEntry(deleteTarget.id)
+            .catch(() => {
+                toast.error('Could not delete that entry. Please try again.');
+            })
+            .finally(() => {
+                setIsDeleting(false);
+                setDeleteTarget(null);
+            });
     }, [deleteCommittedEntry, deleteTarget, isDeleting]);
 
     const handleStartNewClick = useCallback(() => {

--- a/frontend/src/pages/student/digital-transcript/DigitalTranscriptWysiwygEntry.tsx
+++ b/frontend/src/pages/student/digital-transcript/DigitalTranscriptWysiwygEntry.tsx
@@ -8,6 +8,7 @@ import {
 } from 'react';
 import { Plus } from 'lucide-react';
 import { useSearchParams } from 'react-router-dom';
+import { toast } from 'sonner';
 import { useAuth } from '@/auth/useAuth';
 import { ConfirmDialog } from '@/components/shared';
 import { LearningRecordPrivacyNotice } from '@/components/learning-record/LearningRecordPrivacyNotice';
@@ -214,7 +215,12 @@ export interface FunnelAutoSaveState {
 }
 
 export interface FunnelFinishHandlers {
-    validateFinishRequirements: () => boolean;
+    /**
+     * Async because finishing flushes the debounced autosave before it resolves:
+     * navigating away cancels a pending save, so a last-second edit would
+     * otherwise be lost.
+     */
+    validateFinishRequirements: () => Promise<boolean>;
 }
 
 const COMMITTED_AUTOSAVE_MS = 500;
@@ -270,6 +276,14 @@ export function DigitalTranscriptWysiwygEntry({
     const [deleteConfirmFor, setDeleteConfirmFor] =
         useState<TranscriptEntry | null>(null);
     const baselinesRef = useRef<Record<string, TranscriptEntry>>({});
+    /**
+     * Last payload this component successfully wrote, per row id. Distinct from
+     * `baselinesRef`, which tracks the local editing baseline and is also written
+     * from session rows that were never sent anywhere — this one is only ever set
+     * on a confirmed write, so it is a true record of what the server holds. Used
+     * by `writeActiveRow` to skip a write the server already has.
+     */
+    const lastWrittenRef = useRef<Record<string, TranscriptEntry>>({});
     const prevExpandedIdRef = useRef<string | null>(null);
     const activePreviewFieldRef = useRef<string | null>(null);
     activePreviewFieldRef.current = activePreviewField;
@@ -378,6 +392,43 @@ export function DigitalTranscriptWysiwygEntry({
         [onFunnelAutoSaveStatusChange]
     );
 
+    /**
+     * The debounce timer id lives in a ref, not only in the effect closure, so the
+     * Finish flush can cancel a still-pending autosave before it awaits — the
+     * effect's own cleanup runs on re-render or unmount, which is far too late to
+     * be a cancellation. Safe to share: React runs an effect's cleanup before the
+     * next setup, so cleanup can never clear a newer run's timer, and the null
+     * check makes a double cancel a no-op.
+     */
+    const autosaveTimerRef = useRef<number | null>(null);
+    const cancelPendingAutoSave = useCallback(() => {
+        if (autosaveTimerRef.current === null) return;
+        window.clearTimeout(autosaveTimerRef.current);
+        autosaveTimerRef.current = null;
+    }, []);
+
+    /**
+     * Ownership of the autosave label. Every save intent — a scheduled debounce,
+     * the Finish flush — takes the next ticket, and a save only reports its
+     * outcome while it still holds the latest one.
+     *
+     * Two orderings need this. Serializing writes makes it possible for a
+     * superseded save to resolve after a newer one has already started and repaint
+     * 'saved' over its 'saving'. And even before serialization, an in-flight save
+     * could resolve 'saved' over the 'pending' of an edit made while it was on the
+     * wire — claiming the ticket at schedule time rather than at fire time closes
+     * both.
+     */
+    const saveTicketRef = useRef(0);
+    const nextSaveTicket = useCallback(() => {
+        saveTicketRef.current += 1;
+        return saveTicketRef.current;
+    }, []);
+    const isLatestSaveTicket = useCallback(
+        (ticket: number) => ticket === saveTicketRef.current,
+        []
+    );
+
     const buildSavedEntry = useCallback(
         (row: TranscriptEntry): TranscriptEntry => {
             const existing = entries.find((e) => e.id === row.id);
@@ -390,7 +441,13 @@ export function DigitalTranscriptWysiwygEntry({
         [entries]
     );
 
-    const persistActiveRow = useCallback(async (): Promise<boolean> => {
+    /**
+     * The actual write. Never call this directly — go through `persistActiveRow`,
+     * which serializes attempts. Reads the live session through `sessionRef`, so a
+     * caller that waited in the queue writes what the resident has typed by then,
+     * not what was on screen when it was enqueued.
+     */
+    const writeActiveRow = useCallback(async (): Promise<boolean> => {
         const current = sessionRef.current;
         const id = current?.expandedId;
         if (!id) return false;
@@ -398,8 +455,19 @@ export function DigitalTranscriptWysiwygEntry({
         if (!row) return false;
 
         const saved = buildSavedEntry(row);
+        // Two independent answers to "does the server already have this". `entries`
+        // is the committed state from the hook, but it only refreshes on re-render:
+        // a queued attempt resumes on the microtask queue, ahead of the re-render
+        // carrying the previous attempt's setEntries, so on its own it would always
+        // read stale and issue a redundant PUT. `lastWrittenRef` is set
+        // synchronously on the success path below, so it closes that window without
+        // depending on render timing.
         const existing = entries.find((e) => e.id === id);
-        if (existing && entryPayloadEqual(saved, existing)) {
+        const lastWritten = lastWrittenRef.current[id];
+        if (
+            (existing && entryPayloadEqual(saved, existing)) ||
+            (lastWritten && entryPayloadEqual(saved, lastWritten))
+        ) {
             return true;
         }
 
@@ -415,39 +483,114 @@ export function DigitalTranscriptWysiwygEntry({
                 };
             });
             baselinesRef.current[id] = cloneTranscriptEntry(saved);
+            lastWrittenRef.current[id] = cloneTranscriptEntry(saved);
             return true;
         } catch {
             return false;
         }
     }, [buildSavedEntry, upsertCommittedEntry, entries]);
 
-    const validateFinishRequirements = useCallback((): boolean => {
-        const current = sessionRef.current;
-        const id = current?.expandedId;
-        if (!id) return false;
-        const row = current.rows.find((r) => r.id === id);
-        if (!row) return false;
+    /**
+     * Serializes writes so two callers can never have an upsert in flight for the
+     * same row at once. The debounced autosave and the Finish flush overlap by
+     * design — the timer's save can still be awaiting the server when Finish fires
+     * — and running them concurrently is worse than a wasted request:
+     * `upsertCommittedEntry` chooses POST vs PUT from a client_id → backend id map
+     * written only *after* the create resolves, so two racing calls for a row with
+     * no id yet both POST, and the unique index on (user_id, client_id) rejects the
+     * loser. That surfaced as "Saved" while the losing call's newer answers were
+     * dropped.
+     *
+     * Each caller gets the promise for its own attempt, so it still sees its own
+     * boolean. The queue link carries both handlers deliberately: a failed or
+     * throwing attempt must not stall the chain or reject an unrelated caller.
+     */
+    const persistQueueRef = useRef<Promise<void>>(Promise.resolve());
 
-        if (!entryIsComplete(row, 'funnel')) {
-            setSaveErrorRowId(id);
-            setActiveStep(firstIncompleteFunnelStep(row));
-            setActivePreviewField(null);
-            return false;
-        }
+    const persistActiveRow = useCallback((): Promise<boolean> => {
+        const attempt = persistQueueRef.current.then(() => writeActiveRow());
+        persistQueueRef.current = attempt.then(
+            () => undefined,
+            () => undefined
+        );
+        return attempt;
+    }, [writeActiveRow]);
 
-        setSaveErrorRowId(null);
-        // Success path only, mirroring the attendance/program convention: the
-        // row is complete and the resident is finishing. The row itself was
-        // already persisted by the autosave in persistActiveRow.
-        entriesCommittedThisSessionRef.current += 1;
-        analyticsRef.current?.entryCompleted(row);
-        return true;
-    }, []);
+    const validateFinishRequirements =
+        useCallback(async (): Promise<boolean> => {
+            const current = sessionRef.current;
+            const id = current?.expandedId;
+            if (!id) return false;
+            const row = current.rows.find((r) => r.id === id);
+            if (!row) return false;
+
+            if (!entryIsComplete(row, 'funnel')) {
+                setSaveErrorRowId(id);
+                setActiveStep(firstIncompleteFunnelStep(row));
+                setActivePreviewField(null);
+                return false;
+            }
+
+            // Flush the debounced autosave before finishing. Finishing navigates
+            // away, which unmounts this component and cancels any pending save, so
+            // an edit made within COMMITTED_AUTOSAVE_MS of the click would never
+            // reach the server. persistActiveRow reads the live session and no-ops
+            // when the row already matches what is committed.
+            //
+            // Cancel the pending debounce first: this flush writes the same live
+            // row that timer would have written, so letting it fire afterwards is
+            // pure duplicate traffic. That is a cancellation, not the race fix — a
+            // timer that has already fired is mid-request and cannot be called
+            // back, which is what persistActiveRow's queue is for. Deliberately
+            // after the completeness check above, so an incomplete row keeps its
+            // pending autosave and partial answers still reach the server.
+            cancelPendingAutoSave();
+            nextSaveTicket();
+            reportAutoSaveStatus('saving');
+            if (!(await persistActiveRow())) {
+                setSaveErrorRowId(id);
+                reportAutoSaveStatus('error');
+                return false;
+            }
+            reportAutoSaveStatus('saved', new Date());
+
+            setSaveErrorRowId(null);
+            // Success path only, mirroring the attendance/program convention: the
+            // row is complete, saved, and the resident is finishing. The tracker
+            // refuses a second completion for the same entry, so the session count
+            // only advances when an event was actually emitted.
+            if (analyticsRef.current?.entryCompleted(row)) {
+                entriesCommittedThisSessionRef.current += 1;
+            }
+            return true;
+        }, [
+            persistActiveRow,
+            reportAutoSaveStatus,
+            cancelPendingAutoSave,
+            nextSaveTicket
+        ]);
 
     useEffect(() => {
         if (!isFunnel || !onRegisterFunnelFinish) return;
         onRegisterFunnelFinish({ validateFinishRequirements });
     }, [isFunnel, onRegisterFunnelFinish, validateFinishRequirements]);
+
+    // ID-830: one lr_session_ended per visit to the form, covering both ways to
+    // leave — pagehide for tab/browser close and bfcache, the cleanup for in-app
+    // navigation, which is how Finish leaves. beforeunload/unload are deliberately
+    // not used: they are unreliable and break bfcache. The tracker's one-shot
+    // makes the overlap harmless.
+    useEffect(() => {
+        if (!isFunnel) return;
+        const tracker = analyticsRef.current;
+        tracker?.beginSession();
+        const end = () => tracker?.endSession();
+        window.addEventListener('pagehide', end);
+        return () => {
+            window.removeEventListener('pagehide', end);
+            end();
+        };
+    }, [isFunnel]);
 
     // ID-806: one lr_entry_started per entry actually opened for editing.
     // Gated on hydrated + an expanded row so loading and empty renders are not
@@ -477,10 +620,19 @@ export function DigitalTranscriptWysiwygEntry({
 
         reportAutoSaveStatus('pending');
 
-        const t = window.setTimeout(() => {
+        // Claim the label before scheduling. Any save already in flight now holds a
+        // stale ticket, so it cannot resolve and paint 'saved' over this newer dirty
+        // state. A still-pending timer always holds the latest ticket — every later
+        // intent cancels it first — which is why 'saving' below needs no guard while
+        // the outcome does.
+        const ticket = nextSaveTicket();
+
+        autosaveTimerRef.current = window.setTimeout(() => {
+            autosaveTimerRef.current = null;
             void (async () => {
                 reportAutoSaveStatus('saving');
                 const ok = await persistActiveRow();
+                if (!isLatestSaveTicket(ticket)) return;
                 if (ok) {
                     reportAutoSaveStatus('saved', new Date());
                 } else {
@@ -489,7 +641,7 @@ export function DigitalTranscriptWysiwygEntry({
             })();
         }, COMMITTED_AUTOSAVE_MS);
 
-        return () => window.clearTimeout(t);
+        return cancelPendingAutoSave;
     }, [
         isFunnel,
         session,
@@ -497,6 +649,9 @@ export function DigitalTranscriptWysiwygEntry({
         buildSavedEntry,
         persistActiveRow,
         reportAutoSaveStatus,
+        cancelPendingAutoSave,
+        nextSaveTicket,
+        isLatestSaveTicket,
         onFunnelAutoSaveStatusChange
     ]);
 
@@ -552,11 +707,7 @@ export function DigitalTranscriptWysiwygEntry({
                     ) {
                         setActivePreviewField(previewField);
                     }
-                    const current = sessionRef.current;
-                    const editedRow = current?.rows.find((r) => r.id === id);
-                    if (editedRow) {
-                        analyticsRef.current?.noteEdit(editedRow, patchedKey);
-                    }
+                    analyticsRef.current?.noteEdit(patchedKey);
                 }
             }
             setSession((prev) => {
@@ -650,7 +801,12 @@ export function DigitalTranscriptWysiwygEntry({
                 ...row,
                 topSkills: row.topSkills.slice(0, TOP_SKILLS_MAX)
             };
-            void upsertCommittedEntry(saved);
+            // Fire-and-forget, but upsertCommittedEntry now rejects on a failed
+            // write, so the rejection has to be handled here or it surfaces as an
+            // unhandled promise rejection. The categories variant has no autosave
+            // label, so the row's save-error state is the only channel available —
+            // the same one the incomplete-row check above uses.
+            void upsertCommittedEntry(saved).catch(() => setSaveErrorRowId(id));
             setSession((prev) => {
                 if (!prev) return prev;
                 const next = syncSessionRowsAfterUpsert(prev, saved);
@@ -660,6 +816,51 @@ export function DigitalTranscriptWysiwygEntry({
         },
         [formVariant, upsertCommittedEntry]
     );
+
+    const handleConfirmDeleteEntry = useCallback(() => {
+        const target = deleteConfirmFor;
+        setDeleteConfirmFor(null);
+        if (!target) return;
+        // Drop local state only once the server confirms. deleteCommittedEntry now
+        // rejects on a failed delete and keeps the entry, so removing the row up
+        // front would hide a record that still exists — it would come back on the
+        // next hydrate, which reads as data loss in reverse.
+        void deleteCommittedEntry(target.id)
+            .then(() => {
+                delete baselinesRef.current[target.id];
+                delete lastWrittenRef.current[target.id];
+                setSession((prev) => {
+                    if (!prev) return null;
+                    const rows = prev.rows.filter((r) => r.id !== target.id);
+                    // Deleting the last row must not null the session: bootstrapped
+                    // is already true, so nothing reinitializes it and the editor
+                    // would sit on its loading state until a reload. Reopen a blank
+                    // draft, the same way bootstrap recovers from an empty session.
+                    if (rows.length === 0) {
+                        return ensureDraftEditorOpen(
+                            {
+                                ...prev,
+                                rows,
+                                expandedId: null,
+                                lastPreviewId: null
+                            },
+                            entries,
+                            defaultFacility
+                        );
+                    }
+                    const expandedId =
+                        prev.expandedId === target.id ? null : prev.expandedId;
+                    const lastPreviewId =
+                        prev.lastPreviewId === target.id
+                            ? (rows[rows.length - 1]?.id ?? null)
+                            : prev.lastPreviewId;
+                    return { ...prev, rows, expandedId, lastPreviewId };
+                });
+            })
+            .catch(() => {
+                toast.error('Could not delete that entry. Please try again.');
+            });
+    }, [deleteConfirmFor, deleteCommittedEntry, entries, defaultFacility]);
 
     const displayRows = useMemo(
         () => (session ? sortEntriesNewestFirst(session.rows) : []),
@@ -958,29 +1159,7 @@ export function DigitalTranscriptWysiwygEntry({
                 cancelLabel="Cancel"
                 variant="destructive"
                 buttonClassName="h-10"
-                onConfirm={() => {
-                    const target = deleteConfirmFor;
-                    setDeleteConfirmFor(null);
-                    if (!target) return;
-                    delete baselinesRef.current[target.id];
-                    void deleteCommittedEntry(target.id);
-                    setSession((prev) => {
-                        if (!prev) return null;
-                        const rows = prev.rows.filter(
-                            (r) => r.id !== target.id
-                        );
-                        if (rows.length === 0) return null;
-                        const expandedId =
-                            prev.expandedId === target.id
-                                ? null
-                                : prev.expandedId;
-                        const lastPreviewId =
-                            prev.lastPreviewId === target.id
-                                ? (rows[rows.length - 1]?.id ?? null)
-                                : prev.lastPreviewId;
-                        return { ...prev, rows, expandedId, lastPreviewId };
-                    });
-                }}
+                onConfirm={handleConfirmDeleteEntry}
             />
         </div>
     );

--- a/frontend/src/pages/student/digital-transcript/learningRecordAnalytics.ts
+++ b/frontend/src/pages/student/digital-transcript/learningRecordAnalytics.ts
@@ -1,6 +1,8 @@
 import { ANALYTICS_EVENTS, captureEvent, flowTimerSeconds } from '@/lib/events';
 import {
+    FUNNEL_FORM_FIELD_TOTAL,
     FUNNEL_FORM_STEPS,
+    countFunnelFieldsAnswered,
     funnelStepFieldAnswered,
     funnelStepFieldKind,
     type FunnelStepField,
@@ -88,63 +90,154 @@ function funnelFieldForPatchKey(key: string): FunnelStepField | null {
 }
 
 interface QuestionTiming {
-    field: FunnelStepField;
-    startedMs: number;
+    /** Start of the editing run in progress, or null when no run is open. */
+    openMs: number | null;
     lastEditMs: number;
+    /** Sum of every closed editing run for this question, in ms. */
+    totalMs: number;
 }
 
 /**
- * Per-entry tracker. One instance per expanded entry; `reset()` starts a new one.
+ * Per-entry tracker. One instance per form mount; `entryStarted()` begins a new
+ * entry and clears the previous one's state.
  * Not a hook — the form holds it in a ref so it survives re-renders.
+ *
+ * Every `lr_question_left` for an entry comes from `stepChanged` or
+ * `entryCompleted`, exactly once per question. `noteEdit` only accumulates
+ * timing.
  */
 export class LearningRecordTracker {
     private entryStartMs = Date.now();
     /**
-     * Set once at construction, which the form does on mount — so
+     * Start of the current visit to the form, re-based by `beginSession` — so
      * `seconds_since_session_start` measures from when the resident opened the
      * form, not from when they opened the first entry. Never reset by
      * `entryStarted`, so it stays comparable across entries in one sitting.
      */
-    private readonly sessionStartMs = Date.now();
+    private sessionStartMs = Date.now();
     private entryIndex = 0;
-    private current: QuestionTiming | null = null;
+    /** Accumulated editing time per question, for the entry in progress. */
+    private timings = new Map<FunnelStepField, QuestionTiming>();
+    /** Question currently being edited, so its run can be closed on switch. */
+    private currentField: FunnelStepField | null = null;
     /** Fields edited at least once during this entry. */
     private touched = new Set<FunnelStepField>();
     /** Steps already reported, so re-visiting a step does not double count. */
     private reportedSteps = new Set<number>();
+    /**
+     * The step currently on screen. Tracked so `entryCompleted` can charge the
+     * elapsed step time to the step the resident is actually standing on, and zero
+     * to steps it is flushing that were never visited.
+     */
+    private currentStepIndex = 0;
     private stepStartMs = Date.now();
+    /** Set by `entryCompleted`, so a second Finish cannot emit a duplicate. */
+    private completed = false;
+    /** Entries actually saved this session, reported by `endSession`. */
+    private entriesCompleted = 0;
+    /** One-shot guard for `endSession`, re-armed by `beginSession`. */
+    private sessionEndSent = false;
+
+    /**
+     * Opens a session window. Called when the form's session effect mounts — which
+     * React StrictMode does twice in development, discarding the first cycle;
+     * without re-arming the one-shot, that throwaway cleanup would latch the guard
+     * and suppress the real session-end event.
+     *
+     * Re-bases everything `endSession` reports, not just the one-shot. Its cleanup
+     * always emits, so by the time this runs any earlier window has already been
+     * reported — carrying that window's start time or entry count forward would
+     * double count it into the next event. StrictMode walks exactly that path
+     * (mount → cleanup emits → mount), and so would `isFunnel` flipping while the
+     * component stays mounted. Per-entry state is deliberately left alone; that
+     * belongs to `entryStarted`.
+     */
+    beginSession(): void {
+        this.sessionEndSent = false;
+        this.sessionStartMs = Date.now();
+        this.entriesCompleted = 0;
+    }
+
+    /**
+     * Called once when the resident leaves the form, by either route: in-app
+     * navigation or `pagehide`.
+     *
+     * This is the only measure of total time in the tool that includes residents
+     * who never saved an entry — `seconds_since_session_start` rides on
+     * `lr_entry_completed`, so an abandoned session is invisible to it, and that
+     * is exactly the friction signal the pilot is looking for.
+     */
+    endSession(): void {
+        if (this.sessionEndSent) return;
+        this.sessionEndSent = true;
+        captureEvent(ANALYTICS_EVENTS.LrSessionEnded, {
+            duration_seconds: flowTimerSeconds(this.sessionStartMs),
+            entries_completed: this.entriesCompleted
+        });
+    }
 
     /** Called once when the form becomes interactive. */
     entryStarted(entryIndexInSession: number): void {
         this.entryIndex = entryIndexInSession;
         this.entryStartMs = Date.now();
         this.stepStartMs = Date.now();
-        this.current = null;
+        this.timings.clear();
+        this.currentField = null;
         this.touched.clear();
         this.reportedSteps.clear();
+        // Matches the form's `activeStep` state, which is always 0 on a fresh entry.
+        this.currentStepIndex = 0;
+        this.completed = false;
         captureEvent(ANALYTICS_EVENTS.LrEntryStarted, {
             entry_index_in_session: entryIndexInSession
         });
     }
 
     /**
-     * Called on every field mutation. Emits `lr_question_left` for the previous
-     * question when focus effectively moves to a different one.
+     * Called on every field mutation. Records timing only — it deliberately
+     * emits nothing.
+     *
+     * `lr_question_left` is emitted exclusively by `stepChanged` /
+     * `entryCompleted`, which is what guarantees exactly one event per question
+     * per entry, carrying the values the resident actually left behind. When
+     * this method also emitted, a question edited before the end of its step
+     * produced two events — the second with `duration_seconds: 0` but
+     * `touched: true` — which dragged the per-question median toward zero and
+     * inflated the denominator for answer-rate charts.
      */
-    noteEdit(entry: TranscriptReflectionFields, patchKey: string): void {
+    noteEdit(patchKey: string): void {
         const field = funnelFieldForPatchKey(patchKey);
         if (!field) return;
         this.touched.add(field);
 
-        if (this.current && this.current.field !== field) {
-            this.emitQuestion(entry, this.current.field, true);
-        }
         const now = Date.now();
-        if (this.current?.field !== field) {
-            this.current = { field, startedMs: now, lastEditMs: now };
-        } else {
-            this.current.lastEditMs = now;
+        if (this.currentField && this.currentField !== field) {
+            this.closeRun(this.currentField);
         }
+        const timing = this.timings.get(field);
+        if (timing) {
+            timing.openMs ??= now;
+            timing.lastEditMs = now;
+        } else {
+            this.timings.set(field, {
+                openMs: now,
+                lastEditMs: now,
+                totalMs: 0
+            });
+        }
+        this.currentField = field;
+    }
+
+    /**
+     * Folds an in-progress run into the question's total. The run ends at the
+     * last keystroke, not at the moment of the switch, so idle time after the
+     * resident stops typing is not charged to the question.
+     */
+    private closeRun(field: FunnelStepField): void {
+        const timing = this.timings.get(field);
+        if (timing?.openMs == null) return;
+        timing.totalMs += Math.max(0, timing.lastEditMs - timing.openMs);
+        timing.openMs = null;
     }
 
     /**
@@ -158,79 +251,120 @@ export class LearningRecordTracker {
         fromStepIndex: number,
         toStepIndex: number
     ): void {
-        const from = FUNNEL_FORM_STEPS[fromStepIndex];
-        if (from && !this.reportedSteps.has(fromStepIndex)) {
-            this.reportedSteps.add(fromStepIndex);
-            let answered = 0;
-            for (const field of from.fields) {
-                if (funnelStepFieldAnswered(entry, field)) answered += 1;
-                this.emitQuestion(entry, field, this.touched.has(field));
-            }
-            captureEvent(ANALYTICS_EVENTS.LrStepCompleted, {
-                step_id: from.id,
-                step_index: fromStepIndex,
-                duration_seconds: flowTimerSeconds(this.stepStartMs),
-                answered_count: answered
-            });
-        }
-        this.current = null;
+        if (this.currentField) this.closeRun(this.currentField);
+        this.currentField = null;
+
+        this.reportStep(
+            entry,
+            fromStepIndex,
+            flowTimerSeconds(this.stepStartMs)
+        );
         this.stepStartMs = Date.now();
-        void toStepIndex;
+        this.currentStepIndex = toStepIndex;
     }
 
-    /** Called when the resident finishes a complete entry. */
-    entryCompleted(entry: TranscriptReflectionFields): void {
-        // Flush the final step so its questions are represented too.
-        const lastIndex = FUNNEL_FORM_STEPS.length - 1;
-        const last = FUNNEL_FORM_STEPS[lastIndex];
-        if (last && !this.reportedSteps.has(lastIndex)) {
-            this.reportedSteps.add(lastIndex);
-            for (const field of last.fields) {
-                this.emitQuestion(entry, field, this.touched.has(field));
-            }
-        }
-        this.current = null;
+    /**
+     * Emits one `lr_question_left` per field of a step, then one
+     * `lr_step_completed` for the step itself. Idempotent per entry: the
+     * `reportedSteps` guard makes a second call for the same step a no-op, which is
+     * what lets `entryCompleted` flush unconditionally without double counting.
+     */
+    private reportStep(
+        entry: TranscriptReflectionFields,
+        stepIndex: number,
+        durationSeconds: number
+    ): void {
+        const step = FUNNEL_FORM_STEPS[stepIndex];
+        if (!step || this.reportedSteps.has(stepIndex)) return;
+        this.reportedSteps.add(stepIndex);
 
         let answered = 0;
-        let total = 0;
-        for (const step of FUNNEL_FORM_STEPS) {
-            for (const field of step.fields) {
-                total += 1;
-                if (funnelStepFieldAnswered(entry, field)) answered += 1;
-            }
+        for (const field of step.fields) {
+            if (funnelStepFieldAnswered(entry, field)) answered += 1;
+            this.emitQuestion(entry, field);
+        }
+        captureEvent(ANALYTICS_EVENTS.LrStepCompleted, {
+            step_id: step.id,
+            step_index: stepIndex,
+            duration_seconds: durationSeconds,
+            answered_count: answered
+        });
+    }
+
+    /**
+     * Called when the resident finishes a complete entry, *after* the entry has
+     * been persisted — a completion event for an entry that failed to save
+     * would overstate the funnel.
+     *
+     * Returns false without emitting if this entry was already completed, so a
+     * second Finish click cannot produce a duplicate.
+     */
+    entryCompleted(entry: TranscriptReflectionFields): boolean {
+        if (this.completed) return false;
+        this.completed = true;
+        this.entriesCompleted += 1;
+
+        if (this.currentField) this.closeRun(this.currentField);
+        this.currentField = null;
+
+        // Flush every step that has not reported yet, not just the final one.
+        // `stepChanged` reports a step only when the resident *leaves* it, and two
+        // paths dodge that. The progress card is an ungated tablist and `activeStep`
+        // always starts at 0, so resuming a saved entry and jumping straight to the
+        // last step leaves the middle step never reported at all — its questions
+        // vanish from the answer-rate denominator this module exists to supply. And
+        // the final step is never left, so before this it emitted `lr_question_left`
+        // via a partial flush here but never an `lr_step_completed`, leaving it
+        // absent from the step funnel on every single entry.
+        //
+        // Duration is real for the step on screen and 0 for steps never visited —
+        // `stepStartMs` is one timestamp and means nothing for an unvisited step.
+        for (let i = 0; i < FUNNEL_FORM_STEPS.length; i++) {
+            this.reportStep(
+                entry,
+                i,
+                i === this.currentStepIndex
+                    ? flowTimerSeconds(this.stepStartMs)
+                    : 0
+            );
         }
 
+        // Counted with the same helpers `entryIsComplete` uses, which exclude the
+        // optional completionDate. The old local loop walked all of
+        // FUNNEL_FORM_STEPS, so total_fields was 10 against a 9-field completion
+        // requirement and answered_count could not reach it without a date —
+        // capping any completion-rate insight built on the pair at 90%.
         captureEvent(ANALYTICS_EVENTS.LrEntryCompleted, {
             duration_seconds: flowTimerSeconds(this.entryStartMs),
-            answered_count: answered,
-            total_fields: total,
+            answered_count: countFunnelFieldsAnswered(entry),
+            total_fields: FUNNEL_FORM_FIELD_TOTAL,
             entry_index_in_session: this.entryIndex,
             seconds_since_session_start: flowTimerSeconds(this.sessionStartMs),
             submitted_at: new Date().toISOString()
         });
+        return true;
     }
 
+    /**
+     * The single emitter for `lr_question_left`. `touched` is derived here
+     * rather than passed in, so no caller can reintroduce a second event for a
+     * question that was already reported.
+     */
     private emitQuestion(
         entry: TranscriptReflectionFields,
-        field: FunnelStepField,
-        touched: boolean
+        field: FunnelStepField
     ): void {
-        const kind = funnelStepFieldKind(field);
-        const timing = this.current?.field === field ? this.current : null;
+        this.closeRun(field);
+        const timing = this.timings.get(field);
         // Untouched questions report 0 seconds and touched=false so time charts
         // can exclude them while selection-rate charts still count them.
-        const duration = timing
-            ? Math.max(
-                  0,
-                  Math.round((timing.lastEditMs - timing.startedMs) / 1000)
-              )
-            : 0;
+        const duration = timing ? Math.round(timing.totalMs / 1000) : 0;
         captureEvent(ANALYTICS_EVENTS.LrQuestionLeft, {
             question_key: field,
             step_id: stepIdForField(field),
-            kind,
+            kind: funnelStepFieldKind(field),
             duration_seconds: duration,
-            touched,
+            touched: this.touched.has(field),
             answered: funnelStepFieldAnswered(entry, field),
             selection_count: selectionCount(entry, field),
             char_count: charCount(entry, field)

--- a/frontend/src/vite-env.d.ts
+++ b/frontend/src/vite-env.d.ts
@@ -3,7 +3,7 @@
 interface ImportMetaEnv {
     readonly VITE_PUBLIC_POSTHOG_KEY: string;
     readonly VITE_PUBLIC_POSTHOG_HOST: string;
-    /** 'production' | 'development' — set per deployment at image build time. Blank locally, which disables analytics. */
+    /** 'production' | 'development' | 'local' — set per deployment at image build time. Blank locally, which disables analytics; set 'local' to send deliberately from a dev machine. */
     readonly VITE_DEPLOYMENT: string;
     /** Deployment identity: 'stlouis' | 'maine' | 'alaska' | 'mocode' | 'demo' | 'staging'. */
     readonly VITE_STATE: string;


### PR DESCRIPTION
Branch: `cpride/posthog_lr_fixes`
Follows: PR #1207 (`cpride/posthog_learning_record`), merged as `b7512cd0`
Tickets: **[ID-827](https://app.asana.com/1/1201607307149189/project/1212887022738973/task/1217097620641814)** (filter by facility), plus fixes supporting **[ID-830](https://app.asana.com/1/1201607307149189/project/1209460078641109/task/1217564912951082)** (Learning Record insights)

## Summary

**A resident's work could be lost three ways, and none of them looked like failure.** Clicking
*Finish* navigated away immediately, which unmounted the form and cancelled the pending 500 ms
autosave, so anything typed in the final half-second never reached the server. A write that
*failed* resolved as success, so the resident saw "Saved" and Finish navigated home on an entry
that was never persisted. And the autosave and the Finish flush could race, with the loser's
newer answers dropped under the same green label.

Finish now saves first and leaves only once the save succeeds; a failed write surfaces as an
error and keeps the resident on the form; and writes are serialized so they cannot overwrite each
other.

Everything else is invisible to residents and staff:

- **Analytics correctness** — the Learning Record events were counting some questions twice, and
  the form's final step never reached the step funnel at all, plus three smaller issues raised in
  review of #1207 and merged without being addressed.
- **ID-827, filter by facility** — `facility_id` is a per-database autoincrement, so maine's
  facility 1 and St. Louis's facility 1 collapse into one row in any breakdown. Events now also
  carry `facility` (`maine:1`) and `facility_name`.
- **A new `lr_session_ended` event** so ID-830's "total time in the tool per session" graph can be
  built from a real measurement rather than a proxy.

> **Before building the per-question charts:** the Learning Record events maine has sent since
> Aug 18 count some questions twice. This PR stops that. Start those charts from the date this
> deploys — the affected data is about one test entry, so it isn't worth correcting.

No backend, schema, or API changes. The only non-frontend files in the diff are Go module
manifests from an unrelated security bump — see [Unrelated: Go dependency bump](#unrelated-go-dependency-bump).

## Where to see each change

| Route | What changed | What to look for |
| --- | --- | --- |
| `/learning-record-funnel/entry` | Finish saves before it closes | Type into the last field and click **Finish** immediately. Reload the entry — the final keystrokes are there. Previously they were gone. |
| `/learning-record-funnel/entry` | Finish fails safely | Stop the backend, then click **Finish**. It stays on the form and shows the save error rather than navigating home on an unsaved entry. |
| `/learning-record-funnel/entry` | Failed autosaves show an error | Stop the backend and type. The autosave label reads **error**, not "Saved". Previously a failed write reported success. |
| `/learning-record-funnel/entry` · home | Failed deletes keep the entry | Stop the backend, delete an entry. It stays, with an error toast. Previously the row vanished locally and returned on the next reload. |
| `/learning-record-funnel/entry` | One analytics event per question | No visible change. With a real PostHog key, a completed entry now emits exactly 10 `lr_question_left`, 3 `lr_step_completed`, 1 `lr_entry_completed` — the third step event is new, see below. |
| `/learning-record-funnel/entry` | Final step reaches the step funnel | No visible change, but **`lr_step_completed` data changes shape**. The event fires on *leaving* a step and the last step is never left, so `future` emitted none on any entry ever recorded. Entry completion now flushes it. A step the resident skipped flushes with `duration_seconds: 0`. |
| `/learning-record-funnel/entry` | New `lr_session_ended` | Open the form, save nothing, navigate away — one event with `entries_completed: 0`. Nothing captured abandoned sessions before. |
| Login / any event | Facility tagging (ID-827) | Events now carry `facility` = `<state>:<id>` and `facility_name` alongside the existing `facility_id`. |
| Any page that loads data | SWR JSON failures report | A 200 response with an empty or malformed body now emits `api_error` instead of failing silently to analytics. |
| `demov2` | Public demo stops reporting | The demo build now gets a placeholder PostHog key, which the frontend rejects. |

---

# Reviewer notes

## The duplicate-event bug

Two code paths emitted the same event for the same question. `noteEdit` emitted
`lr_question_left` for the previous field whenever the resident moved to a new one, and
`stepChanged` then re-emitted **every** field of that step — including the one already reported.

Walking the first step (`programName`, `completionDate`, `whatMadeYouFinish`):

| Action | Emitted, before this PR |
| --- | --- |
| type in `programName` | — |
| type in `completionDate` | `programName` · `touched: true` · real duration |
| click Next | `programName` **again** · `touched: true` · `duration_seconds: 0`, then `completionDate`, then `whatMadeYouFinish` |

The duplicate carried `duration_seconds: 0` because the timing pointer had already moved on, but
`touched` came from a set and was still `true`. That combination is what made it harmful rather
than merely noisy:

- **Median time per question** filters on `touched = true` specifically to keep zeros out. The
  duplicate put a zero inside the filter, dragging the median down for every question except the
  last one edited in each step.
- **Answer rate per question** divides answered events by total events. The denominator doubled
  for touched questions but not untouched ones, so the rate was distorted per question and varied
  with the order the resident happened to fill the form in.

**The fix is structural, not a patch.** `noteEdit` no longer emits anything — it only accumulates
timing. `stepChanged` and `entryCompleted` are now the only emitters, and `touched` is derived
inside the emitter rather than passed in by the caller, so a second event for an already-reported
question cannot be reintroduced by a future edit.

Timing also got more accurate on the way through. It was previously read off whichever editing run
happened to be open, so a question the resident returned to reported only its last run. It now sums
each question's editing runs across the whole entry, with each run ending at the last keystroke so
idle time after they stop typing isn't charged to the question.

Making `entryCompleted` an emitter also closed an older gap. `lr_step_completed` fires when a
resident *leaves* a step, and the last step is never left — so `future` emitted none on any entry
ever recorded, and step-level timing covered two thirds of the form. The same gap hit the middle
step from the other direction: the progress card is an ungated tablist and `activeStep` starts at 0,
so resuming a saved entry and jumping to the last step left `experience` unreported, dropping its
questions from the answer-rate denominator.

`entryCompleted` now flushes every step that hasn't reported. The existing `reportedSteps` guard
makes an already-reported step a no-op, so the flush is unconditional and cannot double count. A
completed entry emits **3** `lr_step_completed`, not 2. Duration is real for the step on screen and
`0` for one never visited — those zeros keep the denominator complete and are expected in
`lr_step_completed` timing.

Two smaller corrections in the same file:

- **`total_fields` was 10 against a 9-field completion requirement.** The local loop walked every
  field while `entryIsComplete` excludes the optional `completionDate`, so `answered_count` could
  not reach `total_fields` without a date — capping any completion-rate insight built on the pair
  at 90%. Both now come from the helpers `entryIsComplete` itself uses.
- **`beginSession` re-bases the session start and entry count**, not just the one-shot. Its
  cleanup always emits, so an earlier window has already been reported by the time it runs;
  carrying that window's start time or count forward double counted it into the next
  `lr_session_ended`. StrictMode walks exactly that path, and so would `isFunnel` flipping while
  the component stays mounted.

## Finish now saves before it completes

`validateFinishRequirements` is `async` and awaits `persistActiveRow()`. Order is validate
completeness → persist → record completion, so an entry that failed to save no longer produces a
completion event and no longer overstates the funnel.

This is also what fixes the data loss described in the summary — the same await covers both, since
the pending autosave is exactly what was being discarded.

Notes for review:

- `persistActiveRow` reads the live session and returns early when the row already matches what is
  committed, so this adds no redundant write on the common path.
- `FunnelFinishHandlers.validateFinishRequirements` now returns `Promise<boolean>`.
  `funnelOnFinish` keeps its `() => void` type and is adapted at the call site with
  `() => void handleFinish()`, matching the existing `onClick={() => void handleDownload()}`
  convention one line above — so the Shell and the button component are untouched.
- The await opens a window for a second click, so `handleFinish` is guarded by an in-flight ref.
  The tracker separately refuses a duplicate completion event; the ref is what prevents a double
  navigation.
- No new UI. The existing autosave indicator already renders `saving` / `saved` / `error`, and
  finishing now drives it.

## Saving now fails loudly

**A failed write was reported as success.** `API.fetchWithHandling` resolves `{ success: false }`
rather than throwing, so `apiCreateEntry` returned null and `apiUpdateEntry` returned false on a
500, a timeout, or offline — and `upsertCommittedEntry` awaited them and resolved normally anyway.
Callers read that as success. `upsertCommittedEntry` and `deleteCommittedEntry` now reject, and
every caller handles it.

**Concurrent saves could drop answers.** The debounced autosave and the Finish flush overlap by
design — the timer's save can still be on the wire when Finish fires. `upsertCommittedEntry`
chooses POST vs PUT from a `client_id → backend id` map written only *after* a create resolves, so
two racing calls for a row with no id yet both POST, and the unique index on
`(user_id, client_id)` rejects the loser. That surfaced as "Saved" with the loser's newer answers
gone. `persistActiveRow` now serializes attempts through a queue; `writeActiveRow` holds the write
itself and reads the live session, so a caller that waited writes what the resident has typed by
then rather than what was on screen when it queued.

Notes for review:

- **The autosave label could lie.** A superseded save resolving late repainted `saved` over a
  newer `saving`, and an in-flight save could repaint `saved` over the `pending` of an edit made
  while it was on the wire. Save intents now claim a ticket at schedule time and report an outcome
  only while they still hold the latest.
- **Finish cancels the pending debounce** before flushing, since the flush writes the same row.
  Deliberately *after* the completeness check, so an incomplete row keeps its autosave and partial
  answers still reach the server.
- **A failed delete used to remove the row locally**, where it reappeared on the next hydrate —
  data loss in reverse. Local state now clears only once the server confirms.
- `lastWrittenRef` records confirmed writes so a queued attempt can skip a redundant PUT.
  `entries` alone can't do this: a queued attempt resumes on the microtask queue, ahead of the
  re-render carrying the previous attempt's `setEntries`, so it would always read stale.

## ID-827 — filter by facility

The ticket asks for "a facility flag for being able to filter insights by not only state deployments
but also state and the facility within." Facility filtering technically worked already — `facility_id`
is on every event — but **breakdowns were wrong**, which is the part that matters.

`facilities.id` is a `SERIAL`
([00002_create_init_tables.sql:12-19](backend/migrations/00002_create_init_tables.sql#L12-L19)), a
per-database autoincrement. Each state's database starts at 1, so `facility_id: 1` names a different
facility depending on which deployment sent it, and a breakdown merges them into one row. This is
the same collision that already forced `distinct_id` to be namespaced to `maine:78`.

Two more schema facts shaped the fix: `facilities.name` has **no unique constraint** and is editable
from the admin UI (so it can collide across states, and a rename splits history), and there is **no
slug or external id column** — the only durable unique key is the pair (deployment, id).

So `identifyUser` now sends three facility properties instead of one, built as a single object so
the person and event copies cannot drift:

| Property | Role |
| --- | --- |
| `facility` (new) | `maine:1` — the stable key to filter and break down on. Survives renames, never collides across states. |
| `facility_name` (new) | `BCF` — display label, so dashboard rows read as names rather than opaque ids. |
| `facility_id` (unchanged) | Kept so the existing pilot dashboard filter keeps working. |

Notes for review:

- **`facility` only exists on events sent after this deploys.** Nothing backfills, so a `facility`
  breakdown starts at the deploy date.
- **Pre-login events carry no facility at all** — the login screen's `$pageview`, an `api_error`
  from an unauthenticated request. Correct, since there is no facility yet, but it means a
  facility-scoped total reads lower than an unscoped one.
- **`facility_name` names a building, not a person.** Worth stating plainly given the context: it is
  an institution name, not resident data.
- `resetAnalytics` needed no change — `posthog.reset()` clears super properties and only the
  deployment tags are re-registered, so facility correctly disappears on logout and returns at the
  next identify. Facility is user-scoped, unlike `deployment`/`state`.

## New event: `lr_session_ended`

ID-830 asks for "total time spent in the tool per session." Nothing measured it:
`seconds_since_session_start` only rides on `lr_entry_completed`, so a resident who opened the form
and abandoned it contributed **nothing** — and abandonment is exactly what a friction study is
looking for. The alternative, PostHog's `$session_duration`, is the whole-app session on a
30-minute inactivity timeout, so it counts time spent anywhere else in the app.

The form already recorded `sessionStartMs` at mount; it simply never reported when the session
ended. `lr_session_ended` now fires once when the resident leaves, carrying `duration_seconds` and
`entries_completed`.

- **Both routes out are covered**: `pagehide` for tab/browser close and bfcache, the effect cleanup
  for in-app navigation, which is how Finish leaves. A one-shot in the tracker makes the overlap
  harmless. `beforeunload`/`unload` are deliberately not used — unreliable, and they break bfcache.
- **It also improves the "achievements per session" graph**, which can now break down on
  `entries_completed` — a real per-session total including a **zero bucket** for sessions that saved
  nothing, rather than being inferred from `entry_index_in_session`.
- **Dev-only wrinkle**: React StrictMode double-invokes effects, so the throwaway cleanup emits one
  ~0-second event before the real one. `beginSession()` re-arms the one-shot so the real event still
  fires. Production runs the effect once. Filter `duration_seconds > 0` if dev noise gets in the way.
- Both properties stay inside the module's privacy rule: a duration and a count, no content.

## Smaller fixes from the #1207 review

- **Secrets no longer interpolated into shell source.** `POSTHOG_KEY` / `POSTHOG_HOST` move to the
  build step's `env:` block. Rendered directly into the `run:` script, a value containing shell
  syntax would execute on the runner.
- **The demo placeholder key now exists.** The comment in `container_builds.yml` claimed builds
  that shouldn't report get a placeholder key — no such branch existed, so `demov2` was reporting
  as `deployment=development, state=demo` on the real key. Three documents already stated demo was
  silent; this makes that true rather than rewriting the docs to match the leak. The primary
  dashboard filter (`deployment equals production`) already excluded demo, but the documented
  alternative (`state is not in staging, unknown`) would have let seeded demo data into the pilot
  numbers.
- **SWR JSON decode failures report.** `res.json()` sat outside both the network and HTTP error
  handlers, so an OK response with a bad body reached the user as an error while analytics saw
  nothing — the exact gap `swrFetcher.ts` was added to close.
- **`vite-env.d.ts` documents `local`.** `.env.example` tells developers to set
  `VITE_DEPLOYMENT=local`; the type declaration listed only `production` and `development`.


### Manual checks against the running app

#### First — make the app report at all

A normal dev checkout sends **nothing**. `initAnalytics` returns early unless the key is
`phc_`-prefixed *and* a deployment is named, so every check below is silently a no-op until
`frontend/.env` has all four of these:

```
VITE_PUBLIC_POSTHOG_KEY=phc_...            # a real key; the .env.example sample is rejected
VITE_PUBLIC_POSTHOG_HOST=https://us.i.posthog.com
VITE_DEPLOYMENT=local
VITE_STATE=maine                            # without this, stateTag() falls back to `unknown`
```

That last line matters for the facility check specifically: leave `VITE_STATE` blank and the
events read `facility: unknown:<id>`, which looks like a bug but is the documented fallback.

The Learning Record checks also need the `learning_record` feature flag **on** — the form is
behind it, and the `lr_*` events only exist inside the form.

Use the dev tools and posthog activity chart to see events.

## Unrelated: Go dependency bump

`d3be631a` bumps `klauspost/compress` to v1.18.7 across all four Go modules to clear
**GO-2026-5841**. `go.mod` / `go.sum` only — no Go source changes, which is why the summary above
still says no backend changes:

```
backend/go.mod              backend/migrations/go.mod    backend/seeder/go.mod
backend/go.sum              backend/migrations/go.sum    backend/seeder/go.sum
provider-middleware/go.mod  provider-middleware/go.sum
```

It rides along because it was already on the branch. It is independent of the Learning Record
work and can be reviewed on its own — the *Scan Go Dependencies for Vulnerabilities* and both
`golangci-lint` checks cover it.

## Not in this PR

- **The consent question from #1207 is still open.** It asked reviewers to decide whether
  person-attributed `lr_*` events and `char_count` match resident copy promising "all identifying
  information removed." The only review was an approval with no comment on it, so nothing was
  decided and both still ship. Worth settling before the pilot quotes any of this data.

