### PR TITLE
fix: hide Knowledge Center FAQ content and guided tour when KC is disabled

### DIFF
--- a/frontend/src/data/faqData.ts
+++ b/frontend/src/data/faqData.ts
@@ -10,7 +10,7 @@ interface FAQEntry {
     extra?: string;
 }
 
-export const FAQ_CATEGORIES: Record<string, FAQEntry[]> = {
+const KNOWLEDGE_CENTER_CATEGORIES: Record<string, FAQEntry[]> = {
     Overview: [
         {
             question: "What is UnlockEd's Knowledge Center?",
@@ -80,53 +80,63 @@ export const FAQ_CATEGORIES: Record<string, FAQEntry[]> = {
             question: 'How can I request new content for UnlockEd?',
             answer: "Let the staff know! We can't promise everything, but we're always looking for useful additions."
         }
-    ],
-    'Managing My Account': [
-        {
-            question: LEARNING_RECORD_PRINT_SHARE_FAQ.question,
-            answer: LEARNING_RECORD_PRINT_SHARE_FAQ.answer
-        },
-        {
-            question: LEARNING_RECORD_SAVED_HERE_FAQ.question,
-            answer: LEARNING_RECORD_SAVED_HERE_FAQ.answer
-        },
-        {
-            question: 'Can I change my name or username?',
-            answer: 'Talk to the staff and they can help you.'
-        },
-        {
-            question: 'How do I reset my password?',
-            answer: 'Talk to the staff and they can help you.'
-        },
-        {
-            question: 'Does UnlockEd have a way to track my progress?',
-            answer: "Right now, UnlockEd is a library of resources you can explore freely. Some of these resources may have more of a learning path built into them, but the tool doesn't guide you along or track your progress like some other courses do. We're considering ways to help users track their learning in the future. We're always eager to hear what you'd find useful, so please let us know!"
-        },
-        {
-            question: 'Is my activity on UnlockEd private?',
-            answer: "The UnlockEd team and authorized facility staff can see your library and course activity. Your Learning Record entries are separate — staff don't see your individual entries there."
-        }
-    ],
-    'Getting Help and Troubleshooting': [
-        {
-            question: 'Can I use UnlockEd more often?',
-            answer: "We're excited you'd want to use it even more! Please share this request and positive feedback with the staff. They're collecting all of it as input for the future plans."
-        },
-        {
-            question: 'If I need more help, what do I do?',
-            answer: "Ask the staff. If they can't help, they'll reach out to the UnlockEd team."
-        },
-        {
-            question: "What should I do if something isn't working?",
-            answer: "Let the staff know, and they'll report the issue!"
-        },
-        {
-            question: 'How can I share ideas to improve UnlockEd?',
-            answer: "We want to hear from you! If you have ideas, suggestions, or things you'd like to change, please share them with the staff, and they'll get passed along to the UnlockEd team."
-        },
-        {
-            question: "What's next for UnlockEd?",
-            answer: "We're always improving what we offer based on what people find helpful. For the Knowledge Center, we will continue to add valuable content and make it easy to find and use those resources. We're also exploring other offerings that would help residents access courses and track the programs they've completed. We would love to know what's valuable to you!"
-        }
     ]
 };
+
+export function getFaqCategories(
+    hasKnowledgeCenter: boolean
+): Record<string, FAQEntry[]> {
+    return {
+        ...(hasKnowledgeCenter ? KNOWLEDGE_CENTER_CATEGORIES : {}),
+        'Managing My Account': [
+            {
+                question: LEARNING_RECORD_PRINT_SHARE_FAQ.question,
+                answer: LEARNING_RECORD_PRINT_SHARE_FAQ.answer
+            },
+            {
+                question: LEARNING_RECORD_SAVED_HERE_FAQ.question,
+                answer: LEARNING_RECORD_SAVED_HERE_FAQ.answer
+            },
+            {
+                question: 'Can I change my name or username?',
+                answer: 'Talk to the staff and they can help you.'
+            },
+            {
+                question: 'How do I reset my password?',
+                answer: 'Talk to the staff and they can help you.'
+            },
+            {
+                question: 'Does UnlockEd have a way to track my progress?',
+                answer: "Right now, UnlockEd is a library of resources you can explore freely. Some of these resources may have more of a learning path built into them, but the tool doesn't guide you along or track your progress like some other courses do. We're considering ways to help users track their learning in the future. We're always eager to hear what you'd find useful, so please let us know!"
+            },
+            {
+                question: 'Is my activity on UnlockEd private?',
+                answer: "The UnlockEd team and authorized facility staff can see your library and course activity. Your Learning Record entries are separate — staff don't see your individual entries there."
+            }
+        ],
+        'Getting Help and Troubleshooting': [
+            {
+                question: 'Can I use UnlockEd more often?',
+                answer: "We're excited you'd want to use it even more! Please share this request and positive feedback with the staff. They're collecting all of it as input for the future plans."
+            },
+            {
+                question: 'If I need more help, what do I do?',
+                answer: "Ask the staff. If they can't help, they'll reach out to the UnlockEd team."
+            },
+            {
+                question: "What should I do if something isn't working?",
+                answer: "Let the staff know, and they'll report the issue!"
+            },
+            {
+                question: 'How can I share ideas to improve UnlockEd?',
+                answer: "We want to hear from you! If you have ideas, suggestions, or things you'd like to change, please share them with the staff, and they'll get passed along to the UnlockEd team."
+            },
+            {
+                question: "What's next for UnlockEd?",
+                answer: hasKnowledgeCenter
+                    ? "We're always improving what we offer based on what people find helpful. For the Knowledge Center, we will continue to add valuable content and make it easy to find and use those resources. We're also exploring other offerings that would help residents access courses and track the programs they've completed. We would love to know what's valuable to you!"
+                    : "We're always improving what we offer based on what people find helpful. We're also exploring other offerings that would help residents access courses and track the programs they've completed. We would love to know what's valuable to you!"
+            }
+        ]
+    };
+}

--- a/frontend/src/data/faqData.ts
+++ b/frontend/src/data/faqData.ts
@@ -119,12 +119,16 @@ export function getFaqCategories(
                       }
                   ]
                 : []),
-            {
-                question: 'Is my activity on UnlockEd private?',
-                answer: hasLearningRecord
-                    ? "The UnlockEd team and authorized facility staff can see your library and course activity. Your Learning Record entries are separate — staff don't see your individual entries there."
-                    : 'The UnlockEd team and authorized facility staff can see your library and course activity.'
-            }
+            ...(hasKnowledgeCenter
+                ? [
+                      {
+                          question: 'Is my activity on UnlockEd private?',
+                          answer: hasLearningRecord
+                              ? "The UnlockEd team and authorized facility staff can see your library and course activity. Your Learning Record entries are separate — staff don't see your individual entries there."
+                              : 'The UnlockEd team and authorized facility staff can see your library and course activity.'
+                      }
+                  ]
+                : [])
         ],
         'Getting Help and Troubleshooting': [
             {

--- a/frontend/src/data/faqData.ts
+++ b/frontend/src/data/faqData.ts
@@ -84,19 +84,24 @@ const KNOWLEDGE_CENTER_CATEGORIES: Record<string, FAQEntry[]> = {
 };
 
 export function getFaqCategories(
-    hasKnowledgeCenter: boolean
+    hasKnowledgeCenter: boolean,
+    hasLearningRecord: boolean
 ): Record<string, FAQEntry[]> {
     return {
         ...(hasKnowledgeCenter ? KNOWLEDGE_CENTER_CATEGORIES : {}),
         'Managing My Account': [
-            {
-                question: LEARNING_RECORD_PRINT_SHARE_FAQ.question,
-                answer: LEARNING_RECORD_PRINT_SHARE_FAQ.answer
-            },
-            {
-                question: LEARNING_RECORD_SAVED_HERE_FAQ.question,
-                answer: LEARNING_RECORD_SAVED_HERE_FAQ.answer
-            },
+            ...(hasLearningRecord
+                ? [
+                      {
+                          question: LEARNING_RECORD_PRINT_SHARE_FAQ.question,
+                          answer: LEARNING_RECORD_PRINT_SHARE_FAQ.answer
+                      },
+                      {
+                          question: LEARNING_RECORD_SAVED_HERE_FAQ.question,
+                          answer: LEARNING_RECORD_SAVED_HERE_FAQ.answer
+                      }
+                  ]
+                : []),
             {
                 question: 'Can I change my name or username?',
                 answer: 'Talk to the staff and they can help you.'
@@ -105,13 +110,20 @@ export function getFaqCategories(
                 question: 'How do I reset my password?',
                 answer: 'Talk to the staff and they can help you.'
             },
-            {
-                question: 'Does UnlockEd have a way to track my progress?',
-                answer: "Right now, UnlockEd is a library of resources you can explore freely. Some of these resources may have more of a learning path built into them, but the tool doesn't guide you along or track your progress like some other courses do. We're considering ways to help users track their learning in the future. We're always eager to hear what you'd find useful, so please let us know!"
-            },
+            ...(hasKnowledgeCenter
+                ? [
+                      {
+                          question:
+                              'Does UnlockEd have a way to track my progress?',
+                          answer: "Right now, UnlockEd is a library of resources you can explore freely. Some of these resources may have more of a learning path built into them, but the tool doesn't guide you along or track your progress like some other courses do. We're considering ways to help users track their learning in the future. We're always eager to hear what you'd find useful, so please let us know!"
+                      }
+                  ]
+                : []),
             {
                 question: 'Is my activity on UnlockEd private?',
-                answer: "The UnlockEd team and authorized facility staff can see your library and course activity. Your Learning Record entries are separate — staff don't see your individual entries there."
+                answer: hasLearningRecord
+                    ? "The UnlockEd team and authorized facility staff can see your library and course activity. Your Learning Record entries are separate — staff don't see your individual entries there."
+                    : 'The UnlockEd team and authorized facility staff can see your library and course activity.'
             }
         ],
         'Getting Help and Troubleshooting': [

--- a/frontend/src/pages/FAQs.tsx
+++ b/frontend/src/pages/FAQs.tsx
@@ -5,7 +5,9 @@ import {
     AccordionItem,
     AccordionTrigger
 } from '@/components/ui/accordion';
-import { FAQ_CATEGORIES } from '@/data/faqData';
+import { getFaqCategories } from '@/data/faqData';
+import { useAuth, hasFeature } from '@/auth/useAuth';
+import { FeatureAccess } from '@/types';
 
 function logQuestionClick(question: string) {
     void API.post('analytics/faq-click', { question }).catch(() => {
@@ -14,6 +16,10 @@ function logQuestionClick(question: string) {
 }
 
 export function FAQContent({ compact = false }: { compact?: boolean }) {
+    const { user } = useAuth();
+    const hasKnowledgeCenter =
+        !!user && hasFeature(user, FeatureAccess.OpenContentAccess);
+
     return (
         <div className={compact ? 'space-y-4' : 'space-y-6'}>
             {!compact && (
@@ -21,51 +27,55 @@ export function FAQContent({ compact = false }: { compact?: boolean }) {
                     Frequently Asked Questions
                 </h2>
             )}
-            {Object.entries(FAQ_CATEGORIES).map(([category, questions]) => (
-                <div key={category}>
-                    <h3
-                        className={
-                            compact
-                                ? 'text-base font-semibold text-foreground mb-2'
-                                : 'text-lg font-semibold text-foreground mb-2'
-                        }
-                    >
-                        {category}
-                    </h3>
-                    <div className="bg-card rounded-lg border border-border">
-                        <Accordion type="single" collapsible>
-                            {questions.map((faq, index) => (
-                                <AccordionItem
-                                    key={`${category}-${index}`}
-                                    value={`${category}-${index}`}
-                                >
-                                    <AccordionTrigger
-                                        onClick={() =>
-                                            logQuestionClick(faq.question)
-                                        }
-                                        className="px-4 text-foreground hover:no-underline hover:text-brand"
+            {Object.entries(getFaqCategories(hasKnowledgeCenter)).map(
+                ([category, questions]) => (
+                    <div key={category}>
+                        <h3
+                            className={
+                                compact
+                                    ? 'text-base font-semibold text-foreground mb-2'
+                                    : 'text-lg font-semibold text-foreground mb-2'
+                            }
+                        >
+                            {category}
+                        </h3>
+                        <div className="bg-card rounded-lg border border-border">
+                            <Accordion type="single" collapsible>
+                                {questions.map((faq, index) => (
+                                    <AccordionItem
+                                        key={`${category}-${index}`}
+                                        value={`${category}-${index}`}
                                     >
-                                        {faq.question}
-                                    </AccordionTrigger>
-                                    <AccordionContent className="px-4 text-muted-foreground">
-                                        <p>{faq.answer}</p>
-                                        {faq.list && (
-                                            <ul className="list-disc list-outside pl-6 mt-2 space-y-1">
-                                                {faq.list.map((item, i) => (
-                                                    <li key={i}>{item}</li>
-                                                ))}
-                                            </ul>
-                                        )}
-                                        {faq.extra && (
-                                            <p className="mt-2">{faq.extra}</p>
-                                        )}
-                                    </AccordionContent>
-                                </AccordionItem>
-                            ))}
-                        </Accordion>
+                                        <AccordionTrigger
+                                            onClick={() =>
+                                                logQuestionClick(faq.question)
+                                            }
+                                            className="px-4 text-foreground hover:no-underline hover:text-brand"
+                                        >
+                                            {faq.question}
+                                        </AccordionTrigger>
+                                        <AccordionContent className="px-4 text-muted-foreground">
+                                            <p>{faq.answer}</p>
+                                            {faq.list && (
+                                                <ul className="list-disc list-outside pl-6 mt-2 space-y-1">
+                                                    {faq.list.map((item, i) => (
+                                                        <li key={i}>{item}</li>
+                                                    ))}
+                                                </ul>
+                                            )}
+                                            {faq.extra && (
+                                                <p className="mt-2">
+                                                    {faq.extra}
+                                                </p>
+                                            )}
+                                        </AccordionContent>
+                                    </AccordionItem>
+                                ))}
+                            </Accordion>
+                        </div>
                     </div>
-                </div>
-            ))}
+                )
+            )}
         </div>
     );
 }

--- a/frontend/src/pages/FAQs.tsx
+++ b/frontend/src/pages/FAQs.tsx
@@ -19,6 +19,8 @@ export function FAQContent({ compact = false }: { compact?: boolean }) {
     const { user } = useAuth();
     const hasKnowledgeCenter =
         !!user && hasFeature(user, FeatureAccess.OpenContentAccess);
+    const hasLearningRecord =
+        !!user && hasFeature(user, FeatureAccess.LearningRecordAccess);
 
     return (
         <div className={compact ? 'space-y-4' : 'space-y-6'}>
@@ -27,55 +29,53 @@ export function FAQContent({ compact = false }: { compact?: boolean }) {
                     Frequently Asked Questions
                 </h2>
             )}
-            {Object.entries(getFaqCategories(hasKnowledgeCenter)).map(
-                ([category, questions]) => (
-                    <div key={category}>
-                        <h3
-                            className={
-                                compact
-                                    ? 'text-base font-semibold text-foreground mb-2'
-                                    : 'text-lg font-semibold text-foreground mb-2'
-                            }
-                        >
-                            {category}
-                        </h3>
-                        <div className="bg-card rounded-lg border border-border">
-                            <Accordion type="single" collapsible>
-                                {questions.map((faq, index) => (
-                                    <AccordionItem
-                                        key={`${category}-${index}`}
-                                        value={`${category}-${index}`}
+            {Object.entries(
+                getFaqCategories(hasKnowledgeCenter, hasLearningRecord)
+            ).map(([category, questions]) => (
+                <div key={category}>
+                    <h3
+                        className={
+                            compact
+                                ? 'text-base font-semibold text-foreground mb-2'
+                                : 'text-lg font-semibold text-foreground mb-2'
+                        }
+                    >
+                        {category}
+                    </h3>
+                    <div className="bg-card rounded-lg border border-border">
+                        <Accordion type="single" collapsible>
+                            {questions.map((faq, index) => (
+                                <AccordionItem
+                                    key={`${category}-${index}`}
+                                    value={`${category}-${index}`}
+                                >
+                                    <AccordionTrigger
+                                        onClick={() =>
+                                            logQuestionClick(faq.question)
+                                        }
+                                        className="px-4 text-foreground hover:no-underline hover:text-brand"
                                     >
-                                        <AccordionTrigger
-                                            onClick={() =>
-                                                logQuestionClick(faq.question)
-                                            }
-                                            className="px-4 text-foreground hover:no-underline hover:text-brand"
-                                        >
-                                            {faq.question}
-                                        </AccordionTrigger>
-                                        <AccordionContent className="px-4 text-muted-foreground">
-                                            <p>{faq.answer}</p>
-                                            {faq.list && (
-                                                <ul className="list-disc list-outside pl-6 mt-2 space-y-1">
-                                                    {faq.list.map((item, i) => (
-                                                        <li key={i}>{item}</li>
-                                                    ))}
-                                                </ul>
-                                            )}
-                                            {faq.extra && (
-                                                <p className="mt-2">
-                                                    {faq.extra}
-                                                </p>
-                                            )}
-                                        </AccordionContent>
-                                    </AccordionItem>
-                                ))}
-                            </Accordion>
-                        </div>
+                                        {faq.question}
+                                    </AccordionTrigger>
+                                    <AccordionContent className="px-4 text-muted-foreground">
+                                        <p>{faq.answer}</p>
+                                        {faq.list && (
+                                            <ul className="list-disc list-outside pl-6 mt-2 space-y-1">
+                                                {faq.list.map((item, i) => (
+                                                    <li key={i}>{item}</li>
+                                                ))}
+                                            </ul>
+                                        )}
+                                        {faq.extra && (
+                                            <p className="mt-2">{faq.extra}</p>
+                                        )}
+                                    </AccordionContent>
+                                </AccordionItem>
+                            ))}
+                        </Accordion>
                     </div>
-                )
-            )}
+                </div>
+            ))}
         </div>
     );
 }

--- a/frontend/src/pages/HelpCenter.tsx
+++ b/frontend/src/pages/HelpCenter.tsx
@@ -2,8 +2,14 @@ import { FAQContent } from './FAQs';
 import Tour from '@/components/Tour';
 import { XMarkIcon } from '@heroicons/react/24/outline';
 import { PageHeader } from '@/components/shared';
+import { useAuth, hasFeature } from '@/auth/useAuth';
+import { FeatureAccess } from '@/types';
 
 export default function HelpCenter({ close }: { close?: () => void }) {
+    const { user } = useAuth();
+    const hasKnowledgeCenter =
+        !!user && hasFeature(user, FeatureAccess.OpenContentAccess);
+
     if (close) {
         return (
             <div className="flex flex-col gap-4">
@@ -16,7 +22,7 @@ export default function HelpCenter({ close }: { close?: () => void }) {
                     </button>
                 </div>
                 <PageHeader title="Help Center" />
-                <Tour close={close} />
+                {hasKnowledgeCenter && <Tour close={close} />}
                 <FAQContent />
             </div>
         );

--- a/frontend/src/pages/student/ResidentHome.tsx
+++ b/frontend/src/pages/student/ResidentHome.tsx
@@ -453,12 +453,17 @@ export default function ResidentHome() {
     }, []);
 
     useEffect(() => {
-        if (tourState.tourActive && tourState.target === '#navigate-homepage') {
+        if (!tourState.tourActive || !user) return;
+        if (!openContentEnabled) {
+            setTourState({ tourActive: false, run: false });
+            return;
+        }
+        if (tourState.target === '#navigate-homepage') {
             setTourState({
                 stepIndex: targetToStepIndexMap['#popular-content'],
                 target: '#popular-content'
             });
-        } else if (tourState.tourActive && tourState.stepIndex !== 1) {
+        } else if (tourState.stepIndex !== 1) {
             setTourState({
                 run: true,
                 stepIndex: 0,
@@ -466,7 +471,7 @@ export default function ResidentHome() {
             });
         }
         // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, [tourState.tourActive]);
+    }, [tourState.tourActive, openContentEnabled, user]);
 
     const dismissReflectNudge = useCallback(() => {
         setReflectNudgeDismissed(true);


### PR DESCRIPTION
## Pre-Submission PR Checklist

- [x] No debug/console/fmt.Println statements
- [x] Unnecessary development comments removed
- [x] All acceptance criteria verified
- [x] Functions according to **ticket specifications**
- [x] Tested manually where applicable
- [ ] Branch rebased with latest main
- [x] No business logic exists within the database layer

## Description of the change

Residents were seeing FAQ questions and a guided tour for features their facility doesn't even have turned on. A resident on a facility with only Program tracking enabled would open the FAQ and see questions like "What is UnlockEd's Knowledge Center?" or "Where is my record saved?" (Learning Record) — features they can't access and that don't apply to them at all.

This PR makes the FAQ (and the guided tour) only show content for features the facility actually has turned on:

- **Knowledge Center off** → hides the "Overview" and "Finding and Using Content" FAQ sections, drops the Knowledge Center mention from the "What's next for UnlockEd?" answer, and removes the "Start Tour" button (the guided tour only walks through Knowledge Center screens, so it doesn't make sense without it). Also stops the tour from popping up automatically the first time a resident logs in, if Knowledge Center is off.
- **Learning Record off** → hides the two Learning Record FAQ questions ("What does 'print or share' mean?" and "Where is my record saved?"), and trims the "Is my activity on UnlockEd private?" answer so it doesn't reference Learning Record when the resident doesn't have that feature.
- Also found and fixed one more spot that was leaking Knowledge Center content: "Does UnlockEd have a way to track my progress?" reads like generic account copy, but the answer is actually describing the Knowledge Center library experience — it's now hidden when Knowledge Center is off too.

Nothing else in the FAQ needed changing — the rest (name/username, password reset, general help questions) applies to everyone regardless of which features are on.

### Where to see it

https://github.com/user-attachments/assets/e03372cb-91f2-4faa-8b93-21978db3ba17


Log in as a resident, then open **FAQ** from the left nav (or go to `/faqs`). Toggle Knowledge Center and Learning Record on/off for the resident's facility from `/feature-control` as an admin, then reload the FAQ each time to see it update. A video of this walkthrough is attached to the PR.

- **Related issues**: [Asana Task](https://app.asana.com/1/1201607307149189/project/1209460078641109/task/1216768705639775)]

## Additional context

This only touches frontend copy/visibility logic — no backend, database, or migration changes.
