### PR TITLE
fix: add asap changes per Carolinas request to fix pilot per ticket 837

### DIFF
--- a/frontend/src/pages/student/digital-transcript/AchievementFormMetadata.tsx
+++ b/frontend/src/pages/student/digital-transcript/AchievementFormMetadata.tsx
@@ -60,10 +60,17 @@ export function AchievementFormMetadata({
                     data-slot="transcript-program-name"
                     value={entry.programName}
                     onChange={(e) => onChange({ programName: e.target.value })}
-                    aria-invalid={showErrors && !programOk}
+                    aria-invalid={!isFunnel && showErrors && !programOk}
                     className="h-10 border-border/80 bg-muted/40"
                 />
-                {showErrors && !programOk ? (
+                {/*
+                  Funnel-gated for the same reason the completion date below is:
+                  no funnel question is required (ID-837), so the only thing that
+                  can set showSaveErrors there is a failed write — and a blank
+                  name is not why it failed. The funnel reports write failures
+                  through the toolbar's autosave label instead.
+                */}
+                {!isFunnel && showErrors && !programOk ? (
                     <p className="mt-2 text-sm text-destructive" role="alert">
                         {showSaveErrors
                             ? 'Please enter an achievement name to save your record.'

--- a/frontend/src/pages/student/digital-transcript/DigitalTranscriptEntryPage.tsx
+++ b/frontend/src/pages/student/digital-transcript/DigitalTranscriptEntryPage.tsx
@@ -142,14 +142,15 @@ export default function DigitalTranscriptEntryPage() {
     // completion event, but nothing else stops a double navigation.
     const finishInFlightRef = useRef(false);
 
+    // Unanswered questions no longer hold the resident here (ID-837) — only a
+    // failed write does, and the toolbar's "Failed to save" is what explains it.
     const handleFinish = useCallback(async () => {
         if (finishInFlightRef.current) return;
         finishInFlightRef.current = true;
         try {
-            const ok =
-                (await funnelFinishRef.current?.validateFinishRequirements()) ??
-                false;
-            if (ok) navigateHome();
+            const saved =
+                (await funnelFinishRef.current?.saveBeforeFinish()) ?? true;
+            if (saved) navigateHome();
         } finally {
             finishInFlightRef.current = false;
         }

--- a/frontend/src/pages/student/digital-transcript/DigitalTranscriptWysiwygEntry.tsx
+++ b/frontend/src/pages/student/digital-transcript/DigitalTranscriptWysiwygEntry.tsx
@@ -39,10 +39,7 @@ import {
 } from './AchievementsRecordPreview';
 import { AchievementRow } from './AchievementRow';
 import type { LearningRecordFormVariant } from './learningRecordPrototypes';
-import {
-    entryIsComplete,
-    firstIncompleteFunnelStep
-} from './learningRecordDocumentModel';
+import { entryIsComplete } from './learningRecordDocumentModel';
 import { CONFIDENCE_LEVEL_SOLID } from './confidenceLevelVisual';
 import { LEARNING_RECORD_BUTTON_SIZE } from './learningRecordButtons';
 import {
@@ -217,11 +214,14 @@ export interface FunnelAutoSaveState {
 
 export interface FunnelFinishHandlers {
     /**
-     * Async because finishing flushes the debounced autosave before it resolves:
-     * navigating away cancels a pending save, so a last-second edit would
-     * otherwise be lost.
+     * Flush the debounced autosave so the entry page can navigate home.
+     *
+     * Async because navigating away cancels a pending save, so a last-second
+     * edit would otherwise be lost. Resolves false only when the write itself
+     * failed — an unanswered question is not a failure, since every funnel
+     * question is optional.
      */
-    validateFinishRequirements: () => Promise<boolean>;
+    saveBeforeFinish: () => Promise<boolean>;
 }
 
 const COMMITTED_AUTOSAVE_MS = 500;
@@ -544,63 +544,66 @@ export function DigitalTranscriptWysiwygEntry({
         return attempt;
     }, [writeActiveRow]);
 
-    const validateFinishRequirements =
-        useCallback(async (): Promise<boolean> => {
-            const current = sessionRef.current;
-            const id = current?.expandedId;
-            if (!id) return false;
-            const row = current.rows.find((r) => r.id === id);
-            if (!row) return false;
+    // ID-837: Finish is not a submit gate. Every funnel question is optional, so
+    // this used to refuse to finish an entry with a blank answer and jump the
+    // resident back to the first incomplete step — with no message on eight of
+    // the nine fields, which read as "you must answer all nine". Partial rows are
+    // already autosaved and the API accepts them, so finishing a partial entry is
+    // just finishing: save what is there and let the caller navigate home.
+    const saveBeforeFinish = useCallback(async (): Promise<boolean> => {
+        const current = sessionRef.current;
+        const id = current?.expandedId;
+        // Nothing open, so nothing to flush. True, not false: the caller reads
+        // this as "safe to leave", and there is no work left to lose.
+        if (!id) return true;
+        const row = current.rows.find((r) => r.id === id);
+        if (!row) return true;
 
-            if (!entryIsComplete(row, 'funnel')) {
-                setSaveErrorRowId(id);
-                setActiveStep(firstIncompleteFunnelStep(row));
-                setActivePreviewField(null);
-                return false;
-            }
+        // Flush the debounced autosave before finishing. Finishing navigates
+        // away, which unmounts this component and cancels any pending save, so
+        // an edit made within COMMITTED_AUTOSAVE_MS of the click would never
+        // reach the server. persistActiveRow reads the live session and no-ops
+        // when the row already matches what is committed.
+        //
+        // Cancel the pending debounce first: this flush writes the same live
+        // row that timer would have written, so letting it fire afterwards is
+        // pure duplicate traffic. That is a cancellation, not the race fix — a
+        // timer that has already fired is mid-request and cannot be called
+        // back, which is what persistActiveRow's queue is for.
+        cancelPendingAutoSave();
+        nextSaveTicket();
+        reportAutoSaveStatus('saving');
+        if (!(await persistActiveRow())) {
+            setSaveErrorRowId(id);
+            reportAutoSaveStatus('error');
+            return false;
+        }
+        reportAutoSaveStatus('saved', new Date());
 
-            // Flush the debounced autosave before finishing. Finishing navigates
-            // away, which unmounts this component and cancels any pending save, so
-            // an edit made within COMMITTED_AUTOSAVE_MS of the click would never
-            // reach the server. persistActiveRow reads the live session and no-ops
-            // when the row already matches what is committed.
-            //
-            // Cancel the pending debounce first: this flush writes the same live
-            // row that timer would have written, so letting it fire afterwards is
-            // pure duplicate traffic. That is a cancellation, not the race fix — a
-            // timer that has already fired is mid-request and cannot be called
-            // back, which is what persistActiveRow's queue is for. Deliberately
-            // after the completeness check above, so an incomplete row keeps its
-            // pending autosave and partial answers still reach the server.
-            cancelPendingAutoSave();
-            nextSaveTicket();
-            reportAutoSaveStatus('saving');
-            if (!(await persistActiveRow())) {
-                setSaveErrorRowId(id);
-                reportAutoSaveStatus('error');
-                return false;
-            }
-            reportAutoSaveStatus('saved', new Date());
-
-            setSaveErrorRowId(null);
-            // Success path only, mirroring the attendance/program convention: the
-            // row is complete, saved, and the resident is finishing. The tracker
-            // refuses a second completion for the same entry and reports the
-            // accepted one to the session itself, so the sitting's count advances
-            // only when an event was actually emitted.
+        setSaveErrorRowId(null);
+        // Still gated on completeness, unlike the navigation above: an
+        // `lr_entry_completed` for a half-answered entry would overstate the
+        // funnel. A partial finish is reported instead by the unmount cleanup's
+        // `abandonedCurrentStep`, which banks the time so a later Finish on the
+        // same row can report the cumulative total. The tracker refuses a second
+        // completion for the same entry and reports the accepted one to the
+        // session itself, so the sitting's count advances only when an event was
+        // actually emitted.
+        if (entryIsComplete(row, 'funnel')) {
             analyticsRef.current?.entryCompleted(row, id);
-            return true;
-        }, [
-            persistActiveRow,
-            reportAutoSaveStatus,
-            cancelPendingAutoSave,
-            nextSaveTicket
-        ]);
+        }
+        return true;
+    }, [
+        persistActiveRow,
+        reportAutoSaveStatus,
+        cancelPendingAutoSave,
+        nextSaveTicket
+    ]);
 
     useEffect(() => {
         if (!isFunnel || !onRegisterFunnelFinish) return;
-        onRegisterFunnelFinish({ validateFinishRequirements });
-    }, [isFunnel, onRegisterFunnelFinish, validateFinishRequirements]);
+        onRegisterFunnelFinish({ saveBeforeFinish });
+    }, [isFunnel, onRegisterFunnelFinish, saveBeforeFinish]);
 
     // ID-830: mark this mount as a visit to the form. The session itself lives in
     // learningRecordSession, not here, because this component unmounts on every

--- a/frontend/src/pages/student/digital-transcript/DigitalTranscriptWysiwygEntry.tsx
+++ b/frontend/src/pages/student/digital-transcript/DigitalTranscriptWysiwygEntry.tsx
@@ -226,6 +226,14 @@ export interface FunnelFinishHandlers {
 
 const COMMITTED_AUTOSAVE_MS = 500;
 
+/**
+ * How many times Finish will re-flush a row the resident is still editing before
+ * giving up and letting the debounce handle the rest. Two would cover the realistic
+ * case (one edit landing during the first write); three leaves a pass spare without
+ * making a pathological typist expensive.
+ */
+const FINISH_FLUSH_MAX_ATTEMPTS = 3;
+
 interface DigitalTranscriptWysiwygEntryProps {
     formVariant: LearningRecordFormVariant;
     hydrated: boolean;
@@ -292,7 +300,7 @@ export function DigitalTranscriptWysiwygEntry({
     const sessionRef = useRef<TranscriptEntrySession | null>(null);
     sessionRef.current = session;
     // ID-806 question-level behavior tracking. Driven from patchRow /
-    // handleActiveStepChange / validateFinishRequirements so it does not depend
+    // handleActiveStepChange / saveBeforeFinish so it does not depend
     // on the form's markup. Counts and enums only — never answer content.
     const analyticsRef = useRef<LearningRecordTracker | null>(null);
     analyticsRef.current ??= new LearningRecordTracker();
@@ -564,23 +572,61 @@ export function DigitalTranscriptWysiwygEntry({
         // an edit made within COMMITTED_AUTOSAVE_MS of the click would never
         // reach the server. persistActiveRow reads the live session and no-ops
         // when the row already matches what is committed.
-        //
-        // Cancel the pending debounce first: this flush writes the same live
-        // row that timer would have written, so letting it fire afterwards is
-        // pure duplicate traffic. That is a cancellation, not the race fix — a
-        // timer that has already fired is mid-request and cannot be called
-        // back, which is what persistActiveRow's queue is for.
-        cancelPendingAutoSave();
-        nextSaveTicket();
         reportAutoSaveStatus('saving');
-        if (!(await persistActiveRow())) {
-            setSaveErrorRowId(id);
-            reportAutoSaveStatus('error');
-            return false;
+
+        // One flush is not enough. persistActiveRow snapshots the row when its
+        // turn in the queue comes up, so anything typed while that write is on
+        // the wire is not in the payload — writeActiveRow notices (`live !== row`)
+        // and keeps it on screen, but the only thing that would re-send it is the
+        // debounce the edit scheduled, and navigating home cancels exactly that.
+        // On a slow connection the window is wide enough to lose a whole answer.
+        //
+        // So compare the live row before and after each write and go again while
+        // it is still moving. Bounded because a resident who never stops typing
+        // must not be able to hold Finish hostage; on exhaustion the remaining
+        // edit is left to the debounce, which is the pre-existing behavior.
+        let liveRow: TranscriptEntry = row;
+        for (let attempt = 0; attempt < FINISH_FLUSH_MAX_ATTEMPTS; attempt++) {
+            // Cancel before each pass: this flush writes the same live row the
+            // pending timer would have, so letting it fire afterwards is pure
+            // duplicate traffic. That is a cancellation, not the race fix — a
+            // timer that has already fired is mid-request and cannot be called
+            // back, which is what persistActiveRow's queue is for. On a repeat
+            // pass the timer being cancelled is the one the resident's own edit
+            // just scheduled, so reclaim the label ticket from it too.
+            cancelPendingAutoSave();
+            nextSaveTicket();
+
+            const before = liveRow;
+            if (!(await persistActiveRow())) {
+                setSaveErrorRowId(id);
+                reportAutoSaveStatus('error');
+                return false;
+            }
+
+            // Yield a task before reading the session back. sessionRef is
+            // assigned during render, and both the resident's keystroke and
+            // writeActiveRow's own setSession are auto-batched by React outside
+            // an event handler — so the microtask this continuation runs on can
+            // still see the pre-edit session and conclude, wrongly, that nothing
+            // moved. One tick lets React's scheduler commit first.
+            await new Promise<void>((resolve) => window.setTimeout(resolve, 0));
+
+            const after = sessionRef.current?.rows.find((r) => r.id === id);
+            // The row went away mid-save (deleted, or the session reset). Nothing
+            // left to flush, and `before` is the last state that was written.
+            if (!after) break;
+            liveRow = after;
+            if (entryPayloadEqual(before, after)) break;
         }
         reportAutoSaveStatus('saved', new Date());
 
         setSaveErrorRowId(null);
+        // Read from `liveRow`, not the snapshot taken before the first write: an
+        // answer typed during the flush is part of the entry the resident is
+        // finishing, and judging completeness on the stale copy would report a
+        // finished entry as partial.
+        //
         // Still gated on completeness, unlike the navigation above: an
         // `lr_entry_completed` for a half-answered entry would overstate the
         // funnel. A partial finish is reported instead by the unmount cleanup's
@@ -589,8 +635,8 @@ export function DigitalTranscriptWysiwygEntry({
         // completion for the same entry and reports the accepted one to the
         // session itself, so the sitting's count advances only when an event was
         // actually emitted.
-        if (entryIsComplete(row, 'funnel')) {
-            analyticsRef.current?.entryCompleted(row, id);
+        if (entryIsComplete(liveRow, 'funnel')) {
+            analyticsRef.current?.entryCompleted(liveRow, id);
         }
         return true;
     }, [

--- a/frontend/src/pages/student/digital-transcript/learningRecordDocumentModel.ts
+++ b/frontend/src/pages/student/digital-transcript/learningRecordDocumentModel.ts
@@ -1,9 +1,7 @@
 import type { TranscriptDraft } from '@/types/digital-transcript';
 import {
     countFunnelFieldsAnswered,
-    FUNNEL_FORM_FIELD_TOTAL,
-    FUNNEL_FORM_STEP_COUNT,
-    isFunnelStepComplete
+    FUNNEL_FORM_FIELD_TOTAL
 } from './transcriptReflectionConfig';
 import type { LearningRecordFormVariant } from './learningRecordPrototypes';
 
@@ -243,16 +241,6 @@ export function entryIsComplete(
         return countFunnelFieldsAnswered(source) === FUNNEL_FORM_FIELD_TOTAL;
     }
     return countEditorFormSlots(source) === editorFormSlotsTotal();
-}
-
-/** First funnel step index with unanswered required fields, or 0 if all complete. */
-export function firstIncompleteFunnelStep(
-    source: LearningRecordDocumentSource
-): number {
-    for (let i = 0; i < FUNNEL_FORM_STEP_COUNT; i++) {
-        if (!isFunnelStepComplete(i, source)) return i;
-    }
-    return 0;
 }
 
 /**

--- a/frontend/src/pages/student/digital-transcript/transcriptReflectionConfig.ts
+++ b/frontend/src/pages/student/digital-transcript/transcriptReflectionConfig.ts
@@ -577,18 +577,6 @@ export function funnelPreviewFieldAnswered(
     }
 }
 
-/** True when every countable field in the funnel step has a non-empty answer. */
-export function isFunnelStepComplete(
-    stepIndex: number,
-    entry: TranscriptReflectionFields
-): boolean {
-    const step = FUNNEL_FORM_STEPS[stepIndex];
-    if (!step) return false;
-    return step.fields
-        .filter((field) => field !== 'completionDate')
-        .every((field) => funnelStepFieldAnswered(entry, field));
-}
-
 export function countFunnelStepFieldsAnswered(
     stepIndex: number,
     entry: TranscriptReflectionFields


### PR DESCRIPTION
## Pre-Submission PR Checklist

- [x] No debug/console/fmt.Println statements
- [x] Unnecessary development comments removed
- [x] All acceptance criteria verified
- [x] Functions according to **ticket specifications**
- [x] Tested manually where applicable
- [x] Branch rebased with latest main
- [x] No business logic exists within the database layer

## Description of the change

Per Carolina, the finish button on the Learning record should take the users to the home page rather than force them to fill out all questions.

- **Related issues**: Link to related Asana ticket that this closes: [Pressing Finish on Learning Record not doing what is expected](https://app.asana.com/1/1201607307149189/project/1209460078641109/task/1217836727459059)