### PR TITLE
feat: make the AI tutor resident-only

### DIFF
--- a/frontend/src/components/navigation/Sidebar.tsx
+++ b/frontend/src/components/navigation/Sidebar.tsx
@@ -149,8 +149,10 @@ interface NavSectionProps {
     onToggleHelpCenter?: () => void;
 }
 
-// Identical for both audiences — admin and resident get the same link, unlike
-// e.g. ProgramAccess where each nav renders a genuinely different UI.
+// Resident nav only. The AI Tutor MVP (ID-868) ships the resident-facing side
+// alone — there is no staff experience behind this link — so admins get no
+// entry point, and tutor-routes.tsx narrows the route to match. Admins still
+// enable the feature itself from Feature Control.
 function AiTutorNavItem({
     collapsed,
     isActive,
@@ -315,12 +317,6 @@ function AdminNav({ collapsed, isActive, onNavigate }: NavSectionProps) {
                     ]}
                 />
             )}
-
-            <AiTutorNavItem
-                collapsed={collapsed}
-                isActive={isActive}
-                onNavigate={onNavigate}
-            />
         </>
     );
 }

--- a/frontend/src/pages/AiTutor.tsx
+++ b/frontend/src/pages/AiTutor.tsx
@@ -1,13 +1,9 @@
-import { useAuth, isAdministrator } from '@/auth/useAuth';
-
 export default function AiTutor() {
-    const { user } = useAuth();
-    // AuthenticatedLayout only renders the h-16 header for admins (any width)
-    // or on mobile; residents on desktop get no header, so there's nothing to
-    // subtract there.
-    const heightClass = isAdministrator(user)
-        ? 'h-[calc(100vh-4rem)]'
-        : 'h-[calc(100vh-4rem)] md:h-screen';
+    // Residents only (see tutor-routes.tsx). AuthenticatedLayout renders the
+    // h-16 header for them on mobile but not on desktop, so the h-16 is
+    // subtracted only below md. The admin branch this used to carry went with
+    // the admin route.
+    const heightClass = 'h-[calc(100vh-4rem)] md:h-screen';
 
     return (
         <div className={`w-full ${heightClass}`}>

--- a/frontend/src/routes/tutor-routes.tsx
+++ b/frontend/src/routes/tutor-routes.tsx
@@ -1,11 +1,13 @@
 import { declareAuthenticatedRoutes } from '@/auth/declareAuthenticatedRoutes';
-import { AllRoles } from '@/auth/useAuth';
-import { FeatureAccess } from '@/types';
+import { FeatureAccess, UserRole } from '@/types';
 import AiTutor from '@/pages/AiTutor';
 import type { RouteObject } from 'react-router-dom';
 
 export const TutorRoutes: RouteObject = declareAuthenticatedRoutes(
     [{ path: 'ai-tutor', element: <AiTutor />, handle: { title: 'AI Tutor' } }],
-    AllRoles,
+    // Resident-only: the MVP (ID-868) ships no staff experience inside the
+    // tutor, so there is nothing here for an admin to see. RouteGuard redirects
+    // any other role away before the iframe mounts; the sidebar link is gone too.
+    [UserRole.Student],
     [FeatureAccess.AiTutorAccess]
 );


### PR DESCRIPTION
Makes the embedded AI Tutor resident-only, so the admin view isn't exposed in the
MVP (ID-868).

- `Sidebar.tsx` — `AiTutorNavItem` removed from `AdminNav`, kept in `StudentNav`.
  The comment claiming the link is "identical for both audiences" is updated;
  it's no longer true.
- `tutor-routes.tsx` — `AllRoles` → `[UserRole.Student]`, matching
  `program-routes.tsx:38`. Without this an admin typing `/ai-tutor` still loads
  the iframe; `RouteGuard` now redirects them.
- `AiTutor.tsx` — the admin/resident iframe-height branch became dead code once
  the route went resident-only, so it and the `useAuth` import are gone.

**Feature Control is unaffected** — sys/dept admins keep the `ai_tutor` toggle
(`FeatureControl.tsx`), which is how the feature gets enabled, not a view of the
tutor.

## Consequence worth knowing

Staff can no longer open the tutor at all, which also means they can't reach the
tutor's super-admin impersonation picker. That picker is admin-only
functionality, so it falls under "resident-facing side only" — but in practice it
was already off in staging and demo (`ALLOW_IMPERSONATION` unset on a production
build), and it's now explicitly gated on the tutor side too rather than closed by
side effect.

Practical effect: **QA of the resident experience in staging/demo needs a
resident account.**

## Verification

`tsc`, `eslint` and `npm run build` clean. No tests here — this frontend has no
test runner or test files; standing one up was out of scope for this ticket.

## Companion PR

Pairs with the `unlocked-hiset-ai` PR, which does the actual scope lock inside
the tutor.
