### PR TITLE
Repair the first-login tour and make client crashes diagnosable (ID-846)

### DIFF
--- a/backend/src/handlers/auth.go
+++ b/backend/src/handlers/auth.go
@@ -139,6 +139,13 @@ func (s *Server) authMiddleware(next http.Handler, resolver RouteResolver) http.
 		// Call to named or custom resolver by routedef
 		if resolver != nil {
 			if !resolver(s.Db, r.WithContext(ctx)) {
+				log.WithFields(log.Fields{
+					"handler":     "authMiddleware",
+					"method":      r.Method,
+					"path":        r.URL.Path,
+					"user_id":     claims.UserID,
+					"facility_id": claims.FacilityID,
+				}).Warn("route resolver denied access to resource")
 				http.Error(w, "User is not allowed to view this resource", http.StatusUnauthorized)
 				return
 			}

--- a/backend/src/handlers/auth.go
+++ b/backend/src/handlers/auth.go
@@ -132,6 +132,28 @@ func (s *Server) authMiddleware(next http.Handler, resolver RouteResolver) http.
 		}
 
 		if claims.PasswordReset && !isAuthRoute(r) {
+			// Logged because this gate was completely silent, and it is not a
+			// benign one. Every endpoint the reset page itself calls is exempt
+			// via isAuthRoute, so reaching here means something else asked for a
+			// route it cannot have yet -- including /api/client-errors, which is
+			// not exempt: a crash reported by a resident who still carries
+			// password_reset never reaches the log, because the reporter gets
+			// this response instead of the handler (client_error_handler.go).
+			//
+			// Note the status: http.Redirect with StatusOK sends 200 plus a
+			// Location header, which no XHR treats as a redirect, so every API
+			// call made while this flag is set reads as a successful request with
+			// an HTML body. Fixing that is a separate change -- it needs the
+			// client to distinguish document navigations from API calls -- but at
+			// least the occurrence is now visible.
+			log.WithFields(log.Fields{
+				"handler":     "authMiddleware",
+				"method":      r.Method,
+				"path":        r.URL.Path,
+				"user_id":     claims.UserID,
+				"facility_id": claims.FacilityID,
+				"role":        claims.Role,
+			}).Warn("password reset required, request redirected to /reset-password")
 			http.Redirect(w, r.WithContext(ctx), "/reset-password", http.StatusOK)
 			return
 		}

--- a/backend/src/handlers/client_error_handler.go
+++ b/backend/src/handlers/client_error_handler.go
@@ -1,0 +1,88 @@
+package handlers
+
+import (
+	"encoding/json"
+	"net/http"
+	"strings"
+)
+
+/*
+Client-side crash reporting.
+
+The SPA's only error boundary is react-router's `errorElement`, which renders
+`pages/Error.tsx` — a page that used to discard the exception entirely. A resident
+therefore saw "Something went wrong" while the deployment logs stayed completely
+silent, which is what made ID-846 impossible to diagnose from Maine's logs. This
+endpoint gives the browser somewhere to say what actually threw.
+
+Two known blind spots, both acceptable: the report needs a valid session and a CSRF
+cookie, so a crash caused by a broken session reports nothing; and a resident still
+carrying `password_reset` gets the HTML redirect from `authMiddleware` instead of a
+log line (see auth.go's password-reset gate).
+*/
+
+// Field caps. A stack is the only field worth real bytes; everything else is short
+// by nature, and all of it arrives from the browser, so none of it is trusted.
+const (
+	clientErrorStackMax = 2048
+	clientErrorFieldMax = 512
+)
+
+type ClientErrorReport struct {
+	Name      string `json:"name"`
+	Message   string `json:"message"`
+	Stack     string `json:"stack"`
+	Route     string `json:"route"`
+	Source    string `json:"source"`
+	UserAgent string `json:"user_agent"`
+}
+
+// Caps length and strips newlines so one report cannot spread across log lines or
+// flood the log with a runaway stack.
+func truncateForLog(value string, max int) string {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return ""
+	}
+	if len(value) > max {
+		value = value[:max] + "…(truncated)"
+	}
+	return strings.ReplaceAll(value, "\n", " | ")
+}
+
+func (srv *Server) registerClientErrorRoutes() []routeDef {
+	return []routeDef{
+		// Deliberately not a featureRoute: a crash must be reportable with every
+		// feature turned off.
+		newRoute("POST /api/client-errors", srv.handleReportClientError),
+	}
+}
+
+func (srv *Server) handleReportClientError(w http.ResponseWriter, r *http.Request, log sLog) error {
+	report := ClientErrorReport{}
+	defer func() {
+		if r.Body.Close() != nil {
+			log.warn("error closing client error report body")
+		}
+	}()
+	if err := json.NewDecoder(http.MaxBytesReader(w, r.Body, 16*1024)).Decode(&report); err != nil {
+		return newJSONReqBodyServiceError(err)
+	}
+	if claims, ok := r.Context().Value(ClaimsKey).(*Claims); ok {
+		// handleError only attaches these for admins on writes, so a resident's
+		// report would otherwise carry no identity at all.
+		log.add("user_id", claims.UserID)
+		log.add("facility_id", claims.FacilityID)
+		log.add("role", claims.Role)
+	}
+	log.add("client_error", true)
+	log.add("error_name", truncateForLog(report.Name, clientErrorFieldMax))
+	log.add("error_message", truncateForLog(report.Message, clientErrorFieldMax))
+	log.add("client_route", truncateForLog(report.Route, clientErrorFieldMax))
+	log.add("client_source", truncateForLog(report.Source, clientErrorFieldMax))
+	log.add("user_agent", truncateForLog(report.UserAgent, clientErrorFieldMax))
+	log.add("stack", truncateForLog(report.Stack, clientErrorStackMax))
+	log.error("client-side error reported by browser")
+	w.WriteHeader(http.StatusNoContent)
+	return nil
+}

--- a/backend/src/handlers/login_flow.go
+++ b/backend/src/handlers/login_flow.go
@@ -41,6 +41,43 @@ type LoginRequest struct {
 	CsrfToken string `json:"csrf_token"`
 }
 
+/*
+MarshalJSON keeps the password and CSRF token out of anything that serializes
+this struct, which in practice means the logs.
+
+handleLogin logs the whole form (see below), so every login attempt wrote the
+submitted password to the deployment log in cleartext -- twice on a failure,
+since both the "Failed login attempt" line and the error line carry the same
+fields. Maine's logs contain months of real resident and admin passwords as a
+result.
+
+Redacting at the type level rather than at the call site is deliberate: it
+cannot be undone by someone later logging the form again. The Kratos request
+body is built field-by-field in buildKratosLoginForm and never marshals this
+struct, so authentication is unaffected.
+*/
+func (form LoginRequest) MarshalJSON() ([]byte, error) {
+	type redacted struct {
+		Username  string `json:"identifier"`
+		Password  string `json:"password"`
+		FlowID    string `json:"flow_id"`
+		Challenge string `json:"challenge"`
+		CsrfToken string `json:"csrf_token"`
+	}
+	safe := redacted{
+		Username:  form.Username,
+		FlowID:    form.FlowID,
+		Challenge: form.Challenge,
+	}
+	if form.Password != "" {
+		safe.Password = "[REDACTED]"
+	}
+	if form.CsrfToken != "" {
+		safe.CsrfToken = "[REDACTED]"
+	}
+	return json.Marshal(safe)
+}
+
 func (s *Server) handleLogout(w http.ResponseWriter, r *http.Request, log sLog) error {
 	return writeJsonResponse(w, http.StatusOK, map[string]string{"redirect_to": LogoutEndpoint})
 }
@@ -71,6 +108,8 @@ func (s *Server) handleLogin(w http.ResponseWriter, r *http.Request, log sLog) e
 		s.errorResponse(w, int(http.StatusTooManyRequests), msg)
 		return nil
 	}
+	// Safe to log whole: LoginRequest.MarshalJSON redacts the password and CSRF
+	// token. Keep it that way -- these lines go to the deployment logs.
 	log.add("form", form)
 	// create json body to send to kratos for processing login
 	jsonBody, err := buildKratosLoginForm(form)

--- a/backend/src/handlers/middleware.go
+++ b/backend/src/handlers/middleware.go
@@ -188,6 +188,17 @@ func (srv *Server) checkFeatureAccessMiddleware(next http.Handler, accessLevel .
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		claims, ok := r.Context().Value(ClaimsKey).(*Claims)
 		if !ok || !claims.hasFeatureAccess(accessLevel...) {
+			// Logged because this 401 was previously invisible: a feature-gated
+			// route rejected a resident with no trace anywhere but a prometheus
+			// counter, which is exactly the "not enough information in the logs"
+			// ID-846 ran into.
+			fields := log.Fields{"handler": "checkFeatureAccessMiddleware", "method": r.Method, "path": r.URL.Path, "required_features": accessLevel}
+			if ok {
+				fields["user_id"] = claims.UserID
+				fields["facility_id"] = claims.FacilityID
+				fields["feature_access"] = claims.FeatureAccess
+			}
+			log.WithFields(fields).Warn("feature not enabled for user")
 			srv.errorResponse(w, http.StatusUnauthorized, "Feature not enabled")
 			return
 		}

--- a/backend/src/handlers/server.go
+++ b/backend/src/handlers/server.go
@@ -114,6 +114,7 @@ func (srv *Server) RegisterRoutes() {
 		srv.registerTagRoutes,
 		srv.registerReportsRoutes,
 		srv.registerLearningRecordRoutes,
+		srv.registerClientErrorRoutes,
 	} {
 		srv.register(route)
 	}

--- a/frontend/src/api/reportClientError.ts
+++ b/frontend/src/api/reportClientError.ts
@@ -24,9 +24,21 @@ interface ClientErrorReport {
     user_agent: string;
 }
 
-/** The server caps again; this only keeps the request small. */
+/**
+ * These only keep the request small — the server caps again, at
+ * clientErrorStackMax (2048) and clientErrorFieldMax (512) in
+ * client_error_handler.go.
+ *
+ * Both MUST stay above their server counterpart, so the server is the single
+ * place that truncates and the only place that marks it. When FIELD_MAX was 500
+ * — below the server's 512 — `clamp` silently cut a long message here with no
+ * marker and the server's `…(truncated)` never fired, so a truncated message was
+ * indistinguishable from a complete one in the log. Marking in both places
+ * instead would double-mark, which is why the caps are ordered rather than the
+ * marker duplicated.
+ */
 const STACK_MAX = 4000;
-const FIELD_MAX = 500;
+const FIELD_MAX = 1024;
 
 /**
  * One report per distinct error per page session. Without this a boundary that

--- a/frontend/src/api/reportClientError.ts
+++ b/frontend/src/api/reportClientError.ts
@@ -1,0 +1,140 @@
+import API from '@/api/api';
+
+/**
+ * Client-side crash reporting.
+ *
+ * The app's only error boundary is react-router's `errorElement`, and the page it
+ * renders (`pages/Error.tsx`) used to discard the exception — so a resident saw
+ * "Something went wrong" while the deployment logs stayed silent. That is what made
+ * ID-846 undiagnosable from the Maine logs. Everything here exists to get the
+ * exception into `POST /api/client-errors`, which logs it server-side with the
+ * resident's user_id and facility_id attached.
+ *
+ * PRIVACY: only the error's own name/message/stack, the route path, and the user
+ * agent are sent. Never form content, and never the query string — `?edit=<id>` and
+ * friends are stripped by `routeOf()`.
+ */
+
+interface ClientErrorReport {
+    name: string;
+    message: string;
+    stack: string;
+    route: string;
+    source: string;
+    user_agent: string;
+}
+
+/** The server caps again; this only keeps the request small. */
+const STACK_MAX = 4000;
+const FIELD_MAX = 500;
+
+/**
+ * One report per distinct error per page session. Without this a boundary that
+ * re-renders, or an error thrown in a loop, would hammer the endpoint — and the
+ * global handlers below can see the same throw twice.
+ */
+const alreadyReported = new Set<string>();
+
+function clamp(value: string, max: number): string {
+    return value.length > max ? value.slice(0, max) : value;
+}
+
+/** Pull name/message/stack off anything that can be thrown, including non-Errors. */
+export function describeError(error: unknown): {
+    name: string;
+    message: string;
+    stack: string;
+} {
+    if (error instanceof Error) {
+        return {
+            name: error.name,
+            message: error.message,
+            stack: error.stack ?? ''
+        };
+    }
+    // A router `throw new Response(...)` or a thrown string/object.
+    if (error instanceof Response) {
+        return {
+            name: 'Response',
+            message: `${error.status} ${error.statusText}`,
+            stack: ''
+        };
+    }
+    if (typeof error === 'string') {
+        return { name: 'thrown string', message: error, stack: '' };
+    }
+    let message: string;
+    try {
+        message = JSON.stringify(error) ?? String(error);
+    } catch {
+        message = String(error);
+    }
+    return { name: 'unknown', message, stack: '' };
+}
+
+/** Path only — the query string can carry entry ids, so it is dropped. */
+function routeOf(): string {
+    try {
+        return window.location.pathname;
+    } catch {
+        return '';
+    }
+}
+
+/**
+ * Report a crash. Fire-and-forget by design: it must never throw, and must never be
+ * awaited on a path that is already failing.
+ *
+ * `source` says which channel caught it — `errorElement`, `window.onerror`,
+ * `unhandledrejection`, or a named call site.
+ */
+export function reportClientError(error: unknown, source: string): void {
+    try {
+        const { name, message, stack } = describeError(error);
+        const route = routeOf();
+        const key = `${source}|${name}|${message}|${route}`;
+        if (alreadyReported.has(key)) return;
+        alreadyReported.add(key);
+
+        // Local visibility first: this is what a repro run reads, and it happens
+        // even if the POST never lands (an unauthenticated or password_reset
+        // session cannot report). The one deliberate exception to the project's
+        // no-console rule: this is the diagnostic channel, so it has to print.
+        // eslint-disable-next-line no-console
+        console.error(
+            `[client-error] ${source} at ${route}: ${name}: ${message}`,
+            error
+        );
+
+        const report: ClientErrorReport = {
+            name: clamp(name, FIELD_MAX),
+            message: clamp(message, FIELD_MAX),
+            stack: clamp(stack, STACK_MAX),
+            route: clamp(route, FIELD_MAX),
+            source: clamp(source, FIELD_MAX),
+            user_agent: clamp(navigator.userAgent ?? '', FIELD_MAX)
+        };
+        // API.post resolves rather than throwing on any status, so nothing here can
+        // turn a report into a second failure.
+        void API.post<null, ClientErrorReport>('client-errors', report);
+    } catch {
+        /* reporting must never be the thing that breaks the page */
+    }
+}
+
+/**
+ * Catch what the error boundary cannot see: throws outside React's tree and
+ * un-`catch`ed promise rejections (the LR entry page's hydrate effect being the one
+ * that matters — it strands the page on "Loading your editor…" with no trace).
+ */
+export function installGlobalErrorReporting(): void {
+    window.addEventListener('error', (event: ErrorEvent) => {
+        reportClientError(event.error ?? event.message, 'window.onerror');
+    });
+    window.addEventListener(
+        'unhandledrejection',
+        (event: PromiseRejectionEvent) => {
+            reportClientError(event.reason, 'unhandledrejection');
+        }
+    );
+}

--- a/frontend/src/components/UnlockEdTour.tsx
+++ b/frontend/src/components/UnlockEdTour.tsx
@@ -1,6 +1,7 @@
 import { useEffect } from 'react';
 import {
     initialTourState,
+    isTargetOnRoute,
     isTourRoute,
     targetToStepIndexMap
 } from '@/contexts/tourState';
@@ -20,6 +21,9 @@ export default function UnlockEdTour() {
     const navigate = useNavigate();
     const { pathname } = useLocation();
     const onTourRoute = isTourRoute(pathname);
+    // `stepIndex`, not `target`: Joyride renders `steps[stepIndex]`, so that is the
+    // step whose overlay would be left behind.
+    const stepFitsRoute = isTargetOnRoute(steps[stepIndex]?.target, pathname);
 
     // Leaving the tour's own flow ends the tour. Safe to depend on an unstable
     // setTourState: after the first reset both flags are false, so the condition
@@ -152,9 +156,16 @@ export default function UnlockEdTour() {
         }
     };
 
-    // Never mount Joyride off the tour's own routes — see TOUR_ROUTE_PREFIXES
-    // in tourState.ts.
-    if (!onTourRoute) {
+    // Never mount Joyride off the tour's own routes — see TOUR_ROUTE_PREFIXES in
+    // tourState.ts — nor on a tour route that does not have the current step's
+    // target, which strands an overlay no one can dismiss (see TARGET_ROUTES).
+    //
+    // Hides rather than resetting. The tour drives its own cross-route hops, and a
+    // commit where the pathname has landed but the step has not would end the tour
+    // mid-flow if a mismatch reset it. Hiding costs that one frame and nothing else:
+    // the tour reappears as soon as the step catches up, or when the resident
+    // returns to the page that step belongs to.
+    if (!onTourRoute || !stepFitsRoute) {
         return null;
     }
 

--- a/frontend/src/components/UnlockEdTour.tsx
+++ b/frontend/src/components/UnlockEdTour.tsx
@@ -1,17 +1,54 @@
-import { initialTourState, targetToStepIndexMap } from '@/contexts/tourState';
+import { useEffect } from 'react';
+import {
+    initialTourState,
+    isTourRoute,
+    targetToStepIndexMap
+} from '@/contexts/tourState';
 import { useTourContext } from '@/contexts/useTourContext';
+import { consumeFirstLoginTourPending } from '@/contexts/firstLoginTour';
 import { useTheme } from 'next-themes';
 import Joyride, { CallBackProps, EVENTS } from 'react-joyride';
-import { useNavigate } from 'react-router-dom';
+import { useLocation, useNavigate } from 'react-router-dom';
 import { BRAND, BRAND_DARK } from '@/lib/brand';
 
 export default function UnlockEdTour() {
     const {
-        tourState: { run, stepIndex, steps },
+        tourState: { run, stepIndex, steps, tourActive },
         setTourState
     } = useTourContext();
     const { resolvedTheme } = useTheme();
     const navigate = useNavigate();
+    const { pathname } = useLocation();
+    const onTourRoute = isTourRoute(pathname);
+
+    // Leaving the tour's own flow ends the tour. Safe to depend on an unstable
+    // setTourState: after the first reset both flags are false, so the condition
+    // stops firing.
+    useEffect(() => {
+        if (!onTourRoute && (run || tourActive)) {
+            setTourState(initialTourState);
+        }
+    }, [onTourRoute, run, tourActive, setTourState]);
+
+    // Start the tour for a first login that crossed a hard navigation to get here
+    // — see contexts/firstLoginTour.ts.
+    //
+    // This has to be picked up here, inside the router, and not once at boot in
+    // TourProvider: the backend sends every login to `/authcallback`, a loader-only
+    // route that redirects onward on the client. A provider above the router mounts
+    // there, off any tour route, and never mounts again — so the flag would sit
+    // unconsumed while the resident lands on a /home that has all the tour's
+    // targets. Keying on `onTourRoute` instead waits for a page the tour can
+    // actually run on, however many client-side hops that takes.
+    //
+    // Idempotent by construction: the flag is cleared as it is read, so
+    // StrictMode's double-invoked effect and every later route change are no-ops.
+    useEffect(() => {
+        if (!onTourRoute) return;
+        if (consumeFirstLoginTourPending()) {
+            setTourState({ tourActive: true });
+        }
+    }, [onTourRoute, setTourState]);
 
     const style =
         resolvedTheme === 'dark'
@@ -34,6 +71,12 @@ export default function UnlockEdTour() {
 
     const handleCallback = (data: CallBackProps) => {
         const { action, index, type, step } = data;
+        // Joyride merges a default step, but a callback can still arrive without
+        // one; the tour is over either way and nothing below can be resolved.
+        if (!step) {
+            setTourState(initialTourState);
+            return;
+        }
         const currentTarget = step.target;
         if (
             action === 'close' ||
@@ -49,11 +92,16 @@ export default function UnlockEdTour() {
                 }
                 const nextTarget = steps[index + 1]?.target as string;
                 if (nextTarget) {
+                    // An unmapped target used to write `stepIndex: undefined`
+                    // into a *controlled* Joyride, which silently drops it out of
+                    // controlled mode. Always store a number.
+                    const mapped =
+                        targetToStepIndexMap[
+                            nextTarget as keyof typeof targetToStepIndexMap
+                        ];
                     setTourState({
                         stepIndex:
-                            targetToStepIndexMap[
-                                nextTarget as keyof typeof targetToStepIndexMap
-                            ],
+                            typeof mapped === 'number' ? mapped : index + 1,
                         target: nextTarget
                     });
                 }
@@ -85,19 +133,30 @@ export default function UnlockEdTour() {
                         });
                         navigate(-1);
                         return;
-                    default:
+                    default: {
+                        const mapped =
+                            targetToStepIndexMap[
+                                prevTarget as keyof typeof targetToStepIndexMap
+                            ];
                         setTourState({
                             stepIndex:
-                                targetToStepIndexMap[
-                                    prevTarget as keyof typeof targetToStepIndexMap
-                                ],
+                                typeof mapped === 'number'
+                                    ? mapped
+                                    : Math.max(0, index - 1),
                             target: prevTarget
                         });
                         break;
+                    }
                 }
             }
         }
     };
+
+    // Never mount Joyride off the tour's own routes — see TOUR_ROUTE_PREFIXES
+    // in tourState.ts.
+    if (!onTourRoute) {
+        return null;
+    }
 
     return (
         <Joyride

--- a/frontend/src/components/forms/LoginForm.tsx
+++ b/frontend/src/components/forms/LoginForm.tsx
@@ -1,4 +1,4 @@
-import { useLoaderData, useNavigate } from 'react-router-dom';
+import { useLoaderData } from 'react-router-dom';
 import { AuthFlow, AuthResponse, ServerResponseOne } from '@/types';
 import { SubmitHandler, useForm } from 'react-hook-form';
 import { zodResolver } from '@hookform/resolvers/zod';
@@ -18,7 +18,7 @@ import {
     FormMessage
 } from '@/components/ui/form';
 import { Loader2 } from 'lucide-react';
-import { useTourContext } from '@/contexts/useTourContext';
+import { markFirstLoginTourPending } from '@/contexts/firstLoginTour';
 
 function formatCountdown(seconds: number): string {
     const minutes = Math.floor(seconds / 60);
@@ -30,9 +30,7 @@ function formatCountdown(seconds: number): string {
 }
 
 export default function LoginForm() {
-    const navigate = useNavigate();
     const loaderData = useLoaderData() as AuthFlow;
-    const { setTourState } = useTourContext();
     const [processing, setProcessing] = useState(false);
     const [user, setUser] = useState<string | undefined>(undefined);
     const [errorMessage, setErrorMessage] = useState(false);
@@ -83,13 +81,16 @@ export default function LoginForm() {
         if (resp.success) {
             tabSessionManager.onLogin();
             if (resp.data.first_login) {
-                setTourState({ tourActive: true });
+                // Not setTourState: the hard navigation below drops it. The flag
+                // crosses the hop and TourProvider picks it up on the far side.
+                markFirstLoginTourPending();
             }
-            if (resp.data.redirect_to.startsWith('/')) {
-                navigate(resp.data.redirect_to);
-            } else {
-                window.location.href = resp.data.redirect_to;
-            }
+            // A hard navigation for every destination, matching the reasoning
+            // already recorded in ChangePasswordForm. navigate() kept this public
+            // page's above-the-router state — the tour state, the SWR cache —
+            // alive inside the authenticated shell, where nothing but a browser
+            // reload could clear it (ID-846).
+            window.location.href = resp.data.redirect_to;
             return;
         } else if (resp.status && resp.status === 429) {
             const retryAfterHeader = resp.headers?.['retry-after'];

--- a/frontend/src/contexts/firstLoginTour.ts
+++ b/frontend/src/contexts/firstLoginTour.ts
@@ -1,0 +1,50 @@
+/**
+ * The first-login tour flag, carried across a hard navigation.
+ *
+ * `tourActive` lives in `TourProvider`, mounted *above* `RouterProvider` in
+ * `main.tsx`. That means it survives every client-side navigation and only a page
+ * load clears it — the carrier behind ID-846. Both first-login hops are hard
+ * navigations now (`ChangePasswordForm` since 8faf7977, `LoginForm` as of this
+ * change), which retires that whole class of stale state.
+ *
+ * It also means `setTourState({ tourActive: true })` at login time is wiped before
+ * the resident ever reaches `/home` — which is why the product tour has been
+ * silently dead for every resident whose first login goes through a password reset.
+ * This flag is what survives the hop instead.
+ *
+ * `sessionStorage` is the right store: it survives a reload, is scoped to the one
+ * tab that logged in, and is discarded when that tab closes. `UnlockEdTour` consumes
+ * the flag on the first route the tour can actually run on, so it crosses
+ * `login` -> `reset-password` -> `/authcallback` -> `/home` — two hard navigations
+ * and a client-side hop — and starts the tour exactly once.
+ *
+ * Every access is guarded — `sessionStorage` throws outright when a browser is set
+ * to block site data, and a dead tour must never break a login.
+ */
+const FIRST_LOGIN_TOUR_KEY = 'first_login_tour_pending';
+
+/** Called at login when the backend reports `first_login`. */
+export function markFirstLoginTourPending(): void {
+    try {
+        sessionStorage.setItem(FIRST_LOGIN_TOUR_KEY, 'true');
+    } catch {
+        // No session storage: the resident just doesn't get the tour.
+    }
+}
+
+/**
+ * Reads and clears the flag. Returns true at most once per login — callers may
+ * invoke it more than once (React StrictMode double-invokes mount effects), so it
+ * must be safe to call repeatedly and only the first call may report pending.
+ */
+export function consumeFirstLoginTourPending(): boolean {
+    try {
+        if (sessionStorage.getItem(FIRST_LOGIN_TOUR_KEY) !== 'true') {
+            return false;
+        }
+        sessionStorage.removeItem(FIRST_LOGIN_TOUR_KEY);
+        return true;
+    } catch {
+        return false;
+    }
+}

--- a/frontend/src/contexts/tourState.ts
+++ b/frontend/src/contexts/tourState.ts
@@ -167,3 +167,27 @@ export const initialTourState: TourState = {
     tourActive: false,
     target: ''
 };
+
+/**
+ * The routes this tour's steps live on — every target in `initialTourState` is on
+ * the resident homepage, the Knowledge Center, or a library viewer page.
+ *
+ * Off these routes the tour must not render at all (ID-846). react-joyride 2.9.3
+ * mounts its floater's Popper against the current step's target inside a layout
+ * effect and dereferences it with no null check
+ * (Popper -> getReferenceOffsets -> getBoundingClientRect), so a running tour on a
+ * page that has no such element throws
+ * `TypeError: Cannot read properties of null (reading 'nodeName')` from
+ * `componentDidMount`. React hands that to the nearest error boundary — the
+ * router's root `errorElement` — so the entire shell is replaced by the generic
+ * error page. That is what a resident hit by clicking the Learning Record CTA while
+ * the first-login tour was still live, and why refreshing (which clears the
+ * above-the-router tour state) made the next attempt work.
+ */
+export const TOUR_ROUTE_PREFIXES = ['/home', '/knowledge-center', '/viewer/'];
+
+export function isTourRoute(pathname: string): boolean {
+    return TOUR_ROUTE_PREFIXES.some(
+        (prefix) => pathname === prefix || pathname.startsWith(prefix)
+    );
+}

--- a/frontend/src/contexts/tourState.ts
+++ b/frontend/src/contexts/tourState.ts
@@ -200,3 +200,82 @@ export function isTourRoute(pathname: string): boolean {
         (prefix) => pathname === prefix || pathname.startsWith(prefix + '/')
     );
 }
+
+/**
+ * Which of the routes above each step's target actually lives on.
+ *
+ * `isTourRoute` is not enough on its own. In react-joyride 2.9.3 the tooltip and the
+ * overlay are siblings with different conditions: `JoyrideStep.render` bails out when
+ * the target does not resolve, but the overlay is rendered from `steps[stepIndex]`
+ * with no target check at all and is suppressed only on lifecycle (INIT, BEACON,
+ * COMPLETE, ERROR). A route change never touches Joyride's store, so the lifecycle
+ * survives one. A running tour holding a step whose target is not on the current page
+ * therefore paints a full-screen scrim with no tooltip under it, and every step past
+ * the first sets `disableOverlayClose` — nothing to click, and only a refresh clears
+ * it. That is the ID-846 symptom one route short of ID-846.
+ *
+ * Defense in depth, not a fixed repro. Today each tour page re-seats the step when it
+ * mounts, which covers the obvious ways in: ResidentHome resets to step 0 for any
+ * step but 1, and LibraryViewer re-seats /viewer. Two attempts to strand an overlay
+ * through history navigation did not manage it. But that cover is incidental and
+ * uneven — ResidentKnowledgeCenter re-seats ONLY when the target is
+ * `#visit-knowledge-center`, so /knowledge-center has none of it for any other step —
+ * and it puts the invariant in three page components that each have to remember it,
+ * rather than in the one component that mounts Joyride.
+ *
+ * The guard can only ever suppress a render that Joyride would have drawn without a
+ * tooltip anyway: if the target is not on this route, there was no tooltip to lose.
+ *
+ * An empty array means the target is in the sidebar
+ * (components/navigation/Sidebar.tsx), which AuthenticatedLayout renders on every
+ * route, so no pathname rules it out.
+ *
+ * Typed against `targetToStepIndexMap` on purpose: adding a step there will not
+ * compile until the new target is given its routes here.
+ */
+const TARGET_ROUTES: Record<
+    keyof typeof targetToStepIndexMap,
+    readonly string[]
+> = {
+    '#resident-home': ['/home'],
+    '#visit-knowledge-center': [],
+    '#knowledge-center-landing': ['/knowledge-center'],
+    '#knowledge-center-tabs': ['/knowledge-center'],
+    '#knowledge-center-search': ['/knowledge-center'],
+    '#knowledge-center-filters': ['/knowledge-center'],
+    // Rendered by components/knowledge-center/LibraryCard, which the resident
+    // only ever sees on the Knowledge Center — ResidentHome has its own
+    // FeaturedLibraryCard and carries neither id.
+    '#knowledge-center-search-lib': ['/knowledge-center'],
+    '#knowledge-center-fav-lib': ['/knowledge-center'],
+    '#knowledge-center-enter-library': ['/knowledge-center'],
+    '#library-viewer-sub-page': ['/viewer'],
+    // No element in the app carries this id, so the step is skipped by
+    // UnlockEdTour's TARGET_NOT_FOUND handling wherever it runs. Listed under the
+    // route it was written for so this map does not become the reason it is
+    // skipped — that is a separate content bug, and it should stay visible as one.
+    '#library-viewer-favorite': ['/viewer'],
+    '#navigate-homepage': [],
+    '#top-content': ['/home'],
+    '#popular-content': ['/home'],
+    '#end-tour': ['/home']
+};
+
+/**
+ * True when `pathname` can host `target`.
+ *
+ * Fails open for anything not in the map: this exists to hide a tour that is
+ * provably on the wrong page, not to become a second registry a step has to appear
+ * in before it will render at all.
+ */
+export function isTargetOnRoute(
+    target: Step['target'] | undefined,
+    pathname: string
+): boolean {
+    if (typeof target !== 'string') return true;
+    const routes = TARGET_ROUTES[target as keyof typeof TARGET_ROUTES];
+    if (!routes || routes.length === 0) return true;
+    return routes.some(
+        (prefix) => pathname === prefix || pathname.startsWith(prefix + '/')
+    );
+}

--- a/frontend/src/contexts/tourState.ts
+++ b/frontend/src/contexts/tourState.ts
@@ -184,10 +184,19 @@ export const initialTourState: TourState = {
  * the first-login tour was still live, and why refreshing (which clears the
  * above-the-router tour state) made the next attempt work.
  */
-export const TOUR_ROUTE_PREFIXES = ['/home', '/knowledge-center', '/viewer/'];
+export const TOUR_ROUTE_PREFIXES = ['/home', '/knowledge-center', '/viewer'];
 
+/**
+ * Matches on path segments, not raw string prefixes. A bare `startsWith` also
+ * matched `/knowledge-center-management` — an AdminRoles route
+ * (routes/knowledge-routes.tsx) — and `UnlockEdTour` is mounted in
+ * `AuthenticatedLayout`, which wraps admin routes too. The visible cost was an
+ * admin's first login consuming `first_login_tour_pending` on a page that has
+ * none of the tour's targets; the latent one was permitting Joyride to mount
+ * there at all, which is the same shape as the bug this file exists to fix.
+ */
 export function isTourRoute(pathname: string): boolean {
     return TOUR_ROUTE_PREFIXES.some(
-        (prefix) => pathname === prefix || pathname.startsWith(prefix)
+        (prefix) => pathname === prefix || pathname.startsWith(prefix + '/')
     );
 }

--- a/frontend/src/hooks/useSessionViewType.ts
+++ b/frontend/src/hooks/useSessionViewType.ts
@@ -1,5 +1,6 @@
 import { useEffect, useState } from 'react';
 import { ViewType } from '@/types';
+import { getSessionItem, setSessionItem } from '@/lib/safeSessionStorage';
 
 export function useSessionViewType(storageKey: string) {
     const [activeView, setActiveView] = useState<ViewType>(() => {
@@ -7,7 +8,7 @@ export function useSessionViewType(storageKey: string) {
             return ViewType.Grid;
         }
 
-        const savedValue = sessionStorage.getItem(storageKey);
+        const savedValue = getSessionItem(storageKey);
         if (!savedValue) {
             return ViewType.Grid;
         }
@@ -16,7 +17,7 @@ export function useSessionViewType(storageKey: string) {
 
     useEffect(() => {
         if (typeof window !== 'undefined') {
-            sessionStorage.setItem(
+            setSessionItem(
                 storageKey,
                 activeView === ViewType.List ? 'list' : 'grid'
             );

--- a/frontend/src/hooks/useTranscriptDraft.ts
+++ b/frontend/src/hooks/useTranscriptDraft.ts
@@ -8,6 +8,8 @@ import {
     apiUpdateEntry,
     apiUpsertDraft
 } from '@/api/learningRecord';
+import { reportClientError } from '@/api/reportClientError';
+import { newUuid } from '@/lib/uuid';
 import { TOP_SKILLS_MAX } from '@/pages/student/digital-transcript/transcriptReflectionConfig';
 import { dispatchEntrySessionUpdated } from '@/pages/student/digital-transcript/transcriptEntrySessionStorage';
 import type {
@@ -17,7 +19,7 @@ import type {
 
 export function createEmptyDraft(): TranscriptDraft {
     return {
-        id: crypto.randomUUID(),
+        id: newUuid(),
         updatedAt: new Date().toISOString(),
         stepIndex: 0,
         uiPhase: 'survey',
@@ -61,12 +63,22 @@ export function useTranscriptDraft() {
     useEffect(() => {
         let cancelled = false;
         void (async () => {
-            const [{ entries: fetched, backendIds }, fetchedDraft] =
-                await Promise.all([apiGetEntries(), apiGetDraft()]);
-            if (cancelled) return;
-            entryBackendIds.current = backendIds;
-            setEntries(fetched);
-            setDraft(fetchedDraft);
+            try {
+                const [{ entries: fetched, backendIds }, fetchedDraft] =
+                    await Promise.all([apiGetEntries(), apiGetDraft()]);
+                if (cancelled) return;
+                entryBackendIds.current = backendIds;
+                setEntries(fetched);
+                setDraft(fetchedDraft);
+            } catch (err) {
+                // These calls resolve rather than throw on any HTTP status, so
+                // reaching here means something unexpected. Without the catch it
+                // became an unhandled rejection with `hydrated` stuck false, which
+                // strands the entry page on "Loading your editor…" and reports
+                // nothing. Hydrate empty instead, and say so in the logs.
+                if (cancelled) return;
+                reportClientError(err, 'useTranscriptDraft.hydrate');
+            }
             setHydrated(true);
         })();
         return () => {

--- a/frontend/src/lib/safeSessionStorage.ts
+++ b/frontend/src/lib/safeSessionStorage.ts
@@ -1,0 +1,54 @@
+/**
+ * `sessionStorage` that cannot throw.
+ *
+ * When a browser is configured to block site data for the origin, touching
+ * `window.sessionStorage` throws `SecurityError` — it does not return null and
+ * it does not return a dead-but-usable store. That matters here because
+ * UnlockEd runs on managed facility devices, where a locked-down browser policy
+ * is ordinary rather than exotic.
+ *
+ * The failure this exists to prevent: `tabSession.hasLocalSession()` is called
+ * from `checkExistingFlow`, which is a react-router *loader* (auth/useAuth.ts).
+ * A throw inside a loader goes straight to the route's `errorElement`, so the
+ * login page never mounts at all — the resident sees the generic error page with
+ * no form and no way forward, and unlike ID-846's crash a refresh does not help.
+ *
+ * Note what does NOT work as a guard:
+ *
+ *     if (typeof sessionStorage === 'undefined') return;   // still throws
+ *
+ * `typeof` only suppresses `ReferenceError` for an *undeclared identifier*. When
+ * the identifier resolves to a property whose getter throws, `typeof` invokes
+ * that getter and throws right along with it. Several call sites read as guarded
+ * but were not, which is why every access now goes through here instead.
+ *
+ * Reads return null and writes are dropped when storage is unavailable. Every
+ * caller already treats "nothing stored" as a valid state, so degrading to
+ * in-memory-only is the correct behaviour: the feature quietly does less, and
+ * nothing breaks.
+ */
+
+export function getSessionItem(key: string): string | null {
+    try {
+        return sessionStorage.getItem(key);
+    } catch {
+        return null;
+    }
+}
+
+export function setSessionItem(key: string, value: string): void {
+    try {
+        sessionStorage.setItem(key, value);
+    } catch {
+        // Blocked, or over quota in private-mode Safari. Nothing to do: the
+        // caller's state stays in memory for this page session.
+    }
+}
+
+export function removeSessionItem(key: string): void {
+    try {
+        sessionStorage.removeItem(key);
+    } catch {
+        /* nothing stored means nothing to remove */
+    }
+}

--- a/frontend/src/lib/uuid.ts
+++ b/frontend/src/lib/uuid.ts
@@ -1,0 +1,41 @@
+/**
+ * UUID with a fallback.
+ *
+ * `crypto.randomUUID` only exists in a secure context (HTTPS or localhost) and in
+ * reasonably current browsers. Both Learning Record call sites run inside the entry
+ * page's bootstrap effect, so where it is missing the throw lands on the router's
+ * error boundary and the resident gets the generic error page — on facility devices,
+ * which is exactly where an old browser or a plain-HTTP origin turns up.
+ */
+export function newUuid(): string {
+    try {
+        if (typeof crypto !== 'undefined' && 'randomUUID' in crypto) {
+            return crypto.randomUUID();
+        }
+    } catch {
+        /* fall through */
+    }
+    try {
+        if (typeof crypto !== 'undefined' && crypto.getRandomValues) {
+            const bytes = crypto.getRandomValues(new Uint8Array(16));
+            // RFC 4122 version 4, variant 1.
+            bytes[6] = (bytes[6] & 0x0f) | 0x40;
+            bytes[8] = (bytes[8] & 0x3f) | 0x80;
+            const hex = Array.from(bytes, (b) =>
+                b.toString(16).padStart(2, '0')
+            ).join('');
+            return [
+                hex.slice(0, 8),
+                hex.slice(8, 12),
+                hex.slice(12, 16),
+                hex.slice(16, 20),
+                hex.slice(20)
+            ].join('-');
+        }
+    } catch {
+        /* fall through */
+    }
+    // Last resort: not cryptographically random, but these ids only have to be
+    // unique per resident, and a working form beats a crashed one.
+    return `${Date.now().toString(16)}-${Math.random().toString(16).slice(2, 10)}`;
+}

--- a/frontend/src/loaders/routeLoaders.ts
+++ b/frontend/src/loaders/routeLoaders.ts
@@ -49,9 +49,12 @@ function buildClassBreadcrumbs(
 // off for the facility.
 export const getStudentLevel1Data: LoaderFunction = async () => {
     const user = await fetchUser();
-    if (!user) return;
-
     const empty = { topUserContent: [], topFacilityContent: [] };
+    // Must always resolve to a shaped object: ResidentHome destructures this
+    // loader's data directly, so a bare `undefined` throws during render and the
+    // resident gets the generic error page instead of the homepage.
+    if (!user) return json(empty);
+
     if (!hasFeature(user, FeatureAccess.OpenContentAccess)) {
         return json(empty);
     }

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -10,9 +10,14 @@ import posthog from 'posthog-js';
 import { PostHogProvider } from 'posthog-js/react';
 import { initAnalytics } from '@/lib/events';
 import { swrFetcher } from '@/api/swrFetcher';
+import { installGlobalErrorReporting } from '@/api/reportClientError';
 
 // Gated + tagged in lib/events.ts; a no-op when analytics is disabled.
 initAnalytics();
+
+// Catches throws and un-caught promise rejections that never reach a route's
+// errorElement — installed before render so nothing during boot is missed.
+installGlobalErrorReporting();
 
 ReactDOM.createRoot(document.querySelector('#root')!).render(
     <React.StrictMode>

--- a/frontend/src/pages/Error.tsx
+++ b/frontend/src/pages/Error.tsx
@@ -24,13 +24,19 @@ export default function Error({
     // Safe for the prop-driven uses too: every <Error /> in this app is a route
     // element inside the data router, and this returns undefined when the route is
     // not currently an error boundary.
+    //
+    // `undefined` is therefore the only value that means "no error". Everything
+    // below compares against it rather than testing truthiness, because a loader or
+    // render can throw any value at all — `throw null` and `throw ''` are still
+    // crashes, and a truthiness test would drop them on the floor, which is the
+    // exact failure this page was changed to stop doing.
     const routeError: unknown = useRouteError();
     // An errorElement can re-render; the report itself is also deduped, but this
     // keeps the effect honest about firing once per mount.
     const reportedRef = useRef(false);
 
     useEffect(() => {
-        if (!routeError || reportedRef.current) return;
+        if (routeError === undefined || reportedRef.current) return;
         reportedRef.current = true;
         reportClientError(routeError, 'errorElement');
     }, [routeError]);
@@ -55,9 +61,10 @@ export default function Error({
     const { title, description } = getMessage();
     // Shown only for a real crash, and only enough for staff to match the page a
     // resident saw to a log line. The message itself stays out of the UI.
-    const reference = routeError
-        ? new Date().toISOString().replace(/\.\d+Z$/, 'Z')
-        : null;
+    const reference =
+        routeError !== undefined
+            ? new Date().toISOString().replace(/\.\d+Z$/, 'Z')
+            : null;
 
     return (
         <div className="flex flex-col items-center justify-center min-h-[60vh] gap-4">
@@ -71,7 +78,7 @@ export default function Error({
                     Reference: {reference}
                 </p>
             ) : null}
-            {import.meta.env.DEV && routeError ? (
+            {import.meta.env.DEV && routeError !== undefined ? (
                 <pre className="max-w-2xl overflow-x-auto whitespace-pre-wrap text-xs text-destructive">
                     {describeError(routeError).name}:{' '}
                     {describeError(routeError).message}

--- a/frontend/src/pages/Error.tsx
+++ b/frontend/src/pages/Error.tsx
@@ -1,6 +1,19 @@
-import { Link } from 'react-router-dom';
+import { useEffect, useRef } from 'react';
+import { Link, useRouteError } from 'react-router-dom';
 import { ErrorType } from '@/types';
+import { describeError, reportClientError } from '@/api/reportClientError';
 
+/**
+ * The app's only error page. It renders two ways:
+ *   - as a route `errorElement`, where react-router hands it whatever was thrown
+ *     during render, in an effect, or by a loader;
+ *   - as a plain element with a `type`, for /404 and /unauthorized.
+ *
+ * It used to ignore `useRouteError()` entirely, so the exception died here and the
+ * deployment logs showed nothing — the reason ID-846 could not be diagnosed from
+ * Maine's logs. It now logs and reports the error, and shows the resident a
+ * reference they can quote when they report it.
+ */
 export default function Error({
     type,
     back
@@ -8,6 +21,20 @@ export default function Error({
     type?: ErrorType;
     back?: boolean;
 }) {
+    // Safe for the prop-driven uses too: every <Error /> in this app is a route
+    // element inside the data router, and this returns undefined when the route is
+    // not currently an error boundary.
+    const routeError: unknown = useRouteError();
+    // An errorElement can re-render; the report itself is also deduped, but this
+    // keeps the effect honest about firing once per mount.
+    const reportedRef = useRef(false);
+
+    useEffect(() => {
+        if (!routeError || reportedRef.current) return;
+        reportedRef.current = true;
+        reportClientError(routeError, 'errorElement');
+    }, [routeError]);
+
     const getMessage = () => {
         switch (type) {
             case 'not-found':
@@ -26,11 +53,30 @@ export default function Error({
     };
 
     const { title, description } = getMessage();
+    // Shown only for a real crash, and only enough for staff to match the page a
+    // resident saw to a log line. The message itself stays out of the UI.
+    const reference = routeError
+        ? new Date().toISOString().replace(/\.\d+Z$/, 'Z')
+        : null;
 
     return (
         <div className="flex flex-col items-center justify-center min-h-[60vh] gap-4">
             <h1 className="text-4xl font-bold">{title}</h1>
             <p className="text-muted-foreground">{description}</p>
+            {reference ? (
+                <p
+                    className="text-xs text-muted-foreground"
+                    data-slot="error-reference"
+                >
+                    Reference: {reference}
+                </p>
+            ) : null}
+            {import.meta.env.DEV && routeError ? (
+                <pre className="max-w-2xl overflow-x-auto whitespace-pre-wrap text-xs text-destructive">
+                    {describeError(routeError).name}:{' '}
+                    {describeError(routeError).message}
+                </pre>
+            ) : null}
             {back ? (
                 <button
                     onClick={() => window.history.back()}

--- a/frontend/src/pages/knowledge-center/LibraryViewer.tsx
+++ b/frontend/src/pages/knowledge-center/LibraryViewer.tsx
@@ -4,6 +4,7 @@ import { useForm } from 'react-hook-form';
 import { ArrowLeft, Loader2 } from 'lucide-react';
 import { Library, ServerResponseOne } from '@/types';
 import { useAuth, isAdministrator } from '@/auth/useAuth';
+import { removeSessionItem } from '@/lib/safeSessionStorage';
 import { toast } from 'sonner';
 import Breadcrumbs from '@/components/navigation/Breadcrumbs';
 import { FormModal } from '@/components/shared/FormModal';
@@ -114,7 +115,7 @@ export default function LibraryViewer() {
         };
         void fetchLibraryData();
         return () => {
-            sessionStorage.removeItem('tag');
+            removeSessionItem('tag');
         };
     }, [libraryId, url, navigate]);
 

--- a/frontend/src/pages/student/ResidentHome.tsx
+++ b/frontend/src/pages/student/ResidentHome.tsx
@@ -453,7 +453,14 @@ export default function ResidentHome() {
     }, []);
 
     useEffect(() => {
-        if (!tourState.tourActive || !user) return;
+        // `hydrated` gates this page's entire render below, so before it flips
+        // there is no #resident-home in the DOM. react-joyride 2.9.3 resolves the
+        // current step's target once, when `run` goes true, and never retries — no
+        // retry, no TARGET_NOT_FOUND — so starting the tour early leaves it wedged
+        // at `tour:start` with an empty portal and nothing on screen. A first login
+        // hits that every time: the tour flag is picked up on the first render,
+        // which is always before useTranscriptDraft has hydrated.
+        if (!tourState.tourActive || !user || !hydrated) return;
         if (!openContentEnabled) {
             setTourState({ tourActive: false, run: false });
             return;
@@ -471,7 +478,7 @@ export default function ResidentHome() {
             });
         }
         // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, [tourState.tourActive, openContentEnabled, user]);
+    }, [tourState.tourActive, openContentEnabled, user, hydrated]);
 
     const dismissReflectNudge = useCallback(() => {
         setReflectNudgeDismissed(true);

--- a/frontend/src/pages/student/digital-transcript/learningRecordSession.ts
+++ b/frontend/src/pages/student/digital-transcript/learningRecordSession.ts
@@ -1,5 +1,10 @@
 import { ANALYTICS_EVENTS, captureEvent } from '@/lib/events';
 import {
+    getSessionItem,
+    removeSessionItem,
+    setSessionItem
+} from '@/lib/safeSessionStorage';
+import {
     LEARNING_RECORD_SESSION_VERSION,
     getDigitalTranscriptStorageKeys
 } from '@/types/digital-transcript';
@@ -130,19 +135,17 @@ function storageKey(): string {
 }
 
 function persistNow(): void {
-    if (!state || typeof sessionStorage === 'undefined') return;
-    try {
-        sessionStorage.setItem(
-            storageKey(),
-            JSON.stringify({
-                version: LEARNING_RECORD_SESSION_VERSION,
-                ...state
-            })
-        );
-    } catch {
-        // Quota, or private-mode Safari. The session degrades to in-memory only:
-        // it still emits, it just cannot survive a reload.
-    }
+    if (!state) return;
+    // Was `typeof sessionStorage === 'undefined'` guarding a try/catch from the
+    // outside — but `typeof` invokes the getter, so the guard threw before the
+    // try could catch anything. safeSessionStorage swallows it instead.
+    setSessionItem(
+        storageKey(),
+        JSON.stringify({
+            version: LEARNING_RECORD_SESSION_VERSION,
+            ...state
+        })
+    );
 }
 
 function persistSoon(): void {
@@ -161,19 +164,13 @@ function clearPersistTimer(): void {
 }
 
 function clearPersisted(): void {
-    if (typeof sessionStorage === 'undefined') return;
-    try {
-        sessionStorage.removeItem(storageKey());
-    } catch {
-        /* noop */
-    }
+    removeSessionItem(storageKey());
 }
 
 /** Version-gated, field-coerced read — same discipline as the entry session. */
 function readPersisted(): SessionState | null {
-    if (typeof sessionStorage === 'undefined') return null;
     try {
-        const raw = sessionStorage.getItem(storageKey());
+        const raw = getSessionItem(storageKey());
         if (!raw) return null;
         const parsed: unknown = JSON.parse(raw);
         if (!isRecord(parsed)) return null;

--- a/frontend/src/pages/student/digital-transcript/learningRecordTableSort.ts
+++ b/frontend/src/pages/student/digital-transcript/learningRecordTableSort.ts
@@ -5,6 +5,7 @@ import {
 } from '@/pages/student/digital-transcript/learningRecordDocumentModel';
 import type { LearningRecordFormVariant } from './learningRecordPrototypes';
 import { countFunnelFieldsAnswered } from './transcriptReflectionConfig';
+import { getSessionItem, setSessionItem } from '@/lib/safeSessionStorage';
 
 export const LR_TABLE_SORT_STORAGE_KEY = 'lr_table_sort';
 
@@ -107,7 +108,7 @@ export function readTableSortFromSession(): TableSort {
         return DEFAULT_TABLE_SORT;
     }
 
-    const raw = sessionStorage.getItem(LR_TABLE_SORT_STORAGE_KEY);
+    const raw = getSessionItem(LR_TABLE_SORT_STORAGE_KEY);
     if (!raw) {
         return DEFAULT_TABLE_SORT;
     }
@@ -133,7 +134,7 @@ export function readTableSortFromSession(): TableSort {
 
 export function writeTableSortToSession(sort: TableSort): void {
     if (typeof window === 'undefined') return;
-    sessionStorage.setItem(LR_TABLE_SORT_STORAGE_KEY, JSON.stringify(sort));
+    setSessionItem(LR_TABLE_SORT_STORAGE_KEY, JSON.stringify(sort));
 }
 
 export function toggleTableSort(

--- a/frontend/src/pages/student/digital-transcript/transcriptEntrySessionStorage.ts
+++ b/frontend/src/pages/student/digital-transcript/transcriptEntrySessionStorage.ts
@@ -1,3 +1,4 @@
+import { newUuid } from '@/lib/uuid';
 import { TOP_SKILLS_MAX } from '@/pages/student/digital-transcript/transcriptReflectionConfig';
 import { entryIsComplete } from '@/pages/student/digital-transcript/learningRecordDocumentModel';
 import type { LearningRecordFormVariant } from '@/pages/student/digital-transcript/learningRecordPrototypes';
@@ -10,7 +11,7 @@ import {
 } from '@/types/digital-transcript';
 
 function newId() {
-    return crypto.randomUUID();
+    return newUuid();
 }
 
 function isRecord(v: unknown): v is Record<string, unknown> {

--- a/frontend/src/session/tabSession.ts
+++ b/frontend/src/session/tabSession.ts
@@ -1,4 +1,9 @@
 import { INIT_KRATOS_LOGIN_FLOW } from '@/types';
+import {
+    getSessionItem,
+    removeSessionItem,
+    setSessionItem
+} from '@/lib/safeSessionStorage';
 
 const CHANNEL_NAME = 'unlocked_session_channel';
 const SESSION_STORAGE_KEY = 'tab_session_active';
@@ -61,16 +66,24 @@ class TabSessionManager {
         this.channel.postMessage(message);
     }
 
+    /*
+     * These three go through safeSessionStorage because hasLocalSession() is
+     * reached from checkExistingFlow, a route loader: a raw sessionStorage
+     * access that throws there takes the whole /login route to the error
+     * boundary and the resident can never sign in. Losing the flag instead is
+     * harmless — a false reading just means the tab re-checks the session with
+     * Ory, which is the same path a genuinely new tab takes.
+     */
     hasLocalSession(): boolean {
-        return sessionStorage.getItem(SESSION_STORAGE_KEY) === 'true';
+        return getSessionItem(SESSION_STORAGE_KEY) === 'true';
     }
 
     setLocalSession(): void {
-        sessionStorage.setItem(SESSION_STORAGE_KEY, 'true');
+        setSessionItem(SESSION_STORAGE_KEY, 'true');
     }
 
     clearLocalSession(): void {
-        sessionStorage.removeItem(SESSION_STORAGE_KEY);
+        removeSessionItem(SESSION_STORAGE_KEY);
     }
 
     onLogin(): void {


### PR DESCRIPTION
## Pre-Submission PR Checklist

- [x] No debug/console/fmt.Println statements
- [x] Unnecessary development comments removed
- [x] All acceptance criteria verified
- [x] Functions according to **ticket specifications**
- [x] Tested manually where applicable
- [x] Branch rebased with latest main
- [x] No business logic exists within the database layer

## What went wrong

A resident who had just finished their first login tapped **Start my record** and got the generic
"Something went wrong" page. Nothing about it reached our logs, so there was no way to tell from
Maine's deployment what had actually failed.

## Why

Every time the achievement editor opened, it saved a small amount of information into the browser.
Some devices are set to refuse that — a locked-down browser policy is ordinary on facility
equipment — and the refusal took the whole page down instead of being shrugged off.

Two things to be straight about. This is the best explanation we have, found by reading the code; we
did not manage to make it happen on a test machine. And it was not limited to the **Start my
record** button as an earlier version of this description said — the failing save ran every time the
editor opened, by any route, so more residents could have hit it than first thought.

## What changed

- The achievement editor now works on a device that refuses to store anything.
- The same protection was applied everywhere else the app stores information, including the login
  page, which could previously be left with no way to sign in at all.
- Crashes now report themselves to the server instead of vanishing. The error page shows the
  resident a reference number they can quote.
- Three permission refusals that used to happen silently now leave a log line.
- Passwords are no longer written into the logs.
- The first-login guided tour works again. It has been silently dead for every resident whose first
  login goes through a password reset — a real bug, just not this one. Expect it to reappear.
- The achievements list no longer says a program name is missing when the resident has entered one.

## Open items

The ticket says refreshing made it work, and none of what we fixed behaves that way. Something else
may remain, and the new crash reporting is what will name it if it does.

**⚠️ Needs a decision outside this PR.** Passwords have been going into the logs from `main` for some
time, so existing logs already contain real ones. This stops new ones; it does nothing about what is
already written. Someone needs to decide on retention and disclosure.

## How to check it

| Where | What to do | What should happen |
|---|---|---|
| `/home` → **Start my record** | Set the browser to block site data for this origin first (Chrome: Settings → Privacy → Site settings → "Don't allow sites to save data") | The editor opens and typing still saves. Previously: the error page. |
| `/login` | Same blocked-storage browser | The login form appears and sign-in works. |
| First login as a resident | Log in with an account that still has to set a password | After setting it you land on the home page with the guided tour running. |
| Any page that errors | Force an error | The error page shows a **Reference** timestamp, and the server log gains a matching client-error line with the details. |
| Learning Record list | Save an achievement named `a` | The row reads "Untitled achievement" and matches the steps-answered count beside it. Previously it said "Not added yet". A normal name like `Welding 101` shows as typed. |
| Backend logs | Sign in with a wrong password | The logged form shows `"password":"[REDACTED]"`. |

- **Related issues**: addresses [Asana ID-846](Asana ID-846).

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1218469139443738