### PR TITLE
fix: instrumentation for learning record acceptance criteria

### DIFF
--- a/frontend/src/auth/AuthProvider.tsx
+++ b/frontend/src/auth/AuthProvider.tsx
@@ -3,7 +3,8 @@ import { INIT_KRATOS_LOGIN_FLOW, User } from '@/types';
 import { AuthContext, fetchUser, handleLogout } from '@/auth/useAuth';
 import { useNavigate } from 'react-router-dom';
 import { tabSessionManager } from '@/session/tabSession';
-import { identifyUser } from '@/lib/events';
+import { analyticsDistinctId, identifyUser } from '@/lib/events';
+import { setDigitalTranscriptStorageOwner } from '@/types/digital-transcript';
 
 export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({
     children
@@ -26,6 +27,14 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({
                     await handleLogout();
                     return;
                 }
+                // Before anything reads Learning Record storage: discard it if
+                // it belongs to a different resident. Facility workstations are
+                // shared, the keys are per-origin, and logging out clears none of
+                // them — so without this the next person to sign in inherits the
+                // previous one's unfinished achievement and their sitting.
+                setDigitalTranscriptStorageOwner(
+                    analyticsDistinctId(authUser.id)
+                );
                 identifyUser(authUser);
                 setUser(authUser);
             }

--- a/frontend/src/auth/AuthProvider.tsx
+++ b/frontend/src/auth/AuthProvider.tsx
@@ -32,7 +32,7 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({
                 // shared, the keys are per-origin, and logging out clears none of
                 // them — so without this the next person to sign in inherits the
                 // previous one's unfinished achievement and their sitting.
-                setDigitalTranscriptStorageOwner(
+                await setDigitalTranscriptStorageOwner(
                     analyticsDistinctId(authUser.id)
                 );
                 identifyUser(authUser);

--- a/frontend/src/lib/events.ts
+++ b/frontend/src/lib/events.ts
@@ -28,8 +28,12 @@ export const ANALYTICS_EVENTS = {
     LrQuestionLeft: 'lr_question_left',
     LrStepCompleted: 'lr_step_completed',
     LrEntryCompleted: 'lr_entry_completed',
-    // Emitted when the resident leaves the form. The only measure of total time
-    // in the tool that also counts residents who never saved an entry.
+    // Emitted once per sitting, not per form visit: the session survives the trip
+    // out to the list page and ends on pagehide, on a lapsed 30-minute resume
+    // window, or when a later visit recovers one a reload interrupted. Owned by
+    // learningRecordSession.ts, not by the tracker, because the tracker dies with
+    // the editor component. Still the only measure of time in the tool that also
+    // counts residents who never saved an entry.
     LrSessionEnded: 'lr_session_ended',
     // Errors & friction
     ApiError: 'api_error'
@@ -71,7 +75,7 @@ function stateTag(): string {
  * last-write-wins between facilities, and would undercount weekly-active-users —
  * the pilot's headline metric — by collapsing distinct people into one.
  */
-function analyticsDistinctId(userId: number): string {
+export function analyticsDistinctId(userId: number): string {
     return `${stateTag()}:${userId}`;
 }
 

--- a/frontend/src/pages/student/ResidentHome.tsx
+++ b/frontend/src/pages/student/ResidentHome.tsx
@@ -1,4 +1,9 @@
-import { useLoaderData, useNavigate, useSearchParams } from 'react-router-dom';
+import {
+    Link,
+    useLoaderData,
+    useNavigate,
+    useSearchParams
+} from 'react-router-dom';
 import useSWR from 'swr';
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import {
@@ -582,11 +587,11 @@ export default function ResidentHome() {
                                             learningRecordOutlineButtonClassName
                                         }
                                     >
-                                        <a
-                                            href={`${DIGITAL_TRANSCRIPT_ENTRY_PATH}?intent=new`}
+                                        <Link
+                                            to={`${DIGITAL_TRANSCRIPT_ENTRY_PATH}?intent=new`}
                                         >
                                             Log achievements
-                                        </a>
+                                        </Link>
                                     </Button>
                                     <Button
                                         type="button"
@@ -654,8 +659,8 @@ export default function ResidentHome() {
                                                 }
                                                 className="gap-1.5 bg-white px-4 text-[#556830] hover:bg-white/90"
                                             >
-                                                <a
-                                                    href={`${DIGITAL_TRANSCRIPT_ENTRY_PATH}?intent=new`}
+                                                <Link
+                                                    to={`${DIGITAL_TRANSCRIPT_ENTRY_PATH}?intent=new`}
                                                 >
                                                     {!heroIsFirstTime ? (
                                                         <Plus
@@ -664,7 +669,7 @@ export default function ResidentHome() {
                                                         />
                                                     ) : null}
                                                     {heroCtaLabel}
-                                                </a>
+                                                </Link>
                                             </Button>
                                         </div>
                                     </CardContent>

--- a/frontend/src/pages/student/digital-transcript/DigitalTranscriptWysiwygEntry.tsx
+++ b/frontend/src/pages/student/digital-transcript/DigitalTranscriptWysiwygEntry.tsx
@@ -55,6 +55,7 @@ import {
     TOP_SKILLS_MAX
 } from './transcriptReflectionConfig';
 import { LearningRecordTracker } from './learningRecordAnalytics';
+import { enterForm, leaveForm, noteActivity } from './learningRecordSession';
 
 /** Maps a TranscriptEntry patch key to its corresponding preview field id. */
 function patchKeyToPreviewField(key: keyof TranscriptEntry): string | null {
@@ -296,7 +297,6 @@ export function DigitalTranscriptWysiwygEntry({
     const analyticsRef = useRef<LearningRecordTracker | null>(null);
     analyticsRef.current ??= new LearningRecordTracker();
     const analyticsStartedForRef = useRef<string | null>(null);
-    const entriesCommittedThisSessionRef = useRef(0);
 
     const committedIds = useMemo(
         () => new Set(entries.map((e) => e.id)),
@@ -557,11 +557,10 @@ export function DigitalTranscriptWysiwygEntry({
             setSaveErrorRowId(null);
             // Success path only, mirroring the attendance/program convention: the
             // row is complete, saved, and the resident is finishing. The tracker
-            // refuses a second completion for the same entry, so the session count
-            // only advances when an event was actually emitted.
-            if (analyticsRef.current?.entryCompleted(row)) {
-                entriesCommittedThisSessionRef.current += 1;
-            }
+            // refuses a second completion for the same entry and reports the
+            // accepted one to the session itself, so the sitting's count advances
+            // only when an event was actually emitted.
+            analyticsRef.current?.entryCompleted(row, id);
             return true;
         }, [
             persistActiveRow,
@@ -575,20 +574,26 @@ export function DigitalTranscriptWysiwygEntry({
         onRegisterFunnelFinish({ validateFinishRequirements });
     }, [isFunnel, onRegisterFunnelFinish, validateFinishRequirements]);
 
-    // ID-830: one lr_session_ended per visit to the form, covering both ways to
-    // leave — pagehide for tab/browser close and bfcache, the cleanup for in-app
-    // navigation, which is how Finish leaves. beforeunload/unload are deliberately
-    // not used: they are unreliable and break bfcache. The tracker's one-shot
-    // makes the overlap harmless.
+    // ID-830: mark this mount as a visit to the form. The session itself lives in
+    // learningRecordSession, not here, because this component unmounts on every
+    // list <-> entry navigation — one sitting used to emit several partial
+    // lr_session_ended events. leaveForm deliberately does not emit; it stops
+    // active time accruing and lets the module's resume window decide when the
+    // sitting is over. pagehide is registered by the module for the same reason:
+    // registered here it would be gone the moment this unmounts.
     useEffect(() => {
         if (!isFunnel) return;
-        const tracker = analyticsRef.current;
-        tracker?.beginSession();
-        const end = () => tracker?.endSession();
-        window.addEventListener('pagehide', end);
+        enterForm();
         return () => {
-            window.removeEventListener('pagehide', end);
-            end();
+            // Report the step the resident was standing on before the session
+            // window closes — otherwise abandoning mid-form is the one path that
+            // emits nothing for the question in front of them. Read through
+            // sessionRef so the cleanup sees the row as it is now, not as it was
+            // when this effect ran.
+            const current = sessionRef.current;
+            const row = current?.rows.find((r) => r.id === current.expandedId);
+            if (row) analyticsRef.current?.abandonedCurrentStep(row);
+            leaveForm();
         };
     }, [isFunnel]);
 
@@ -600,9 +605,7 @@ export function DigitalTranscriptWysiwygEntry({
         if (!isFunnel || !hydrated || !analyticsExpandedId) return;
         if (analyticsStartedForRef.current === analyticsExpandedId) return;
         analyticsStartedForRef.current = analyticsExpandedId;
-        analyticsRef.current?.entryStarted(
-            entriesCommittedThisSessionRef.current + 1
-        );
+        analyticsRef.current?.entryStarted(analyticsExpandedId);
     }, [isFunnel, hydrated, analyticsExpandedId]);
 
     useEffect(() => {
@@ -708,6 +711,7 @@ export function DigitalTranscriptWysiwygEntry({
                         setActivePreviewField(previewField);
                     }
                     analyticsRef.current?.noteEdit(patchedKey);
+                    noteActivity();
                 }
             }
             setSession((prev) => {

--- a/frontend/src/pages/student/digital-transcript/DigitalTranscriptWysiwygEntry.tsx
+++ b/frontend/src/pages/student/digital-transcript/DigitalTranscriptWysiwygEntry.tsx
@@ -584,7 +584,25 @@ export function DigitalTranscriptWysiwygEntry({
     useEffect(() => {
         if (!isFunnel) return;
         enterForm();
+        // A bfcache restore starts a new sitting without this component
+        // unmounting, so the analytics tracker below never gets recreated and
+        // never re-runs entryStarted for whatever entry is already open. This
+        // renumbers it against the new sitting instead.
+        const handleSessionRestarted = () => {
+            const current = sessionRef.current;
+            analyticsRef.current?.reattachToSession(
+                current?.expandedId ?? null
+            );
+        };
+        window.addEventListener(
+            'learning-record-session-restarted',
+            handleSessionRestarted
+        );
         return () => {
+            window.removeEventListener(
+                'learning-record-session-restarted',
+                handleSessionRestarted
+            );
             // Report the step the resident was standing on before the session
             // window closes — otherwise abandoning mid-form is the one path that
             // emits nothing for the question in front of them. Read through

--- a/frontend/src/pages/student/digital-transcript/learningRecordAnalytics.ts
+++ b/frontend/src/pages/student/digital-transcript/learningRecordAnalytics.ts
@@ -55,6 +55,14 @@ function entryAlreadyCounted(rowId: string): boolean {
  */
 const ENTRY_TIMING_CAP = 200;
 
+/**
+ * Same cutoff and rationale as `learningRecordSession.ts`'s `ACTIVE_IDLE_MS`,
+ * applied per visit: an achievement left open on an unattended screen stops
+ * accruing `cumulative_seconds` this long after the resident's last keystroke,
+ * rather than counting all the way to `Date.now()`.
+ */
+const ENTRY_ACTIVE_IDLE_MS = 5 * 60 * 1000;
+
 function readEntryTiming(): Record<string, number> {
     if (typeof localStorage === 'undefined') return {};
     try {
@@ -273,6 +281,8 @@ export class LearningRecordTracker {
      * next question's `beforeFirstEditMs`.
      */
     private lastAnyEditMs: number | null = null;
+    /** Reference point for `cappedElapsedMs`'s idle cutoff. */
+    private lastActivityMs = Date.now();
     /** The achievement being edited, so partial time can be banked against it. */
     private entryRowId: string | null = null;
     /** Set by `entryCompleted`, so a second Finish cannot emit a duplicate. */
@@ -288,17 +298,47 @@ export class LearningRecordTracker {
      */
     entryStarted(rowId?: string): void {
         this.entryRowId = rowId ?? null;
-        this.entryIndex = noteEntryStarted();
         this.entryStartMs = Date.now();
         this.stepStartMs = Date.now();
         this.timings.clear();
         this.lastAnyEditMs = null;
+        this.lastActivityMs = this.entryStartMs;
         this.currentField = null;
         this.touched.clear();
         this.reportedSteps.clear();
         // Matches the form's `activeStep` state, which is always 0 on a fresh entry.
         this.currentStepIndex = 0;
         this.completed = false;
+
+        // Already saved in an earlier visit: this open is an edit, not a new
+        // achievement. Skipping the counter bump as well as the emit — not just
+        // the emit — keeps `entries_started` and `entries_completed` on
+        // `lr_session_ended` counting the same population; otherwise a resident
+        // who reopens one saved achievement twice reports 3 started against 1
+        // completed.
+        if (rowId && entryAlreadyCounted(rowId)) return;
+
+        this.entryIndex = noteEntryStarted();
+        captureEvent(ANALYTICS_EVENTS.LrEntryStarted, {
+            entry_index_in_session: this.entryIndex
+        });
+    }
+
+    /**
+     * Called when a bfcache restore silently starts a new sitting
+     * (`learning-record-session-restarted`) while this component — and this
+     * tracker — never unmounted. `entryStarted` never re-ran for the row
+     * already open, so `entryIndex` is still numbered against the sitting
+     * that just ended. Re-numbers it against the new one and reports the
+     * corresponding `lr_entry_started`, mirroring what a genuine remount
+     * would have produced. Question/step timing already accumulated is left
+     * untouched — the resident's editing was never actually interrupted,
+     * only the sitting's own bookkeeping was.
+     */
+    reattachToSession(rowId: string | null): void {
+        if (this.completed) return;
+        if (!rowId || rowId !== this.entryRowId) return;
+        this.entryIndex = noteEntryStarted();
         captureEvent(ANALYTICS_EVENTS.LrEntryStarted, {
             entry_index_in_session: this.entryIndex
         });
@@ -344,6 +384,7 @@ export class LearningRecordTracker {
             });
         }
         this.lastAnyEditMs = now;
+        this.lastActivityMs = now;
         this.currentField = field;
     }
 
@@ -357,6 +398,20 @@ export class LearningRecordTracker {
         if (timing?.openMs == null) return;
         timing.totalMs += Math.max(0, timing.lastEditMs - timing.openMs);
         timing.openMs = null;
+    }
+
+    /**
+     * Elapsed time for the current visit, capped the same way
+     * `learningRecordSession.ts` caps `active_seconds`: an unattended tab stops
+     * accruing `ENTRY_ACTIVE_IDLE_MS` after the resident's last keystroke instead
+     * of counting all the way to now.
+     */
+    private cappedElapsedMs(): number {
+        const end = Math.min(
+            Date.now(),
+            this.lastActivityMs + ENTRY_ACTIVE_IDLE_MS
+        );
+        return Math.max(0, end - this.entryStartMs);
     }
 
     /**
@@ -426,7 +481,13 @@ export class LearningRecordTracker {
         // Already counted in an earlier visit or another tab: this Finish is an
         // edit to an existing achievement, not a new one. Returning before the
         // flush also keeps its questions and steps from being reported twice.
-        if (rowId && entryAlreadyCounted(rowId)) return false;
+        // No `lr_entry_completed` will ever fire for this row again, so any time
+        // `abandonedCurrentStep` banked against it on a later re-open must be
+        // discarded here — otherwise it sits in `entryTiming` forever, unread.
+        if (rowId && entryAlreadyCounted(rowId)) {
+            takeEntryActiveMs(rowId);
+            return false;
+        }
         this.completed = true;
         if (rowId) markEntryCounted(rowId);
         noteEntryCompleted();
@@ -465,7 +526,7 @@ export class LearningRecordTracker {
             duration_seconds: flowTimerSeconds(this.entryStartMs),
             cumulative_seconds: Math.round(
                 ((rowId ? takeEntryActiveMs(rowId) : 0) +
-                    Math.max(0, Date.now() - this.entryStartMs)) /
+                    this.cappedElapsedMs()) /
                     1000
             ),
             answered_count: countFunnelFieldsAnswered(entry),
@@ -505,10 +566,7 @@ export class LearningRecordTracker {
         if (this.entryIndex === 0 || this.completed) return;
         // Unfinished: bank this visit so a later Finish can report the total.
         if (this.entryRowId) {
-            bankEntryActiveMs(
-                this.entryRowId,
-                Math.max(0, Date.now() - this.entryStartMs)
-            );
+            bankEntryActiveMs(this.entryRowId, this.cappedElapsedMs());
         }
         if (this.currentField) this.closeRun(this.currentField);
         this.currentField = null;

--- a/frontend/src/pages/student/digital-transcript/learningRecordAnalytics.ts
+++ b/frontend/src/pages/student/digital-transcript/learningRecordAnalytics.ts
@@ -1,4 +1,134 @@
 import { ANALYTICS_EVENTS, captureEvent, flowTimerSeconds } from '@/lib/events';
+import { getDigitalTranscriptStorageKeys } from '@/types/digital-transcript';
+import {
+    noteEntryCompleted,
+    noteEntryStarted,
+    sessionStartMs
+} from './learningRecordSession';
+
+/**
+ * Row ids already counted as a completed achievement.
+ *
+ * `this.completed` guards only one `entryStarted` -> `entryCompleted` pass, and
+ * the tracker is rebuilt whenever the editor remounts — so re-opening a saved
+ * achievement and pressing Finish again emitted a second `lr_entry_completed`
+ * with nothing on the payload to tell the two apart. "Do residents stop at one
+ * or add more" then reads an edit as a new achievement, which can invert the
+ * finding the tile exists to produce.
+ *
+ * Deduping here rather than putting the row id on the event keeps the payload to
+ * counts, booleans and enums: the ids never leave the browser. `localStorage` is
+ * right for this one (unlike the sitting record) because a resident editing an
+ * old achievement in another tab must not be counted twice either.
+ */
+const COUNTED_ENTRIES_CAP = 500;
+
+function readCountedEntries(): string[] {
+    if (typeof localStorage === 'undefined') return [];
+    try {
+        const raw = localStorage.getItem(
+            getDigitalTranscriptStorageKeys().countedEntries
+        );
+        if (!raw) return [];
+        const parsed: unknown = JSON.parse(raw);
+        if (!Array.isArray(parsed)) return [];
+        return parsed.filter((v): v is string => typeof v === 'string');
+    } catch {
+        return [];
+    }
+}
+
+function entryAlreadyCounted(rowId: string): boolean {
+    return readCountedEntries().includes(rowId);
+}
+
+/**
+ * Editing time banked against an achievement that is not finished yet, in ms.
+ *
+ * `entryStarted` re-bases `entryStartMs`, and it fires again when the resident
+ * returns to the same achievement after a route change — so
+ * `lr_entry_completed.duration_seconds` reports only the *final* visit and
+ * systematically understates how long an entry actually took. That is the number
+ * the facilitator cross-reference leans on, so the total is banked here per row
+ * and emitted as `cumulative_seconds` alongside it. `duration_seconds` keeps its
+ * meaning, so nothing already flowing is redefined.
+ */
+const ENTRY_TIMING_CAP = 200;
+
+function readEntryTiming(): Record<string, number> {
+    if (typeof localStorage === 'undefined') return {};
+    try {
+        const raw = localStorage.getItem(
+            getDigitalTranscriptStorageKeys().entryTiming
+        );
+        if (!raw) return {};
+        const parsed: unknown = JSON.parse(raw);
+        if (typeof parsed !== 'object' || parsed === null) return {};
+        const out: Record<string, number> = {};
+        for (const [k, v] of Object.entries(parsed)) {
+            if (typeof v === 'number' && Number.isFinite(v) && v >= 0) {
+                out[k] = v;
+            }
+        }
+        return out;
+    } catch {
+        return {};
+    }
+}
+
+function writeEntryTiming(next: Record<string, number>): void {
+    if (typeof localStorage === 'undefined') return;
+    try {
+        const keys = Object.keys(next);
+        const trimmed =
+            keys.length > ENTRY_TIMING_CAP
+                ? Object.fromEntries(
+                      keys.slice(-ENTRY_TIMING_CAP).map((k) => [k, next[k]])
+                  )
+                : next;
+        localStorage.setItem(
+            getDigitalTranscriptStorageKeys().entryTiming,
+            JSON.stringify(trimmed)
+        );
+    } catch {
+        // Quota or private mode: `cumulative_seconds` falls back to this visit
+        // only, which is what `duration_seconds` already reports.
+    }
+}
+
+function bankEntryActiveMs(rowId: string, ms: number): void {
+    if (ms <= 0) return;
+    const all = readEntryTiming();
+    all[rowId] = (all[rowId] ?? 0) + ms;
+    writeEntryTiming(all);
+}
+
+/** Read and clear — a finished achievement has no more time to accumulate. */
+function takeEntryActiveMs(rowId: string): number {
+    const all = readEntryTiming();
+    const banked = all[rowId] ?? 0;
+    if (rowId in all) {
+        delete all[rowId];
+        writeEntryTiming(all);
+    }
+    return banked;
+}
+
+function markEntryCounted(rowId: string): void {
+    if (typeof localStorage === 'undefined') return;
+    try {
+        const next = [...readCountedEntries(), rowId].slice(
+            -COUNTED_ENTRIES_CAP
+        );
+        localStorage.setItem(
+            getDigitalTranscriptStorageKeys().countedEntries,
+            JSON.stringify(next)
+        );
+    } catch {
+        // Quota or private mode. Falls back to the per-pass `completed` guard,
+        // which still stops a double Finish inside one visit.
+    }
+}
 import {
     FUNNEL_FORM_FIELD_TOTAL,
     FUNNEL_FORM_STEPS,
@@ -95,6 +225,19 @@ interface QuestionTiming {
     lastEditMs: number;
     /** Sum of every closed editing run for this question, in ms. */
     totalMs: number;
+    /**
+     * Quiet time between the resident's previous keystroke anywhere in this step
+     * — or the step opening, for the first question they engage — and their first
+     * keystroke here.
+     *
+     * `duration_seconds` is a typing span, so a question someone stared at for
+     * three minutes and answered in ten seconds reports ten. That makes the
+     * criterion's "surface which questions take unusually long" blind to exactly
+     * the questions it is asking about, because hesitation is where confusion
+     * shows. This is the hesitation, measured from data already collected: no
+     * focus handlers, no coupling to the form's markup.
+     */
+    beforeFirstEditMs: number;
 }
 
 /**
@@ -108,13 +251,6 @@ interface QuestionTiming {
  */
 export class LearningRecordTracker {
     private entryStartMs = Date.now();
-    /**
-     * Start of the current visit to the form, re-based by `beginSession` — so
-     * `seconds_since_session_start` measures from when the resident opened the
-     * form, not from when they opened the first entry. Never reset by
-     * `entryStarted`, so it stays comparable across entries in one sitting.
-     */
-    private sessionStartMs = Date.now();
     private entryIndex = 0;
     /** Accumulated editing time per question, for the entry in progress. */
     private timings = new Map<FunnelStepField, QuestionTiming>();
@@ -131,57 +267,32 @@ export class LearningRecordTracker {
      */
     private currentStepIndex = 0;
     private stepStartMs = Date.now();
+    /**
+     * The resident's most recent keystroke on any question in the current step,
+     * or null before they have typed anything in it. The reference point for the
+     * next question's `beforeFirstEditMs`.
+     */
+    private lastAnyEditMs: number | null = null;
+    /** The achievement being edited, so partial time can be banked against it. */
+    private entryRowId: string | null = null;
     /** Set by `entryCompleted`, so a second Finish cannot emit a duplicate. */
     private completed = false;
-    /** Entries actually saved this session, reported by `endSession`. */
-    private entriesCompleted = 0;
-    /** One-shot guard for `endSession`, re-armed by `beginSession`. */
-    private sessionEndSent = false;
 
     /**
-     * Opens a session window. Called when the form's session effect mounts — which
-     * React StrictMode does twice in development, discarding the first cycle;
-     * without re-arming the one-shot, that throwaway cleanup would latch the guard
-     * and suppress the real session-end event.
+     * Called once when the form becomes interactive.
      *
-     * Re-bases everything `endSession` reports, not just the one-shot. Its cleanup
-     * always emits, so by the time this runs any earlier window has already been
-     * reported — carrying that window's start time or entry count forward would
-     * double count it into the next event. StrictMode walks exactly that path
-     * (mount → cleanup emits → mount), and so would `isFunnel` flipping while the
-     * component stays mounted. Per-entry state is deliberately left alone; that
-     * belongs to `entryStarted`.
+     * The index comes from `learningRecordSession`, not from the caller: it used
+     * to be derived from a ref in the form, which was rebuilt on every mount, so
+     * a resident returning from the list to add a second achievement reported
+     * index 1 again. It now counts across the whole sitting.
      */
-    beginSession(): void {
-        this.sessionEndSent = false;
-        this.sessionStartMs = Date.now();
-        this.entriesCompleted = 0;
-    }
-
-    /**
-     * Called once when the resident leaves the form, by either route: in-app
-     * navigation or `pagehide`.
-     *
-     * This is the only measure of total time in the tool that includes residents
-     * who never saved an entry — `seconds_since_session_start` rides on
-     * `lr_entry_completed`, so an abandoned session is invisible to it, and that
-     * is exactly the friction signal the pilot is looking for.
-     */
-    endSession(): void {
-        if (this.sessionEndSent) return;
-        this.sessionEndSent = true;
-        captureEvent(ANALYTICS_EVENTS.LrSessionEnded, {
-            duration_seconds: flowTimerSeconds(this.sessionStartMs),
-            entries_completed: this.entriesCompleted
-        });
-    }
-
-    /** Called once when the form becomes interactive. */
-    entryStarted(entryIndexInSession: number): void {
-        this.entryIndex = entryIndexInSession;
+    entryStarted(rowId?: string): void {
+        this.entryRowId = rowId ?? null;
+        this.entryIndex = noteEntryStarted();
         this.entryStartMs = Date.now();
         this.stepStartMs = Date.now();
         this.timings.clear();
+        this.lastAnyEditMs = null;
         this.currentField = null;
         this.touched.clear();
         this.reportedSteps.clear();
@@ -189,7 +300,7 @@ export class LearningRecordTracker {
         this.currentStepIndex = 0;
         this.completed = false;
         captureEvent(ANALYTICS_EVENTS.LrEntryStarted, {
-            entry_index_in_session: entryIndexInSession
+            entry_index_in_session: this.entryIndex
         });
     }
 
@@ -219,12 +330,20 @@ export class LearningRecordTracker {
             timing.openMs ??= now;
             timing.lastEditMs = now;
         } else {
+            // First keystroke on this question. Measured before `lastAnyEditMs`
+            // is advanced below, so the reference is still the previous
+            // question's last edit.
             this.timings.set(field, {
                 openMs: now,
                 lastEditMs: now,
-                totalMs: 0
+                totalMs: 0,
+                beforeFirstEditMs: Math.max(
+                    0,
+                    now - (this.lastAnyEditMs ?? this.stepStartMs)
+                )
             });
         }
+        this.lastAnyEditMs = now;
         this.currentField = field;
     }
 
@@ -260,6 +379,7 @@ export class LearningRecordTracker {
             flowTimerSeconds(this.stepStartMs)
         );
         this.stepStartMs = Date.now();
+        this.lastAnyEditMs = null;
         this.currentStepIndex = toStepIndex;
     }
 
@@ -272,7 +392,8 @@ export class LearningRecordTracker {
     private reportStep(
         entry: TranscriptReflectionFields,
         stepIndex: number,
-        durationSeconds: number
+        durationSeconds: number,
+        abandoned = false
     ): void {
         const step = FUNNEL_FORM_STEPS[stepIndex];
         if (!step || this.reportedSteps.has(stepIndex)) return;
@@ -281,13 +402,14 @@ export class LearningRecordTracker {
         let answered = 0;
         for (const field of step.fields) {
             if (funnelStepFieldAnswered(entry, field)) answered += 1;
-            this.emitQuestion(entry, field);
+            this.emitQuestion(entry, field, abandoned);
         }
         captureEvent(ANALYTICS_EVENTS.LrStepCompleted, {
             step_id: step.id,
             step_index: stepIndex,
             duration_seconds: durationSeconds,
-            answered_count: answered
+            answered_count: answered,
+            abandoned
         });
     }
 
@@ -299,10 +421,15 @@ export class LearningRecordTracker {
      * Returns false without emitting if this entry was already completed, so a
      * second Finish click cannot produce a duplicate.
      */
-    entryCompleted(entry: TranscriptReflectionFields): boolean {
+    entryCompleted(entry: TranscriptReflectionFields, rowId?: string): boolean {
         if (this.completed) return false;
+        // Already counted in an earlier visit or another tab: this Finish is an
+        // edit to an existing achievement, not a new one. Returning before the
+        // flush also keeps its questions and steps from being reported twice.
+        if (rowId && entryAlreadyCounted(rowId)) return false;
         this.completed = true;
-        this.entriesCompleted += 1;
+        if (rowId) markEntryCounted(rowId);
+        noteEntryCompleted();
 
         if (this.currentField) this.closeRun(this.currentField);
         this.currentField = null;
@@ -336,13 +463,61 @@ export class LearningRecordTracker {
         // capping any completion-rate insight built on the pair at 90%.
         captureEvent(ANALYTICS_EVENTS.LrEntryCompleted, {
             duration_seconds: flowTimerSeconds(this.entryStartMs),
+            cumulative_seconds: Math.round(
+                ((rowId ? takeEntryActiveMs(rowId) : 0) +
+                    Math.max(0, Date.now() - this.entryStartMs)) /
+                    1000
+            ),
             answered_count: countFunnelFieldsAnswered(entry),
             total_fields: FUNNEL_FORM_FIELD_TOTAL,
             entry_index_in_session: this.entryIndex,
-            seconds_since_session_start: flowTimerSeconds(this.sessionStartMs),
+            seconds_since_session_start: flowTimerSeconds(sessionStartMs()),
             submitted_at: new Date().toISOString()
         });
         return true;
+    }
+
+    /**
+     * Report the step the resident was standing on when they left without
+     * finishing.
+     *
+     * `stepChanged` reports a step only when it is left *for another one*, and
+     * `entryCompleted` flushes everything at the end — so abandoning on the step
+     * in front of you was the one case that emitted nothing. That is both the
+     * sharpest friction signal in the form and the population criterion 3 needs
+     * for its "left it blank" denominator, so it cannot be the case that goes
+     * unreported.
+     *
+     * Only the current step is flushed. Steps never visited are left alone: they
+     * would arrive as rows of zeros and invent a denominator the resident never
+     * actually saw.
+     *
+     * Rows emitted here carry `abandoned: true`. A resident who leaves and comes
+     * back re-opens the entry, which clears `reportedSteps`, so the same step can
+     * be reported again later — once here and once at finish. The flag is what
+     * lets a timing tile exclude the partial row while an answer-rate tile keeps
+     * it, instead of the duplication being silent.
+     */
+    abandonedCurrentStep(entry: TranscriptReflectionFields): void {
+        // No entry was ever opened for editing, so there is no step the resident
+        // can be said to have abandoned. Also keeps React StrictMode's discarded
+        // first mount from emitting anything.
+        if (this.entryIndex === 0 || this.completed) return;
+        // Unfinished: bank this visit so a later Finish can report the total.
+        if (this.entryRowId) {
+            bankEntryActiveMs(
+                this.entryRowId,
+                Math.max(0, Date.now() - this.entryStartMs)
+            );
+        }
+        if (this.currentField) this.closeRun(this.currentField);
+        this.currentField = null;
+        this.reportStep(
+            entry,
+            this.currentStepIndex,
+            flowTimerSeconds(this.stepStartMs),
+            true
+        );
     }
 
     /**
@@ -352,7 +527,8 @@ export class LearningRecordTracker {
      */
     private emitQuestion(
         entry: TranscriptReflectionFields,
-        field: FunnelStepField
+        field: FunnelStepField,
+        abandoned = false
     ): void {
         this.closeRun(field);
         const timing = this.timings.get(field);
@@ -361,13 +537,19 @@ export class LearningRecordTracker {
         const duration = timing ? Math.round(timing.totalMs / 1000) : 0;
         captureEvent(ANALYTICS_EVENTS.LrQuestionLeft, {
             question_key: field,
+            // null, not 0, when the question was never typed in: there is no
+            // hesitation to report, and 0 would read as "answered instantly".
+            seconds_before_first_edit: timing
+                ? Math.round(timing.beforeFirstEditMs / 1000)
+                : null,
             step_id: stepIdForField(field),
             kind: funnelStepFieldKind(field),
             duration_seconds: duration,
             touched: this.touched.has(field),
             answered: funnelStepFieldAnswered(entry, field),
             selection_count: selectionCount(entry, field),
-            char_count: charCount(entry, field)
+            char_count: charCount(entry, field),
+            abandoned
         });
     }
 }

--- a/frontend/src/pages/student/digital-transcript/learningRecordSession.ts
+++ b/frontend/src/pages/student/digital-transcript/learningRecordSession.ts
@@ -110,8 +110,23 @@ function numField(source: Record<string, unknown>, key: string): number {
  * recovering a sitting after a browser crash into a *fresh* tab — an acceptable
  * trade against silently double counting.
  */
+/**
+ * Resolved once, when the sitting opens, and held for its whole lifetime — see
+ * `storageKey()`.
+ *
+ * `getDigitalTranscriptStorageKeys()` resolves against the *current* prototype
+ * route, which is a mutable global (`setDigitalTranscriptStorageContext`) that
+ * changes on navigation. `state` is a module-scoped singleton that survives
+ * navigation by design, so re-resolving on every call let a mid-sitting switch
+ * between prototypes silently retarget persist/clear at a different key than
+ * the one the sitting was actually written under — orphaning the original
+ * record, which a later visit to that route could then recover and report a
+ * second time.
+ */
+let pinnedStorageKey: string | null = null;
+
 function storageKey(): string {
-    return getDigitalTranscriptStorageKeys().session;
+    return pinnedStorageKey ?? getDigitalTranscriptStorageKeys().session;
 }
 
 function persistNow(): void {
@@ -250,11 +265,22 @@ function handlePageHide(): void {
  */
 function handlePageShow(): void {
     if (mountCount === 0 || state) return;
+    pinnedStorageKey = getDigitalTranscriptStorageKeys().session;
     state = freshState();
     state.formVisits = 1;
     openActiveRun();
     attachListeners();
     persistSoon();
+    // The editor component never unmounted across the freeze, so its analytics
+    // tracker is still numbered against the sitting that just ended. Tell it a
+    // new one just started so it can renumber the entry already open, the same
+    // way `transcriptEntrySessionStorage.ts` notifies a mounted component of a
+    // module-state change with no remount to hook into.
+    if (typeof window !== 'undefined') {
+        window.dispatchEvent(
+            new CustomEvent('learning-record-session-restarted')
+        );
+    }
 }
 
 /**
@@ -315,6 +341,7 @@ function freshState(): SessionState {
  * with its own stored close time rather than with now.
  */
 function resumeOrStart(): void {
+    pinnedStorageKey = getDigitalTranscriptStorageKeys().session;
     const stored = readPersisted();
     if (!stored) {
         state = freshState();
@@ -329,6 +356,9 @@ function resumeOrStart(): void {
     // than dropping it, then begin a genuinely new session.
     state = stored;
     endSession('recovered');
+    // endSession() just cleared the pin for the session it ended — the fresh
+    // one below is a new sitting and needs its own.
+    pinnedStorageKey = getDigitalTranscriptStorageKeys().session;
     state = freshState();
 }
 
@@ -396,10 +426,10 @@ export function sessionStartMs(): number {
  * the count no longer restarts when the resident goes back to the list.
  */
 export function noteEntryStarted(): number {
-    if (!state) return 1;
+    if (!state) return 0;
     state.entriesStarted += 1;
     persistSoon();
-    return state.entriesCompleted + 1;
+    return state.entriesStarted;
 }
 
 /** An entry was saved. */
@@ -430,6 +460,9 @@ export function endSession(reason: EndedReason): void {
     clearPersistTimer();
     detachListeners();
     clearPersisted();
+    // The next sitting must re-resolve against whatever route is active then,
+    // not inherit this one's key.
+    pinnedStorageKey = null;
     captureEvent(ANALYTICS_EVENTS.LrSessionEnded, {
         duration_seconds: spanSeconds(finished.startedMs, closedMs),
         active_seconds: Math.round(finished.activeMs / 1000),

--- a/frontend/src/pages/student/digital-transcript/learningRecordSession.ts
+++ b/frontend/src/pages/student/digital-transcript/learningRecordSession.ts
@@ -1,0 +1,441 @@
+import { ANALYTICS_EVENTS, captureEvent } from '@/lib/events';
+import {
+    LEARNING_RECORD_SESSION_VERSION,
+    getDigitalTranscriptStorageKeys
+} from '@/types/digital-transcript';
+
+/**
+ * Session-scoped tracking for the Learning Record form (ID-830 follow-up).
+ *
+ * Why this is a module and not part of `LearningRecordTracker`: the tracker lives
+ * in a ref inside `DigitalTranscriptWysiwygEntry`, and every list <-> entry
+ * navigation is a route change that unmounts that component. A session that must
+ * span a whole sitting therefore cannot live inside it — it was previously
+ * re-based on every mount, so one sitting emitted several partial
+ * `lr_session_ended` events, `entry_index_in_session` restarted at 1 on each
+ * visit, and `seconds_since_session_start` measured from the mount rather than
+ * from the sitting. Module scope fixes all three at once.
+ *
+ * A **session** is one sitting's worth of form visits: it opens when the form
+ * first mounts, survives the gap while the resident is on the list page, and ends
+ * when they leave for good (`pagehide`), when the resume window lapses, or when a
+ * later visit recovers a session a reload interrupted.
+ *
+ * PRIVACY — same contract as `learningRecordAnalytics.ts`: every property here is
+ * a count, a duration in whole seconds, or a fixed enum. Deliberately no session
+ * id; the stitching happens here, so no correlation key needs to reach PostHog.
+ */
+
+/** Why the session ended. Fixed enum — do not let this become free text. */
+type EndedReason = 'navigated_away' | 'page_hidden' | 'recovered';
+
+/**
+ * How long a session survives with the form closed before it is treated as over.
+ * Matches PostHog's own 30-minute inactivity boundary so the app's notion of a
+ * session and PostHog's do not diverge. Doubles as the recovery grace period.
+ */
+const SESSION_IDLE_MS = 30 * 60 * 1000;
+
+/**
+ * How long a silent-but-focused form keeps accruing active time.
+ *
+ * Deliberately generous. A resident staring at a reflection question for ninety
+ * seconds is doing the work, and `lr_question_left.duration_seconds` already runs
+ * keystroke-to-last-keystroke and so already discards think time — if this cutoff
+ * were also short, nothing in the dataset would show hesitation, which is the
+ * friction signal these events exist to surface. Five minutes still caps the
+ * pathological case: a form left open on a focused, unattended screen, where
+ * `visibilitychange` never fires.
+ */
+const ACTIVE_IDLE_MS = 5 * 60 * 1000;
+
+const PERSIST_DEBOUNCE_MS = 2000;
+
+/** Scroll does not bubble, so activity listeners run in the capture phase. */
+const ACTIVITY_EVENTS = ['pointerdown', 'keydown', 'scroll'] as const;
+
+interface SessionState {
+    startedMs: number;
+    /** 0 until the form has been left at least once. */
+    lastFormCloseMs: number;
+    lastActivityMs: number;
+    activeMs: number;
+    /** Start of the open active run, or null when time is not accruing. */
+    activeRunOpenMs: number | null;
+    entriesStarted: number;
+    entriesCompleted: number;
+    formVisits: number;
+}
+
+let state: SessionState | null = null;
+/** Mounted editors. Guards against a stray double `leaveForm`. */
+let mountCount = 0;
+let resumeTimer: number | null = null;
+let persistTimer: number | null = null;
+let listenersAttached = false;
+/** Registered once and never removed — see `handlePageShow`. */
+let pageShowAttached = false;
+
+/**
+ * Whole seconds between two stamps. `flowTimerSeconds` only measures to *now*,
+ * which is wrong for a session that ended when the form closed rather than when
+ * the resume window later lapsed.
+ */
+function spanSeconds(fromMs: number, toMs: number): number {
+    return Math.max(0, Math.round((toMs - fromMs) / 1000));
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+    return typeof value === 'object' && value !== null;
+}
+
+function numField(source: Record<string, unknown>, key: string): number {
+    const raw = source[key];
+    return typeof raw === 'number' && Number.isFinite(raw) ? raw : 0;
+}
+
+/**
+ * The session record lives in **`sessionStorage`**, unlike every other
+ * `unlockEd_digital_transcript_*` key, which uses `localStorage`.
+ *
+ * That is deliberate, and the difference is the point. Draft content *should*
+ * follow a resident across tabs; a clock must not. `localStorage` is shared per
+ * profile, so a second tab opening the form would read the first tab's record,
+ * resume it, and both documents would then emit on their own exit — overlapping,
+ * double-counted sittings. `sessionStorage` is per tab, which makes each tab its
+ * own sitting.
+ *
+ * It costs nothing that matters: `sessionStorage` survives a reload in the same
+ * tab, which is the case reload recovery exists for. What it gives up is
+ * recovering a sitting after a browser crash into a *fresh* tab — an acceptable
+ * trade against silently double counting.
+ */
+function storageKey(): string {
+    return getDigitalTranscriptStorageKeys().session;
+}
+
+function persistNow(): void {
+    if (!state || typeof sessionStorage === 'undefined') return;
+    try {
+        sessionStorage.setItem(
+            storageKey(),
+            JSON.stringify({
+                version: LEARNING_RECORD_SESSION_VERSION,
+                ...state
+            })
+        );
+    } catch {
+        // Quota, or private-mode Safari. The session degrades to in-memory only:
+        // it still emits, it just cannot survive a reload.
+    }
+}
+
+function persistSoon(): void {
+    if (typeof window === 'undefined') return;
+    if (persistTimer !== null) return;
+    persistTimer = window.setTimeout(() => {
+        persistTimer = null;
+        persistNow();
+    }, PERSIST_DEBOUNCE_MS);
+}
+
+function clearPersistTimer(): void {
+    if (persistTimer === null || typeof window === 'undefined') return;
+    window.clearTimeout(persistTimer);
+    persistTimer = null;
+}
+
+function clearPersisted(): void {
+    if (typeof sessionStorage === 'undefined') return;
+    try {
+        sessionStorage.removeItem(storageKey());
+    } catch {
+        /* noop */
+    }
+}
+
+/** Version-gated, field-coerced read — same discipline as the entry session. */
+function readPersisted(): SessionState | null {
+    if (typeof sessionStorage === 'undefined') return null;
+    try {
+        const raw = sessionStorage.getItem(storageKey());
+        if (!raw) return null;
+        const parsed: unknown = JSON.parse(raw);
+        if (!isRecord(parsed)) return null;
+        if (parsed.version !== LEARNING_RECORD_SESSION_VERSION) return null;
+        const startedMs = numField(parsed, 'startedMs');
+        if (startedMs <= 0) return null;
+        return {
+            startedMs,
+            lastFormCloseMs: numField(parsed, 'lastFormCloseMs'),
+            lastActivityMs: numField(parsed, 'lastActivityMs') || startedMs,
+            activeMs: numField(parsed, 'activeMs'),
+            // Never resume an open run across a reload — the stamp predates the
+            // gap, so charging it would bill time the resident spent elsewhere.
+            activeRunOpenMs: null,
+            entriesStarted: numField(parsed, 'entriesStarted'),
+            entriesCompleted: numField(parsed, 'entriesCompleted'),
+            formVisits: numField(parsed, 'formVisits')
+        };
+    } catch {
+        return null;
+    }
+}
+
+function openActiveRun(): void {
+    if (!state) return;
+    if (state.activeRunOpenMs !== null) return;
+    if (typeof document !== 'undefined' && document.hidden) return;
+    state.activeRunOpenMs = Date.now();
+}
+
+/**
+ * Bank the open run. A run that died of idleness stops accruing at the cutoff,
+ * not at now, so walking away mid-entry does not inflate `active_seconds`.
+ */
+function closeActiveRun(): void {
+    if (!state) return;
+    if (state.activeRunOpenMs === null) return;
+    const end = Math.min(Date.now(), state.lastActivityMs + ACTIVE_IDLE_MS);
+    state.activeMs += Math.max(0, end - state.activeRunOpenMs);
+    state.activeRunOpenMs = null;
+}
+
+function clearResumeTimer(): void {
+    if (resumeTimer === null || typeof window === 'undefined') return;
+    window.clearTimeout(resumeTimer);
+    resumeTimer = null;
+}
+
+function armResumeTimer(): void {
+    if (typeof window === 'undefined') return;
+    clearResumeTimer();
+    resumeTimer = window.setTimeout(() => {
+        resumeTimer = null;
+        endSession('navigated_away');
+    }, SESSION_IDLE_MS);
+}
+
+function handleVisibilityChange(): void {
+    if (!state) return;
+    if (document.hidden) {
+        closeActiveRun();
+        persistNow();
+        return;
+    }
+    if (mountCount > 0) {
+        // Re-base activity so the hidden stretch is not also charged as idle.
+        state.lastActivityMs = Date.now();
+        openActiveRun();
+    }
+}
+
+function handlePageHide(): void {
+    endSession('page_hidden');
+}
+
+/**
+ * Restart after a bfcache restore.
+ *
+ * `pagehide` has to report — the page may never come back, and a frozen page's
+ * timers are frozen with it, so waiting for the resume window would lose the
+ * event. But when the page *does* come back, the editor never remounted, so
+ * `enterForm` will not be called again. Without this, every achievement the
+ * resident goes on to save is unattributed and no further session is ever
+ * reported.
+ *
+ * The restored page is a new sitting rather than a continuation: the previous one
+ * was already emitted and its clock stopped at the freeze. The guards make this a
+ * no-op on an ordinary load, where `mountCount` is still 0.
+ */
+function handlePageShow(): void {
+    if (mountCount === 0 || state) return;
+    state = freshState();
+    state.formVisits = 1;
+    openActiveRun();
+    attachListeners();
+    persistSoon();
+}
+
+/**
+ * Listeners belong to the session, not to a component. The previous
+ * implementation registered `pagehide` inside the editor's effect, so it was
+ * removed the moment the editor unmounted — a resident who returned to the list
+ * and *then* closed the tab would produce no event at all now that leaving the
+ * form no longer emits.
+ */
+function attachListeners(): void {
+    if (typeof document === 'undefined') return;
+    // Outlives the session on purpose: it is what notices a bfcache restore
+    // after `endSession` has already torn everything else down.
+    if (!pageShowAttached) {
+        pageShowAttached = true;
+        window.addEventListener('pageshow', handlePageShow);
+    }
+    if (listenersAttached) return;
+    listenersAttached = true;
+    document.addEventListener('visibilitychange', handleVisibilityChange);
+    window.addEventListener('pagehide', handlePageHide);
+    for (const type of ACTIVITY_EVENTS) {
+        document.addEventListener(type, noteActivity, {
+            passive: true,
+            capture: true
+        });
+    }
+}
+
+function detachListeners(): void {
+    if (!listenersAttached || typeof document === 'undefined') return;
+    listenersAttached = false;
+    document.removeEventListener('visibilitychange', handleVisibilityChange);
+    window.removeEventListener('pagehide', handlePageHide);
+    for (const type of ACTIVITY_EVENTS) {
+        document.removeEventListener(type, noteActivity, { capture: true });
+    }
+}
+
+function freshState(): SessionState {
+    const now = Date.now();
+    return {
+        startedMs: now,
+        lastFormCloseMs: 0,
+        lastActivityMs: now,
+        activeMs: 0,
+        activeRunOpenMs: null,
+        entriesStarted: 0,
+        entriesCompleted: 0,
+        formVisits: 0
+    };
+}
+
+/**
+ * Resume a stored session, or report it and start clean.
+ *
+ * Runs before `mountCount` is incremented, so a recovered session is stamped
+ * with its own stored close time rather than with now.
+ */
+function resumeOrStart(): void {
+    const stored = readPersisted();
+    if (!stored) {
+        state = freshState();
+        return;
+    }
+    const referenceMs = stored.lastFormCloseMs || stored.lastActivityMs;
+    if (Date.now() - referenceMs < SESSION_IDLE_MS) {
+        state = stored;
+        return;
+    }
+    // Older than the window: a reload or crash orphaned it. Report it rather
+    // than dropping it, then begin a genuinely new session.
+    state = stored;
+    endSession('recovered');
+    state = freshState();
+}
+
+/** Called when the form mounts. Opens or resumes the sitting. */
+export function enterForm(): void {
+    clearResumeTimer();
+    if (!state) resumeOrStart();
+    mountCount += 1;
+    if (!state) return;
+    state.formVisits += 1;
+    state.lastActivityMs = Date.now();
+    openActiveRun();
+    attachListeners();
+    persistSoon();
+}
+
+/**
+ * Called when the form unmounts — every list <-> entry navigation, Finish
+ * included, plus `isFunnel` flipping and StrictMode's discarded first mount.
+ *
+ * Deliberately does **not** emit. Active time stops accruing here, which is what
+ * keeps the measure form-only, and the resume timer decides later whether the
+ * sitting is actually over.
+ */
+export function leaveForm(): void {
+    // Already closed. Without this guard a second call re-stamps
+    // `lastFormCloseMs` to now and re-arms the resume window, inflating
+    // `duration_seconds` by however long the resident had been away.
+    if (mountCount === 0) return;
+    mountCount -= 1;
+    if (mountCount > 0 || !state) return;
+    closeActiveRun();
+    state.lastFormCloseMs = Date.now();
+    clearPersistTimer();
+    persistNow();
+    armResumeTimer();
+}
+
+/** Any resident interaction. Reopens accrual if the idle cutoff closed it. */
+export function noteActivity(): void {
+    if (!state) return;
+    const now = Date.now();
+    const idleFor = now - state.lastActivityMs;
+    if (state.activeRunOpenMs !== null && idleFor > ACTIVE_IDLE_MS) {
+        // Bank the run capped at the cutoff, then start a new one from now, so
+        // the dead stretch in between is charged to neither.
+        closeActiveRun();
+        state.lastActivityMs = now;
+        openActiveRun();
+        persistSoon();
+        return;
+    }
+    state.lastActivityMs = now;
+    if (state.activeRunOpenMs === null && mountCount > 0) openActiveRun();
+    persistSoon();
+}
+
+/** Start of the sitting, for `seconds_since_session_start`. */
+export function sessionStartMs(): number {
+    return state?.startedMs ?? Date.now();
+}
+
+/**
+ * An entry was opened for editing. Returns its index **within the sitting**, so
+ * the count no longer restarts when the resident goes back to the list.
+ */
+export function noteEntryStarted(): number {
+    if (!state) return 1;
+    state.entriesStarted += 1;
+    persistSoon();
+    return state.entriesCompleted + 1;
+}
+
+/** An entry was saved. */
+export function noteEntryCompleted(): void {
+    if (!state) return;
+    state.entriesCompleted += 1;
+    persistSoon();
+}
+
+/**
+ * Emit `lr_session_ended` and tear the session down. Nulling `state` first is
+ * the one-shot: `pagehide` and the resume timer can both fire, and only the
+ * first does anything.
+ */
+export function endSession(reason: EndedReason): void {
+    if (!state) return;
+    const finished = state;
+    // Mounted means the resident is still in the form (a live `pagehide`), so
+    // now is the close. Otherwise use the recorded close, falling back to last
+    // activity for a session that was orphaned while open.
+    const closedMs =
+        mountCount > 0
+            ? Date.now()
+            : finished.lastFormCloseMs || finished.lastActivityMs;
+    closeActiveRun();
+    state = null;
+    clearResumeTimer();
+    clearPersistTimer();
+    detachListeners();
+    clearPersisted();
+    captureEvent(ANALYTICS_EVENTS.LrSessionEnded, {
+        duration_seconds: spanSeconds(finished.startedMs, closedMs),
+        active_seconds: Math.round(finished.activeMs / 1000),
+        entries_started: finished.entriesStarted,
+        entries_completed: finished.entriesCompleted,
+        form_visits: finished.formVisits,
+        ended_reason: reason
+    });
+}

--- a/frontend/src/types/digital-transcript.ts
+++ b/frontend/src/types/digital-transcript.ts
@@ -74,34 +74,64 @@ const CATEGORIES_STORAGE_KEYS = {
  * resident's own draft and dedupe list intact, which clearing on logout would
  * throw away.
  *
- * The stamp is the deployment-namespaced analytics id, never a name or username.
+ * The stamp is a SHA-256 digest of the deployment-namespaced analytics id, never
+ * the id itself or a name/username — the check only needs equality, not the
+ * original value, so nothing readable is left in `localStorage` once a resident
+ * signs out.
  */
 const TRANSCRIPT_STORAGE_OWNER_KEY = 'unlockEd_digital_transcript_owner_v1';
 
-/** Every key both prototypes can write, so a purge cannot miss one. */
+/** Digest an owner id so the stamp on disk can't be read back to a resident. */
+async function digestOwnerId(ownerId: string): Promise<string> {
+    const bytes = new TextEncoder().encode(ownerId);
+    const digest = await crypto.subtle.digest('SHA-256', bytes);
+    return Array.from(new Uint8Array(digest))
+        .map((b) => b.toString(16).padStart(2, '0'))
+        .join('');
+}
+
+/** Every key any current or former Learning Record storage layout has written. */
 function allDigitalTranscriptStorageKeys() {
     return [
         ...Object.values(FUNNEL_STORAGE_KEYS),
-        ...Object.values(CATEGORIES_STORAGE_KEYS)
+        ...Object.values(CATEGORIES_STORAGE_KEYS),
+        ...Object.values(DIGITAL_TRANSCRIPT_LEGACY_STORAGE),
+        ...Object.values(DIGITAL_TRANSCRIPT_B_STORAGE),
+        ...STALE_TRANSCRIPT_A_STORAGE_KEYS
     ];
 }
 
 /**
- * Drop every Learning Record record on this browser.
+ * Drop every Learning Record record on this browser — current, both prototype
+ * namespaces, and every retired layout (`DIGITAL_TRANSCRIPT_LEGACY_STORAGE`,
+ * `DIGITAL_TRANSCRIPT_B_STORAGE`, `STALE_TRANSCRIPT_A_STORAGE_KEYS`).
  *
  * Both prototype namespaces are cleared explicitly rather than through
  * `getDigitalTranscriptStorageKeys()`, because that resolves against the *current
  * route* — at sign-in the resident is on `/home`, so it would only ever return the
- * funnel keys and would quietly leave the categories ones behind.
+ * funnel keys and would quietly leave the categories ones behind. The retired
+ * layouts have to be swept explicitly for the same reason: nothing else clears
+ * them once `migrateDigitalTranscriptLegacyStorage()` (the only other code that
+ * reads them) stops running against them, and old drafts in an origin-scoped key
+ * are exactly what this purge exists to keep from outliving the resident who
+ * wrote them.
  */
 function purgeDigitalTranscriptStorage(): void {
     for (const key of allDigitalTranscriptStorageKeys()) {
+        // Separate try/catch per store: a throw removing from one must not skip
+        // the other for the same key. `session` — the previous resident's
+        // sitting — lives in sessionStorage, so a localStorage failure must
+        // never be the reason it survives an owner change.
         try {
             if (typeof localStorage !== 'undefined') {
                 localStorage.removeItem(key);
             }
-            // `session` is the one key held in sessionStorage; removing a missing
-            // key is a no-op, so both stores are swept without special-casing.
+        } catch {
+            /* storage unavailable — nothing to purge */
+        }
+        try {
+            // Removing a missing key is a no-op, so both stores are swept
+            // without special-casing which keys actually live in which one.
             if (typeof sessionStorage !== 'undefined') {
                 sessionStorage.removeItem(key);
             }
@@ -124,13 +154,16 @@ function purgeDigitalTranscriptStorage(): void {
  * bounded: a resident mid-entry when this ships loses only text not yet saved to
  * the server.
  */
-export function setDigitalTranscriptStorageOwner(ownerId: string): void {
+export async function setDigitalTranscriptStorageOwner(
+    ownerId: string
+): Promise<void> {
     if (typeof localStorage === 'undefined') return;
     try {
+        const digest = await digestOwnerId(ownerId);
         const previous = localStorage.getItem(TRANSCRIPT_STORAGE_OWNER_KEY);
-        if (previous === ownerId) return;
+        if (previous === digest) return;
         purgeDigitalTranscriptStorage();
-        localStorage.setItem(TRANSCRIPT_STORAGE_OWNER_KEY, ownerId);
+        localStorage.setItem(TRANSCRIPT_STORAGE_OWNER_KEY, digest);
     } catch {
         // Quota or private mode. The stamp cannot be written, so the records are
         // purged on every load rather than shared — the safe direction to fail.

--- a/frontend/src/types/digital-transcript.ts
+++ b/frontend/src/types/digital-transcript.ts
@@ -21,6 +21,15 @@ const STALE_TRANSCRIPT_A_STORAGE_KEYS = [
 
 export const TRANSCRIPT_ENTRY_SESSION_VERSION = 1 as const;
 
+/**
+ * Analytics sitting record (`learningRecordSession.ts`).
+ *
+ * Note the `session` keys below are read from **`sessionStorage`**, not
+ * `localStorage` like every other key in this file — a clock must not be shared
+ * between tabs the way draft content is. See `storageKey` in that module.
+ */
+export const LEARNING_RECORD_SESSION_VERSION = 1 as const;
+
 /** Multi-row achievement editor session (entry page); debounced to localStorage */
 export interface TranscriptEntrySession {
     version: typeof TRANSCRIPT_ENTRY_SESSION_VERSION;
@@ -32,14 +41,101 @@ export interface TranscriptEntrySession {
 const FUNNEL_STORAGE_KEYS = {
     draft: 'unlockEd_digital_transcript_draft_v2_a',
     entries: 'unlockEd_digital_transcript_entries_v2_a',
-    entrySession: 'unlockEd_digital_transcript_entry_session_v1_a'
+    entrySession: 'unlockEd_digital_transcript_entry_session_v1_a',
+    session: 'unlockEd_digital_transcript_session_v1_a',
+    countedEntries: 'unlockEd_digital_transcript_counted_entries_v1_a',
+    entryTiming: 'unlockEd_digital_transcript_entry_timing_v1_a'
 } as const;
 
 const CATEGORIES_STORAGE_KEYS = {
     draft: 'unlockEd_digital_transcript_draft_v2_categories',
     entries: 'unlockEd_digital_transcript_entries_v2_categories',
-    entrySession: 'unlockEd_digital_transcript_entry_session_v1_categories'
+    entrySession: 'unlockEd_digital_transcript_entry_session_v1_categories',
+    session: 'unlockEd_digital_transcript_session_v1_categories',
+    countedEntries: 'unlockEd_digital_transcript_counted_entries_v1_categories',
+    entryTiming: 'unlockEd_digital_transcript_entry_timing_v1_categories'
 } as const;
+
+/**
+ * Who the Learning Record records on this browser belong to.
+ *
+ * Every `unlockEd_digital_transcript_*` key is scoped to the *origin*, not to the
+ * user, and nothing clears them when someone logs out — `handleLogout` resets the
+ * analytics identity and the tab session and stops there. On a shared facility
+ * workstation that meant the next resident to sign in was offered the previous
+ * one's unfinished achievement by name ("pick up where you left off"), which is
+ * the opposite of what the privacy notice on that page promises. The analytics
+ * records leaked the same way: a sitting left open in `sessionStorage` was
+ * *resumed* by the next resident in the same tab, so their `lr_session_ended`
+ * carried someone else's entry counts under their own identity.
+ *
+ * Stamping the owner fixes both, and covers the case clearing-on-logout cannot:
+ * a browser closed without logging out at all. It also keeps a returning
+ * resident's own draft and dedupe list intact, which clearing on logout would
+ * throw away.
+ *
+ * The stamp is the deployment-namespaced analytics id, never a name or username.
+ */
+const TRANSCRIPT_STORAGE_OWNER_KEY = 'unlockEd_digital_transcript_owner_v1';
+
+/** Every key both prototypes can write, so a purge cannot miss one. */
+function allDigitalTranscriptStorageKeys() {
+    return [
+        ...Object.values(FUNNEL_STORAGE_KEYS),
+        ...Object.values(CATEGORIES_STORAGE_KEYS)
+    ];
+}
+
+/**
+ * Drop every Learning Record record on this browser.
+ *
+ * Both prototype namespaces are cleared explicitly rather than through
+ * `getDigitalTranscriptStorageKeys()`, because that resolves against the *current
+ * route* — at sign-in the resident is on `/home`, so it would only ever return the
+ * funnel keys and would quietly leave the categories ones behind.
+ */
+function purgeDigitalTranscriptStorage(): void {
+    for (const key of allDigitalTranscriptStorageKeys()) {
+        try {
+            if (typeof localStorage !== 'undefined') {
+                localStorage.removeItem(key);
+            }
+            // `session` is the one key held in sessionStorage; removing a missing
+            // key is a no-op, so both stores are swept without special-casing.
+            if (typeof sessionStorage !== 'undefined') {
+                sessionStorage.removeItem(key);
+            }
+        } catch {
+            /* storage unavailable — nothing to purge */
+        }
+    }
+}
+
+/**
+ * Record who this browser's Learning Record data belongs to, discarding it first
+ * if it belonged to someone else.
+ *
+ * Call on every successful authentication, not just on a change of user: the
+ * check has to survive a full page load, so it cannot rely on anything in memory.
+ *
+ * **Unrecorded provenance is treated as someone else's.** A browser carrying
+ * records but no stamp predates this check, so there is no way to tell whose they
+ * are — and inheriting them is the exact bug being fixed. The cost is one-time and
+ * bounded: a resident mid-entry when this ships loses only text not yet saved to
+ * the server.
+ */
+export function setDigitalTranscriptStorageOwner(ownerId: string): void {
+    if (typeof localStorage === 'undefined') return;
+    try {
+        const previous = localStorage.getItem(TRANSCRIPT_STORAGE_OWNER_KEY);
+        if (previous === ownerId) return;
+        purgeDigitalTranscriptStorage();
+        localStorage.setItem(TRANSCRIPT_STORAGE_OWNER_KEY, ownerId);
+    } catch {
+        // Quota or private mode. The stamp cannot be written, so the records are
+        // purged on every load rather than shared — the safe direction to fail.
+    }
+}
 
 export function getDigitalTranscriptStorageKeys() {
     const proto = resolveLearningRecordPrototype(


### PR DESCRIPTION
## Pre-Submission PR Checklist

- [x] No debug/console/fmt.Println statements
- [x] Unnecessary development comments removed
- [x] All acceptance criteria verified
- [x] Functions according to **ticket specifications**
- [x] Tested manually where applicable
- [x] Branch rebased with latest main
- [x] No business logic exists within the database layer

## Description of the change

Six acceptance criteria needed behavioural data from PostHog. Four of them could not be answered
from what the app was sending, and two of those would have reported numbers that were **wrong**
rather than missing — which is the worse failure, because nothing on the dashboard would have
looked broken.

No new event names. The same five `lr_*` events, with properties added and four defects fixed.

Companion doc: [What we are sending](https://docs.google.com/document/d/1nGSmn7CKhHDTiF3zYI6htkK9S0NrtGC0M0Q7iRcBqvY/edit?tab=t.0) — the payload reference,
the definition of a *sitting*, and a table mapping each acceptance criterion to the events and
properties that answer it.

### Criterion 6 could not be answered at all

*"Total time spent in the tool per session (distribution)"*

The `lr_session_ended` window lived inside `DigitalTranscriptWysiwygEntry`, which unmounts on every
list ↔ entry navigation (`DigitalTranscriptHome.tsx:352`, `DigitalTranscriptEntryPage.tsx:133-155`).
So one sitting emitted several partial events with nothing on the payload to rejoin them,
`entry_index_in_session` restarted at 1 on each visit, and `seconds_since_session_start` measured
from the mount rather than from the start of the sitting. Three symptoms, one cause.

The session now lives in `learningRecordSession.ts`, a module-level singleton that outlives any
mount. `leaveForm` no longer emits: it stops active time accruing and arms a 30-minute resume
window, so a trip out to the list keeps one sitting intact. `endSession` fires once per sitting —
on `pagehide`, on the window lapsing, or on recovery of a sitting a reload interrupted.

`active_seconds` accrues only while the form is mounted, visible and not idle, so it excludes
background-tab and list-page time. The idle cutoff is **five minutes**, deliberately generous:
`lr_question_left` already discards think time, so a short cutoff here would leave nothing in the
dataset showing hesitation — the exact friction signal the story is built on.

### Criterion 5 was double counting

*"Distribution of number of achievements entered per resident, to see if residents stop at one or
add more"*

`this.completed` guards one `entryStarted` → `entryCompleted` pass, and the tracker is rebuilt on
remount. So re-opening a saved achievement and pressing Finish again emitted a second
`lr_entry_completed` with nothing to tell the two apart — an *edit* read as a new achievement.
That can invert the exact question the criterion exists to answer.

Completions now dedupe against a list of achievement ids in `localStorage`. Nothing new goes on the
wire: the ids never leave the browser.

A rejected re-Finish skips the completion flush, but the resident is still in the form, so leaving
afterwards still emits that step's questions flagged `abandoned: true` (verified in the browser).
Criterion 5 is fully protected — one achievement, one `lr_entry_completed`. Criterion 3 must use
**Unique users** rather than event counts, which the build-order doc already specifies, so a
resident revisiting their own entry cannot inflate a selection rate.

### Criterion 3 was missing the population it is defined over

*"Percent of residents who select at least one option vs. leave it blank"*

Questions only reported when a step was left *for another one* or an entry completed. Nothing
flushed the step the resident was standing on when they gave up — so someone who left a chip
question blank **and** abandoned emitted nothing at all, and the blank-leavers were missing from
the denominator the criterion is defined over.

`abandonedCurrentStep` now flushes that step from the effect cleanup. Only the current step:
unvisited ones would arrive as rows of zeros and invent a denominator nobody saw. Those rows carry
`abandoned: true`, so timing tiles can exclude what answer-rate tiles need to keep.

### Criterion 1 measured typing span, not time on question

*"Average and distribution of time spent per question/step, to surface which questions take
unusually long"*

Per-question `duration_seconds` runs first keystroke to last keystroke. A question someone stared
at for a minute and answered in ten seconds reported ten — so the metric was blind to exactly the
questions it was meant to surface, because hesitation is where confusion shows.

New `seconds_before_first_edit`: the quiet gap between the previous keystroke anywhere in the step
(or the step opening, for the first question engaged) and the first keystroke here. Derived from
state the tracker already held — no focus handlers, no coupling to form markup.

True per-question dwell time would need focus/blur across ~10 field components, which this module
deliberately avoids so it does not depend on the form's markup. Hesitation and typing span as two
separate numbers is more useful than one number silently conflating them.

### Criterion 2 measured only the final visit

*"Average time to complete a single achievement entry"*

`entryStarted` re-bases its timer and fires again when a resident returns to the same achievement,
so entry duration reported the last visit alone and systematically understated the work — and it is
the number the facilitator cross-reference leans on.

New `cumulative_seconds`: editing time banked per achievement and summed across every visit,
excluding time away. Additive, so `duration_seconds` keeps its meaning and there is no second
cutover to explain.

### Also fixed, found while verifying the above

- **bfcache restore left the sitting dead.** `pagehide` reports and tears down; the page returns
  with the editor still mounted, so `enterForm` never runs again and everything the resident did
  afterwards was unattributed. A `pageshow` listener that outlives teardown starts a new sitting.
- **A second `leaveForm` re-stamped the close time**, inflating `duration_seconds` 60s → 660s in
  the probe that caught it.
- **Learning Record storage is per-origin and logout clears none of it**, so the next resident on a
  shared workstation was offered the previous one's unfinished achievement *by name* — on the page
  whose own notice promises the opposite — and could silently resume their sitting. Records are now
  stamped with a SHA-256 digest of the resident's analytics id (never the id itself, so nothing
  readable is left in `localStorage` after logout) and discarded when someone else signs in. That
  also covers a browser closed without logging out at all, which clearing-on-logout cannot, and
  keeps a returning resident's own work. Records carrying no stamp are treated as someone else's.
- **Banked time for an already-counted entry was never released.** `entryCompleted`'s early return
  for a re-Finished achievement skipped `takeEntryActiveMs`, so that entry's `entryTiming` record
  kept growing on every later re-open and abandon with nothing left to ever read or clear it —
  unbounded storage growth on exactly the achievements residents revisit most. Now cleared on that
  same early-return path.
- **`cumulative_seconds` had no idle cutoff.** Both contributions — the visit banked in
  `abandonedCurrentStep` and the final visit added in `entryCompleted` — were raw wall clock with
  nothing capping an unattended tab, so a resident who left an achievement open overnight could
  report as having spent hours completing it, skewing the criterion-2 average. Now capped at the
  same 5-minute idle cutoff as `active_seconds`.
- **`lr_entry_started` wasn't deduped, only `lr_entry_completed` was.** `entryStarted` emitted, and
  bumped `lr_session_ended.entries_started`, on every open of an achievement — including reopening
  one already completed to edit it — while `entryCompleted` and its `entries_completed` counter
  correctly skip a re-Finish. A resident who reopens one saved achievement twice reported 3 started
  against 1 completed on the same session event. `entryStarted` now skips both the counter bump and
  the emit for an already-completed row id, so the two counters describe the same population.
- **The sitting's `sessionStorage` key could drift mid-sitting.** `storageKey()` resolved which
  prototype variant's key to use fresh on every call, from the same mutable route global the rest
  of the module reads — but the sitting itself is a long-lived singleton that survives navigation
  by design. A prototype switch mid-sitting silently retargeted later writes (and the clear in
  `endSession`) at the other variant's key, orphaning the record under the original one, which a
  later visit to that route could recover and report a second time. The key is now resolved once,
  when the sitting opens, and held until `endSession` clears it.
- **A bfcache restore left the analytics tracker numbered against the sitting that had just ended.**
  The bfcache fix above deliberately starts a new sitting on `pageshow` without the editor
  unmounting — but `LearningRecordTracker` lives in that same component's `useRef` and is likewise
  never recreated, and `entryStarted` (the only place that numbers `entryIndex`) is gated to run
  once per row id, so it never re-ran either. An achievement left open across the freeze reported
  `lr_entry_completed` with `entry_index_in_session` from the *old* sitting alongside
  `seconds_since_session_start` from the *new* one — breaking criterion 4's "first entry of the
  sitting" identification, and leaving the new sitting's `entries_started`/`entries_completed` pair
  asymmetric if that entry went on to complete. `learningRecordSession.ts` now dispatches a
  `learning-record-session-restarted` event on restart (the same `window.dispatchEvent`
  convention `transcriptEntrySessionStorage.ts` already uses for this class of problem), and the
  tracker's new `reattachToSession` renumbers `entryIndex` and reports a fresh `lr_entry_started`
  without touching question/step timing already accumulated.
- **`noteEntryStarted` numbered entries by completions, not starts.** It incremented
  `entriesStarted` but returned `entriesCompleted + 1` as `entryIndex` — the two counters only
  happened to agree when nothing had ever been abandoned. A resident who opened and abandoned two
  achievements before ever finishing one had both report `entry_index_in_session: 1`, since neither
  had completed. That breaks criterion 4's "first entry of the sitting" identification the same way
  the two bfcache fixes above do, and it fed directly into `reattachToSession`, which calls this
  same function. Now returns `entriesStarted` itself, and `0` (not `1`) when no sitting is active,
  so a missing session is distinguishable from a real first entry — `LearningRecordTracker` already
  treats `entryIndex === 0` as its own "nothing open" sentinel.
- **The owner-change purge missed three retired key sets.** `allDigitalTranscriptStorageKeys()` only
  enumerated the current `FUNNEL_STORAGE_KEYS`/`CATEGORIES_STORAGE_KEYS`, so
  `DIGITAL_TRANSCRIPT_LEGACY_STORAGE` (pre–variant-split), `DIGITAL_TRANSCRIPT_B_STORAGE` (the
  removed guided-flow variant), and `STALE_TRANSCRIPT_A_STORAGE_KEYS` were never cleared when a new
  resident signed in — despite `purgeDigitalTranscriptStorage`'s own comment claiming to drop
  "every" record. `migrateDigitalTranscriptLegacyStorage()`, the only other code that touches those
  keys, has no call site anywhere in the app, so data written under any of them had no path to ever
  being cleared: on a shared workstation it would outlive every owner change, which is exactly the
  leak this PR's owner stamp exists to close. All three are now included in the purge.
- **A `localStorage` failure could skip the matching `sessionStorage` removal for the same key.**
  `purgeDigitalTranscriptStorage()`'s loop wrapped both stores' `removeItem` in one `try`, so if
  `localStorage.removeItem` threw (quota, private mode, sandboxed access), the `sessionStorage`
  removal for that same key never ran — and `session`, the previous resident's sitting, is the one
  key actually held in `sessionStorage`. A partial failure could leave that sitting in place while
  everything else was cleared. Each store now gets its own `try`/`catch` per key.
- **The two dashboard CTAs were raw `<a href>`**, i.e. full document loads, which fire `pagehide`
  and flush the sitting before the new document can resume it. Now `<Link to>`.

## Changes

- **New `learningRecordSession.ts`** — the sitting: resume window, reload recovery, active-time
  accumulation, single emit. Listeners (`visibilitychange`, `pagehide`, `pageshow`, activity) are
  registered by the module, not the component: registered in the effect they would be removed the
  moment the editor unmounted, so a resident who returned to the list and *then* closed the tab
  would produce no event at all now that leaving the form no longer emits.
- **`learningRecordAnalytics.ts`** — session fields removed; completion dedupe; per-entry time
  banking; `abandonedCurrentStep`; `abandoned` and `seconds_before_first_edit`.
- **`DigitalTranscriptWysiwygEntry.tsx`** — `enterForm`/`leaveForm`, the abandon flush, and the row
  id threaded into `entryStarted`/`entryCompleted`.
- **`ResidentHome.tsx`** — the two CTAs converted to `<Link to>`. The file already navigated
  SPA-style at `:184`/`:356` and reserves `href` for external links (`:159`), so the anchors read as
  an oversight rather than a decision.
- **`AuthProvider.tsx`** — the storage owner check, called (and awaited, since the digest hash is
  computed asynchronously via Web Crypto) before anything reads Learning Record storage.
- **`types/digital-transcript.ts`** — `session`, `countedEntries` and `entryTiming` keys, the
  version constant, and the owner stamp (a SHA-256 digest of the analytics id, not the id itself).
  Both prototype namespaces are purged explicitly:
  `getDigitalTranscriptStorageKeys()` resolves against the *current route*, and at sign-in that is
  `/home`, so it would only ever return the funnel keys and would quietly leave the categories ones
  behind.
- **`lib/events.ts`** — `LrSessionEnded` comment, and `analyticsDistinctId` exported so the owner
  stamp and the PostHog identity share one definition.

**The sitting record uses `sessionStorage`, not `localStorage` like its neighbouring transcript
keys.** Draft content should follow a resident across tabs; a clock must not, or a second tab
resumes the first tab's sitting and both emit. The dedupe and timing records *do* use `localStorage`
deliberately — editing an old achievement in another tab must not be counted twice either.

### Which events answer which acceptance criterion

| Acceptance criterion | Read from | Watch out for |
|---|---|---|
| 1. Time per question/step, and which take unusually long | `lr_question_left`: `question_key`, `duration_seconds`, `seconds_before_first_edit`, `touched`. `lr_step_completed`: `step_id`, `step_index`, `duration_seconds` | A question's `duration_seconds` is a typing span and excludes think time; `seconds_before_first_edit` is the hesitation before engaging it, and is null for questions never typed in. Filter `touched = true` and `abandoned = false` for clean timings. Step rows are honest wall clock. |
| 2. Average time to complete a single achievement entry | `lr_entry_completed`: `cumulative_seconds` (use this), `duration_seconds` | `duration_seconds` covers only the resident's last visit to that achievement; `cumulative_seconds` sums every visit, capped at 5 minutes of idle time per visit so an unattended tab can't inflate it. Compare facilitator estimates against `cumulative_seconds`. |
| 3. Selection rate per pill/checkbox question, and average options selected | `lr_question_left`: `question_key`, `kind = tags`, `answered`, `selection_count` | Count residents with Unique users, not events. Keep `abandoned = true` rows in the denominator: that is the "left it blank" population the criterion asks for. Option ceilings differ by question. |
| 4. Distribution of time-to-first-entry across residents | `lr_entry_completed`: `seconds_since_session_start`, `entry_index_in_session` | `entry_index_in_session = 1` is the first entry of a sitting, so a resident with several sittings contributes several rows. For each resident's genuine first, take `min(timestamp)` per person in SQL. |
| 5. Achievements per resident — do they stop at one or add more | `lr_entry_completed`, grouped by person | One event per achievement: re-finishing an existing one is discarded in the browser, so counts are achievements and not Finish presses. Grouping per resident needs SQL; Trends cannot count distinct on a property. |
| 6. Total time in the tool per session | `lr_session_ended`: `active_seconds` (use this), `duration_seconds`, `form_visits` | `active_seconds` excludes hidden-tab, idle and list-page time. `duration_seconds` spans the whole sitting including all three. See "What a sitting is". |

What rides along on every event (lr_session_ended payload)

| Prop | Status | Meaning |
|---|---|---|
| `duration_seconds` | scope changed | Wall clock, first form open → last form close. |
| `entries_completed` | scope changed | Counts across the sitting. |
| `active_seconds` | new | Mounted, visible, not idle. Criterion 6's "time spent". |
| `form_visits` | new | Times the form was opened this sitting. > 1 proves stitching. |
| `entries_started` | new | Pairs with `entries_completed` for abandonment. Deduped the same way `entries_completed` is: reopening an already-completed achievement bumps neither. |
| `ended_reason` | new | `navigated_away` \| `page_hidden` \| `recovered`. |

Also new: cumulative_seconds on lr_entry_completed; seconds_before_first_edit and abandoned on lr_question_left; abandoned on lr_step_completed. Every value is a count, a whole-second duration, a boolean or a fixed enum — within the privacy contract at learningRecordAnalytics.ts and the resident consent copy at learningRecordResidentCopy.ts:8,17. No session id and no row id are ever sent: all stitching and deduping happens on the client.
## Known limits

- **Entry from outside the app starts a new sitting** — bookmark, typed URL, arrival from another
  site. Those should be new sittings, so this is a boundary rather than a defect.
- **`duration_seconds` straddles the cutover** — still wall clock, but a sitting rather than a
  mount, so later values are systematically larger. Prefer `active_seconds`.
- **A browser kill defers the event** to the next visit, so `recovered` events land in the day they
  were sent rather than the day they happened.
- **The 5-minute idle cutoff is a judgement call.** Applied to both `active_seconds` and
  `cumulative_seconds`. It preserves ordinary thinking pauses and caps unattended screens, but six
  minutes of genuine deliberation loses the tail. Treat both as a conservative floor on effort.
- **Per-question dwell time is still unavailable** — see criterion 1 above. `seconds_before_first_edit`
  is a hesitation proxy, not dwell.
- **Adjacent flows remain uninstrumented**: the list page itself, PDF export, delete/cancel, table
  sort, and the categories prototype.


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1217564912951082
