### PR TITLE
Create Temp Password when a User is created

### DIFF
--- a/backend/src/handlers/ory.go
+++ b/backend/src/handlers/ory.go
@@ -109,6 +109,14 @@ func (srv *Server) HandleCreateUserKratos(username, password string) error {
 		return errors.New("error creating identity")
 	}
 	user.KratosID = created.GetId()
+	// persist the ID before setting the password: if anything below fails, the
+	// stored ID lets a password reset repair the identity instead of trying to
+	// create a second one with the same (unique) username identifier
+	err = srv.Db.UpdateUser(user)
+	if err != nil {
+		log.Error("Error updating user")
+		return err
+	}
 	claims := &Claims{
 		UserID:        user.ID,
 		KratosID:      user.KratosID,
@@ -118,11 +126,6 @@ func (srv *Server) HandleCreateUserKratos(username, password string) error {
 	err = srv.handleUpdatePasswordKratos(claims, password, true)
 	if err != nil {
 		log.Error("Error updating password for new kratos user")
-		return err
-	}
-	err = srv.Db.UpdateUser(user)
-	if err != nil {
-		log.Error("Error updating user")
 		return err
 	}
 	log.Infof("user created successfully + identity registered with kratos: %v", user)

--- a/backend/src/handlers/user_handler.go
+++ b/backend/src/handlers/user_handler.go
@@ -241,11 +241,13 @@ func (srv *Server) handleCreateUser(w http.ResponseWriter, r *http.Request, log 
 		return newInternalServerServiceError(err, "Error creating temporary password")
 	}
 	response := struct {
-		TempPassword string      `json:"temp_password"`
-		User         models.User `json:"user"`
+		TempPassword     string      `json:"temp_password"`
+		User             models.User `json:"user"`
+		KratosRegistered bool        `json:"kratos_registered"`
 	}{
-		User:         reqForm.User,
-		TempPassword: tempPw,
+		User:             reqForm.User,
+		TempPassword:     tempPw,
+		KratosRegistered: true,
 	}
 	if reqForm.User.Role == models.Student {
 		accountCreation := models.NewUserAccountHistory(reqForm.User.ID, models.AccountCreation, &claims.UserID, nil, nil)
@@ -261,6 +263,7 @@ func (srv *Server) handleCreateUser(w http.ResponseWriter, r *http.Request, log 
 		// register the user as an Identity with Kratos + Kolibri
 		if err := srv.HandleCreateUserKratos(reqForm.User.Username, tempPw); err != nil {
 			log.infof("Error creating user in kratos: %v", err)
+			response.KratosRegistered = false
 		}
 		kolibri, err := srv.Db.FindKolibriInstance()
 		if err != nil {

--- a/frontend/src/components/residents/AddResidentDialog.tsx
+++ b/frontend/src/components/residents/AddResidentDialog.tsx
@@ -58,6 +58,7 @@ export function AddResidentDialog({
     const [showPasswordModal, setShowPasswordModal] = useState(false);
     const [tempPassword, setTempPassword] = useState('');
     const [createdUserName, setCreatedUserName] = useState('');
+    const [kratosRegistered, setKratosRegistered] = useState(true);
 
     useEffect(() => {
         if (open) {
@@ -101,6 +102,7 @@ export function AddResidentDialog({
                     `${formData.name_first} ${formData.name_last}`
                 );
                 setTempPassword(response.data.temp_password);
+                setKratosRegistered(response.data.kratos_registered);
                 setShowPasswordModal(true);
                 onSuccess(response.data.user);
             } else {
@@ -255,12 +257,18 @@ export function AddResidentDialog({
                     if (!isOpen) {
                         setTempPassword('');
                         setCreatedUserName('');
+                        setKratosRegistered(true);
                     }
                 }}
                 name={createdUserName}
                 subject="resident"
                 presetPassword={tempPassword}
                 resultTitle="New Password"
+                warning={
+                    kratosRegistered
+                        ? undefined
+                        : "This resident's login could not be registered. Use Reset Password before sharing this with the resident."
+                }
             />
         </>
     );

--- a/frontend/src/components/residents/AddResidentDialog.tsx
+++ b/frontend/src/components/residents/AddResidentDialog.tsx
@@ -23,7 +23,7 @@ import {
     SelectTrigger,
     SelectValue
 } from '@/components/ui/select';
-import { FormModal } from '@/components/shared';
+import { FormModal, ResetPasswordModal } from '@/components/shared';
 
 interface AddResidentDialogProps {
     open: boolean;
@@ -55,6 +55,9 @@ export function AddResidentDialog({
         }
     });
     const [submitting, setSubmitting] = useState(false);
+    const [showPasswordModal, setShowPasswordModal] = useState(false);
+    const [tempPassword, setTempPassword] = useState('');
+    const [createdUserName, setCreatedUserName] = useState('');
 
     useEffect(() => {
         if (open) {
@@ -94,6 +97,11 @@ export function AddResidentDialog({
                     `Resident ${formData.name_first} ${formData.name_last} added successfully`
                 );
                 form.reset();
+                setCreatedUserName(
+                    `${formData.name_first} ${formData.name_last}`
+                );
+                setTempPassword(response.data.temp_password);
+                setShowPasswordModal(true);
                 onSuccess(response.data.user);
             } else {
                 toast.error(response.message ?? 'Failed to create resident');
@@ -104,138 +112,156 @@ export function AddResidentDialog({
     };
 
     return (
-        <FormModal
-            open={open}
-            onOpenChange={onOpenChange}
-            title="Add New Resident"
-            description="Create a new resident profile in the system"
-            titleClassName="text-foreground"
-        >
-            <Form {...form}>
-                <form
-                    onSubmit={(e) => {
-                        e.preventDefault();
-                        void form.handleSubmit((d) => void handleAddUser(d))(e);
-                    }}
-                >
-                    <div className="space-y-4 py-4">
-                        <div className="grid grid-cols-2 gap-4">
-                            <FormField
-                                control={form.control}
-                                name="name_first"
-                                render={({ field }) => (
-                                    <FormItem>
-                                        <FormLabel>First Name</FormLabel>
-                                        <FormControl>
-                                            <Input
-                                                placeholder="First name"
-                                                {...field}
-                                            />
-                                        </FormControl>
-                                        <FormMessage />
-                                    </FormItem>
-                                )}
-                            />
-                            <FormField
-                                control={form.control}
-                                name="name_last"
-                                render={({ field }) => (
-                                    <FormItem>
-                                        <FormLabel>Last Name</FormLabel>
-                                        <FormControl>
-                                            <Input
-                                                placeholder="Last name"
-                                                {...field}
-                                            />
-                                        </FormControl>
-                                        <FormMessage />
-                                    </FormItem>
-                                )}
-                            />
-                        </div>
-                        <FormField
-                            control={form.control}
-                            name="username"
-                            render={({ field }) => (
-                                <FormItem>
-                                    <FormLabel>Username</FormLabel>
-                                    <FormControl>
-                                        <Input
-                                            placeholder="Enter username for login"
-                                            {...field}
-                                        />
-                                    </FormControl>
-                                    <FormMessage />
-                                </FormItem>
-                            )}
-                        />
-                        <FormField
-                            control={form.control}
-                            name="doc_id"
-                            render={({ field }) => (
-                                <FormItem>
-                                    <FormLabel>Resident ID</FormLabel>
-                                    <FormControl>
-                                        <Input
-                                            placeholder="e.g., R001"
-                                            {...field}
-                                        />
-                                    </FormControl>
-                                    <FormMessage />
-                                </FormItem>
-                            )}
-                        />
-                        {showFacilityColumn && (
-                            <FormField
-                                control={form.control}
-                                name="facility_id"
-                                render={({ field }) => (
-                                    <FormItem>
-                                        <FormLabel>Facility</FormLabel>
-                                        <Select
-                                            value={field.value}
-                                            onValueChange={field.onChange}
-                                        >
+        <>
+            <FormModal
+                open={open}
+                onOpenChange={onOpenChange}
+                title="Add New Resident"
+                description="Create a new resident profile in the system"
+                titleClassName="text-foreground"
+            >
+                <Form {...form}>
+                    <form
+                        onSubmit={(e) => {
+                            e.preventDefault();
+                            void form.handleSubmit(
+                                (d) => void handleAddUser(d)
+                            )(e);
+                        }}
+                    >
+                        <div className="space-y-4 py-4">
+                            <div className="grid grid-cols-2 gap-4">
+                                <FormField
+                                    control={form.control}
+                                    name="name_first"
+                                    render={({ field }) => (
+                                        <FormItem>
+                                            <FormLabel>First Name</FormLabel>
                                             <FormControl>
-                                                <SelectTrigger>
-                                                    <SelectValue placeholder="Select facility" />
-                                                </SelectTrigger>
+                                                <Input
+                                                    placeholder="First name"
+                                                    {...field}
+                                                />
                                             </FormControl>
-                                            <SelectContent>
-                                                {facilities.map((f) => (
-                                                    <SelectItem
-                                                        key={f.id}
-                                                        value={String(f.id)}
-                                                    >
-                                                        {f.name}
-                                                    </SelectItem>
-                                                ))}
-                                            </SelectContent>
-                                        </Select>
+                                            <FormMessage />
+                                        </FormItem>
+                                    )}
+                                />
+                                <FormField
+                                    control={form.control}
+                                    name="name_last"
+                                    render={({ field }) => (
+                                        <FormItem>
+                                            <FormLabel>Last Name</FormLabel>
+                                            <FormControl>
+                                                <Input
+                                                    placeholder="Last name"
+                                                    {...field}
+                                                />
+                                            </FormControl>
+                                            <FormMessage />
+                                        </FormItem>
+                                    )}
+                                />
+                            </div>
+                            <FormField
+                                control={form.control}
+                                name="username"
+                                render={({ field }) => (
+                                    <FormItem>
+                                        <FormLabel>Username</FormLabel>
+                                        <FormControl>
+                                            <Input
+                                                placeholder="Enter username for login"
+                                                {...field}
+                                            />
+                                        </FormControl>
                                         <FormMessage />
                                     </FormItem>
                                 )}
                             />
-                        )}
-                    </div>
-                    <DialogFooter className="pt-4">
-                        <Button
-                            variant="outline"
-                            type="button"
-                            onClick={() => onOpenChange(false)}
-                        >
-                            Cancel
-                        </Button>
-                        <Button
-                            type="submit"
-                            disabled={submitting}
-                            variant="brand"
-                        >
-                            {submitting ? 'Adding...' : 'Add Resident'}
-                        </Button>
-                    </DialogFooter>
-                </form>
-            </Form>
-        </FormModal>
+                            <FormField
+                                control={form.control}
+                                name="doc_id"
+                                render={({ field }) => (
+                                    <FormItem>
+                                        <FormLabel>Resident ID</FormLabel>
+                                        <FormControl>
+                                            <Input
+                                                placeholder="e.g., R001"
+                                                {...field}
+                                            />
+                                        </FormControl>
+                                        <FormMessage />
+                                    </FormItem>
+                                )}
+                            />
+                            {showFacilityColumn && (
+                                <FormField
+                                    control={form.control}
+                                    name="facility_id"
+                                    render={({ field }) => (
+                                        <FormItem>
+                                            <FormLabel>Facility</FormLabel>
+                                            <Select
+                                                value={field.value}
+                                                onValueChange={field.onChange}
+                                            >
+                                                <FormControl>
+                                                    <SelectTrigger>
+                                                        <SelectValue placeholder="Select facility" />
+                                                    </SelectTrigger>
+                                                </FormControl>
+                                                <SelectContent>
+                                                    {facilities.map((f) => (
+                                                        <SelectItem
+                                                            key={f.id}
+                                                            value={String(f.id)}
+                                                        >
+                                                            {f.name}
+                                                        </SelectItem>
+                                                    ))}
+                                                </SelectContent>
+                                            </Select>
+                                            <FormMessage />
+                                        </FormItem>
+                                    )}
+                                />
+                            )}
+                        </div>
+                        <DialogFooter className="pt-4">
+                            <Button
+                                variant="outline"
+                                type="button"
+                                onClick={() => onOpenChange(false)}
+                            >
+                                Cancel
+                            </Button>
+                            <Button
+                                type="submit"
+                                disabled={submitting}
+                                variant="brand"
+                            >
+                                {submitting ? 'Adding...' : 'Add Resident'}
+                            </Button>
+                        </DialogFooter>
+                    </form>
+                </Form>
+            </FormModal>
+            <ResetPasswordModal
+                open={showPasswordModal}
+                onOpenChange={(isOpen) => {
+                    setShowPasswordModal(isOpen);
+                    if (!isOpen) {
+                        setTempPassword('');
+                        setCreatedUserName('');
+                    }
+                }}
+                name={createdUserName}
+                subject="resident"
+                presetPassword={tempPassword}
+                resultTitle="New Password"
+            />
+        </>
     );
 }

--- a/frontend/src/components/shared/ResetPasswordModal.tsx
+++ b/frontend/src/components/shared/ResetPasswordModal.tsx
@@ -203,11 +203,19 @@ export function ResetPasswordModal({
                                 </Button>
                             </div>
                         </div>
-                        <p className="text-sm text-gray-600 mt-4">
-                            Share this password securely with the {subject}.
-                            They will be prompted to change it on their next
-                            login.
-                        </p>
+                        {warning ? (
+                            <p className="text-sm text-gray-600 mt-4">
+                                Do not share this password yet. Reset the{' '}
+                                {subject}&apos;s password first, then share the
+                                password that reset gives you.
+                            </p>
+                        ) : (
+                            <p className="text-sm text-gray-600 mt-4">
+                                Share this password securely with the {subject}.
+                                They will be prompted to change it on their next
+                                login.
+                            </p>
+                        )}
                     </div>
                     <DialogFooter>
                         <Button

--- a/frontend/src/components/shared/ResetPasswordModal.tsx
+++ b/frontend/src/components/shared/ResetPasswordModal.tsx
@@ -6,6 +6,8 @@ import { ResetPasswordResponse, ServerResponseOne } from '@/types';
 import { DialogFooter } from '@/components/ui/dialog';
 import { Button } from '@/components/ui/button';
 import { FormModal } from './FormModal';
+import { TonedPanel } from './TonedPanel';
+import { AlertTriangle } from 'lucide-react';
 
 type Phase = 'confirm' | 'result';
 
@@ -35,6 +37,12 @@ interface ResetPasswordModalProps {
     presetPassword?: string;
     /** Title for the result phase. Defaults to 'Password Reset'. */
     resultTitle?: string;
+    /**
+     * Optional warning shown alongside the password in the result phase (e.g.
+     * when the identity provider registration failed and this password may
+     * not work until the account is reset).
+     */
+    warning?: string;
     /** Optional callback fired after a reset successfully completes. */
     onResetComplete?: () => void;
 }
@@ -47,6 +55,7 @@ export function ResetPasswordModal({
     userId,
     presetPassword,
     resultTitle = 'Password Reset',
+    warning,
     onResetComplete
 }: ResetPasswordModalProps) {
     const resultOnly = presetPassword !== undefined;
@@ -159,6 +168,14 @@ export function ResetPasswordModal({
             ) : (
                 <>
                     <div className="py-4">
+                        {warning && (
+                            <TonedPanel tone="amber" className="mb-4">
+                                <div className="flex items-start gap-2 text-sm text-amber-900">
+                                    <AlertTriangle className="size-4 mt-0.5 shrink-0" />
+                                    <span>{warning}</span>
+                                </div>
+                            </TonedPanel>
+                        )}
                         <div className="bg-gray-100 rounded-lg p-4 border border-gray-300">
                             <div className="text-sm text-gray-600 mb-2">
                                 Temporary Password

--- a/frontend/src/pages/admin/AdminManagement.tsx
+++ b/frontend/src/pages/admin/AdminManagement.tsx
@@ -172,6 +172,7 @@ export default function AdminManagement() {
     const [showResetPassword, setShowResetPassword] = useState(false);
     const [selectedAdmin, setSelectedAdmin] = useState<User | null>(null);
     const [tempPassword, setTempPassword] = useState('');
+    const [kratosRegistered, setKratosRegistered] = useState(true);
     const [passwordModalContext, setPasswordModalContext] = useState<
         'create' | 'reset'
     >('reset');
@@ -364,6 +365,7 @@ export default function AdminManagement() {
             );
             setShowAddAdmin(false);
             setTempPassword(response.data.temp_password);
+            setKratosRegistered(response.data.kratos_registered);
             setPasswordModalContext('create');
             setShowResetPassword(true);
             setSelectedAdmin(response.data.user);
@@ -1087,6 +1089,7 @@ export default function AdminManagement() {
                     if (!open) {
                         setTempPassword('');
                         setSelectedAdmin(null);
+                        setKratosRegistered(true);
                     }
                 }}
                 name={`${selectedAdmin?.name_first ?? ''} ${selectedAdmin?.name_last ?? ''}`}
@@ -1103,6 +1106,11 @@ export default function AdminManagement() {
                     passwordModalContext === 'create'
                         ? 'New Password'
                         : 'Password Reset'
+                }
+                warning={
+                    passwordModalContext === 'create' && !kratosRegistered
+                        ? "This administrator's login could not be registered. Use Reset Password before sharing this with them."
+                        : undefined
                 }
             />
 

--- a/frontend/src/types/user.ts
+++ b/frontend/src/types/user.ts
@@ -70,6 +70,7 @@ export interface LoginMetrics {
 export interface NewUserResponse {
     user: User;
     temp_password: string;
+    kratos_registered: boolean;
 }
 
 export interface ResetPasswordResponse {


### PR DESCRIPTION
## Pre-Submission PR Checklist

- [x] No debug/console/fmt.Println statements
- [x] Unnecessary development comments removed
- [x] All acceptance criteria verified
- [x] Functions according to **ticket specifications**
- [x] Tested manually where applicable
- [x] Branch rebased with latest main
- [x] No business logic exists within the database layer

_Rebased onto `main` @ `689d0359` (2026-09-09) — clean, no conflicts (verified via
`git merge-tree` before rebasing; main's new commits don't touch either file this PR changes).
Re-verified after rebase: `yarn build` and `eslint` on the changed files both pass, `server`/
`frontend` containers restart clean on the rebased code (migrations already at version 75, nothing
pending), and the temp-password flow was re-tested live end-to-end with 0 console errors._

## Description of the change

Fixes Asana ID-829: resident creation already generated a temp password on the backend, but the
admin never saw it — `AddResidentDialog.tsx` read `response.data.user` from the create response
and silently discarded `response.data.temp_password`.

**Root cause:** `handleCreateUser` (`backend/src/handlers/user_handler.go`) already calls
`CreateTempPassword()` and returns it in `NewUserResponse` for every single resident creation —
this part was never broken. `AdminManagement.tsx` already does the right thing with that same
response shape for admin creation (opens `ResetPasswordModal` in its `presetPassword` /
result-only mode). `AddResidentDialog.tsx` just never wired that up for residents.

**Fix:** `AddResidentDialog.tsx` now tracks the returned `temp_password` and the created
resident's name in local state, and renders a second `ResetPasswordModal` (result-only mode)
immediately after a successful create — same pattern as `AdminManagement.tsx`. No backend
changes; no changes to either of `AddResidentDialog`'s two callers (`StudentManagement.tsx`,
`ProviderUserManagement.tsx`) — both already pass an `onSuccess` that only consumes the created
`User`, so the fix is fully self-contained in the shared dialog.

- **Related issues**: [Closes Asana ID-829](https://app.asana.com/1/1201607307149189/project/1209460078641109/task/1217564912951074).

## Screenshot(s)

https://github.com/user-attachments/assets/755a17b8-9c62-424d-958f-02e390167ef4

## Additional context

A gap was found during the review — `handleCreateUser` only logging (not surfacing) a
Kratos identity-registration failure, so the newly-visible `temp_password` could be handed out
non-functional — was fixed in this PR (separate commit `5bdccf5f`), rather than left out of
scope, since the ID-829 fix is exactly what made that silent failure consequential: `handleCreateUser`
now returns `kratos_registered` in the response, and both `AddResidentDialog` and `AdminManagement`
show a warning ("...could not be registered. Use Reset Password before sharing this...") instead of
asserting success unconditionally. Verified live against a real Kratos 409 conflict (an orphaned
Kratos identity with no matching DB row) in addition to the golden path — both call sites behave
correctly.

### Review feedback addressed

Two CodeRabbit comments, both applied:

- **Kratos identity orphaning.** `HandleCreateUserKratos` (`backend/src/handlers/ory.go`) persisted
  `KratosID` only *after* the password update succeeded, so a failure in between left the DB with an
  empty `kratos_id` while the identity existed in Kratos. Both reset paths key on `KratosID == ""`
  (`user_handler.go:379`, `:1018`) and would call `CreateIdentity` again — which 409s, since
  `username` is the password credential identifier in `config/kratos/identity.schema.json`. That made
  this PR's own warning copy ("Use Reset Password before sharing this") point admins at an action that
  could not succeed. `srv.Db.UpdateUser(user)` now runs immediately after the ID is assigned, so a
  mid-flight failure leaves a repairable account instead of a stuck one. Side benefit: the delete-user
  handler (`user_handler.go:297`) now reaps the Kratos identity for half-created users instead of
  orphaning the username.
- **Contradictory password-sharing copy.** `ResetPasswordModal.tsx` showed the warning panel and then
  unconditionally rendered "Share this password securely... they will be prompted to change it on
  their next login" — telling the admin both to share and not share it, and describing a next login
  that cannot happen when no identity exists. The trailing paragraph is now gated on `warning`; the
  non-warning path is byte-identical to before.

CodeRabbit's second suggestion on the first item — adopting pre-existing orphaned identities during
recovery — is deliberately **not** included here; see Follow-up below.

## Follow-up (out of scope for this PR)

**Repairing Kratos identities orphaned before this fix.** The ordering change above prevents *new*
orphans but does not adopt existing ones: a user whose `kratos_id` is already empty while a matching
Kratos identity exists still hits the `CreateIdentity` path on reset and 409s, with no way to recover
through the UI.

**This cannot be a migration.** All 75 files in `backend/migrations/` are plain `.sql` run through
goose; the correct `kratos_id` is a UUID that lives only inside Kratos and was never written to
Postgres, so there is no value a SQL statement could compute. (`migrations/main.go` does hold a Kratos
client, but only for `syncOryKratos()` on the `--fresh` path, which *deletes every identity* — a dev
reset, not a repair.)

The repair is a reconciliation: list identities, match on the `username` trait, backfill `kratos_id`.
That is the loop `checkForAdminInKratos` (`server.go:318-343`) already runs for SuperAdmin, and
matching on username is sound because the column is `unique` in Postgres (`models/users.go:59`) and is
the credential identifier in Kratos. Natural home is a system-admin endpoint alongside the existing
`DELETE /api/identities/sync` route (`ory.go:16-17`), rather than a startup hook that adds a Kratos
round-trip to every boot.

Whether it is worth building depends on whether any exist:

```sql
SELECT count(*) FROM users
WHERE (kratos_id IS NULL OR kratos_id = '') AND deleted_at IS NULL;
```

(`kratos_id` is nullable `varchar(255)` — `00002_create_init_tables.sql:33` — and code writes `''`,
hence both checks.) This **over-counts**: it includes users who never reached `CreateIdentity` at all,
who are not orphans. True orphans are the subset that also has a matching Kratos identity, so a
non-zero result means "worth a closer look," not a repair count.

One further source of orphans is *not* closed by this PR: `provider_user_management.go:151-158`
soft-deletes the user when Kratos creation fails but never deletes the identity, so a failed provider
import can strand an identity holding a username the DB no longer shows as taken. Any repair tool
should handle that case rather than assume this PR removed the last source.
